### PR TITLE
Remove obsolete options in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 # Travis configuration file
 # Read more under http://docs.travis-ci.com/user/build-configuration/
 
-# Disable sudo to speed up the build
-sudo: false
-
 # Set the build language to Python
 language: python
-dist: xenial
 python:
   - "3.6"
 install:


### PR DESCRIPTION
Travis CI has removed support for `sudo: false` in an effort to unify their build infrastructures, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.

As for `dist: xenial`: xenial is the default distribution as of April 2019, see https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment, and doesn't need to be specified.