### PR TITLE
Use tox to run tests and build documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,26 +6,11 @@ language: python
 python:
   - "3.6"
 install:
-  - pip install 'pytest>=4.6' pytest-cov # testing 
-  - pip install 'sphinx<=2.4.4' --force-reinstall # python documentation tool
-  - pip install sphinx_bootstrap_theme # documentation theme
-  - pip install sphinx_automodapi # automated function documentation
-  - pip install nbsphinx # jupyter notebook documentation support
-  - pip install jupyter # jupyter notebooks
   - sudo apt-get install pandoc # pandoc for jupyter notebooks
   - sudo apt install python-pydot python-pydot-ng graphviz # graphviz for class inheritance diagrams in docs
-  - pip install m2r # markdown to restructuredText conversion for sphinx
-  - pip install -r requirements.txt
-  - pip install -e . # development installation of package, alternatively: python setup.py develop
-  # ^  DEPRECATION WARNING:
-  # The automatic creation of a `requirements.txt` file is deprecated.
-  # See `Dependency Management` in the docs for other options.
+  - pip install tox-travis
 script:
-  - cd docs/
-  - make clean # remove modules from automodapi
-  - make html # build documentation
-  - cd ..
-  - pytest --cov=./ # run tests and coverage
+  - tox
 after_success:
   - bash <(curl -s https://codecov.io/bash) # upload test coverage to codecov
 deploy: # deploy documentation to github pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 python:
   - "3.6"
 install:
-  - sudo apt install pandoc # pandoc for jupyter notebooks
+  - sudo apt-get install pandoc # pandoc for jupyter notebooks
   - sudo apt install graphviz # graphviz for class inheritance diagrams in docs
   - pip install tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ language: python
 python:
   - "3.6"
 install:
-  - sudo apt-get install pandoc # pandoc for jupyter notebooks
-  - sudo apt install python-pydot python-pydot-ng graphviz # graphviz for class inheritance diagrams in docs
+  - sudo apt install pandoc # pandoc for jupyter notebooks
+  - sudo apt install graphviz # graphviz for class inheritance diagrams in docs
   - pip install tox-travis
 script:
   - tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,20 +48,6 @@ To run the full test suite make sure that you have all specified python versions
 Alternatively, you can run a single specific environment through `tox -e <env>`, e.g. `tox -e py36` to run tests with Python3.6 or `tox -e docs` to just build the documentation.
 
 
-### Code Quality
-
-Code quality is an essential component in a collaborative open-source project.
-
-- All code should be covered by tests within the [unittest](https://docs.python.org/3/library/unittest.html) framework. Every time a commit is
-made [Travis](https://travis-ci.org/probabilistic-numerics/probnum) builds the project and runs the test suite.
-- Documentation of code is essential for any collaborative project. ProbNum uses the
-[NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
-- Code should follow the [PEP8 style](https://www.python.org/dev/peps/pep-0008/) and the internal [style guide](https://github.com/probabilistic-numerics/probnum/blob/master/STYLEGUIDE.md).
-- Keep dependencies to a minimum.
-- Make sure to observe good coding practice.
-
-For all of the above the existing ProbNum code is a good reference.
-
 ### Testing
 
 We use [unittest](https://docs.python.org/3/library/unittest.html) for testing and aim to cover as much code with tests as possible.
@@ -99,7 +85,21 @@ make html
 ```
 
 
-### Continuous Integration (CI)
+## Code Quality
+
+Code quality is an essential component in a collaborative open-source project.
+
+- All code should be covered by tests within the [unittest](https://docs.python.org/3/library/unittest.html) framework. Every time a commit is
+made [Travis](https://travis-ci.org/probabilistic-numerics/probnum) builds the project and runs the test suite.
+- Documentation of code is essential for any collaborative project. ProbNum uses the
+[NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
+- Code should follow the [PEP8 style](https://www.python.org/dev/peps/pep-0008/) and the internal [style guide](https://github.com/probabilistic-numerics/probnum/blob/master/STYLEGUIDE.md).
+- Keep dependencies to a minimum.
+- Make sure to observe good coding practice.
+
+For all of the above the existing ProbNum code is a good reference.
+
+## Continuous Integration (CI)
 
 ProbNum uses [Travis CI](https://travis-ci.org/probabilistic-numerics/probnum) for continuous integration.
 For every pull request and every commit Travis builds the project and runs the test suite (through `tox`), to make sure that no breaking changes are introduced by mistake.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,35 @@ for detailed instructions.
 ## Getting Started
 
 Begin by forking the repository on GitHub. You can then clone the fork to a local machine and get started.
-ProbNum uses a set of packages (e.g. for documentation), which are not dependencies of the main package. In
-order to be able to build the documentation make sure to have the packages listed in `.travis.yml` installed.
 
-_Note_: Make sure your Sphinx version fulfills `sphinx >=1.7.5, <3`.
+### Developer Environment Setup
+Run tests on and to building the documentation locally requires additional setup.
+
+#### External Programs
+Building the documentation locally requires additional packages, which can be found in `.travis.yml`.
+At the time of writing, these packages are:
+- [pandoc](https://pandoc.org/): In Ubuntu, install via `sudo apt install pandoc`
+- [graphviz](https://graphviz.org/): In Ubuntu, install via `sudo apt install graphviz`
+
+#### tox
+Probnum uses [tox](https://tox.readthedocs.io/en/latest/) through [Travis CI](#continuous-integration) to run tests and to build documentation.
+Under the hood, tox builds virtual environments following the specifications in `./tox.ini` in order to run tests accross multiple python versions, while making sure that all the necessary dependencies are installed.
+Using tox unifies the *local* development process with CI, such that local test results should match the outcomes of Travis' builds more closely.
+
+Tox can be installed directly from the Python Package Index (PyPI), e.g. through
+```
+pip install -U tox
+```
+Once tox and the required [external programs](#external-programs) are installed, you can run tests and build the documentation locally by simply calling
+```
+tox
+```
+
+**Word of caution:**
+Running `tox` runs all environments as specified in `tox.ini`, thus potentially running tests accross many different python versions.
+To run the full test suite make sure that you have all specified python versions installed.
+Alternatively, you can run a single specific environment through `tox -e <env>`, e.g. `tox -e py36` to run tests with Python3.6 or `tox -e docs` to just build the documentation.
+
 
 ### Code Quality
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ for detailed instructions.
 Begin by forking the repository on GitHub. You can then clone the fork to a local machine and get started.
 
 ### Developer Environment Setup
-Run tests on and to building the documentation locally requires additional setup.
+Running tests on your machine and building the documentation locally requires additional setup.
 
 #### External Programs
 Building the documentation locally requires additional packages, which can be found in `.travis.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For all of the above the existing ProbNum code is a good reference.
 
 ### Testing
 
-We aim to cover as much code with tests as possible.
+We use [unittest](https://docs.python.org/3/library/unittest.html) for testing and aim to cover as much code with tests as possible.
 Make sure to add tests for newly implemented code.
 You can run the test suite on your machine via:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,11 +78,16 @@ To run the test suite on your machine via you have multiple options:
 When implementing published methods give credit and include the appropriate citations.
 You can build the documentation locally via:
 ```bash
+tox -e docs
+```
+This creates a static web page under `./docs/_build/html/` which you can view in your browser by opening `./docs/_build/html/intro.html`.
+
+Alternatively, you can manually call
+```bash
 cd docs
 make clean
 make html
 ```
-This creates a static web page under `./docs/_build/html/` which you can view in your browser by opening `./docs/_build/html/intro.html`.
 
 
 ### Continuous Integration (CI)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,18 @@ We use [unittest](https://docs.python.org/3/library/unittest.html) for testing a
 Make sure to add tests for newly implemented code.
 To run the test suite on your machine via you have multiple options:
 
-- **Full test suite with tox:** Run the full suite accross different Python versions with `tox`
-- **Single environment with tox:** Run tests via [tox](#tox) for a single Python environment. Example for Python3.6: `tox -e py36`
-- **pytest:** Run tests with directly your local environment by calling `pytest`
+- **Full test suite with tox:** Run the full suite accross different Python versions with
+  ```
+  tox
+  ```
+- **Single environment with tox:** Run tests via [tox](#tox) for a single Python environment. Example for Python3.6:
+  ```
+  tox -e py36
+  ```
+- **pytest:** Run tests with directly your local environment by calling
+  ```
+  pytest
+  ```
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,24 +37,33 @@ made [Travis](https://travis-ci.org/probabilistic-numerics/probnum) builds the p
 
 For all of the above the existing ProbNum code is a good reference.
 
-### Tests and CI
+### Testing
 
-We aim to cover as much code with tests as possible. Make sure to add tests for newly implemented code. Tests are run by
-the continuous integration tool [Travis](https://travis-ci.org/probabilistic-numerics/probnum) and coverage is reported
-by [codecov](https://codecov.io/github/probabilistic-numerics/probnum?branch=master). Once you've cloned this repository, you
-can run the test suite on your machine via:
+We aim to cover as much code with tests as possible.
+Make sure to add tests for newly implemented code.
+You can run the test suite on your machine via:
 ```bash
 pytest
 ```
 
 ### Documentation
 
-[Documentation](https://probabilistic-numerics.github.io/probnum/modules.html) is automatically built using [Sphinx](https://www.sphinx-doc.org/en/master/) and
-[Travis](https://travis-ci.org/probabilistic-numerics/probnum). When implementing published methods give credit and
-include the appropriate citations. You can build the documentation locally via:
+[Documentation](https://probabilistic-numerics.github.io/probnum/modules.html) is automatically built using [Sphinx](https://www.sphinx-doc.org/en/master/) and [Travis](https://travis-ci.org/probabilistic-numerics/probnum).
+When implementing published methods give credit and include the appropriate citations.
+You can build the documentation locally via:
 ```bash
 cd docs
 make clean
 make html
 ```
 This creates a static web page under `./docs/_build/html/` which you can view in your browser by opening `./docs/_build/html/intro.html`.
+
+
+### Continuous Integration (CI)
+
+ProbNum uses [Travis CI](https://travis-ci.org/probabilistic-numerics/probnum) for continuous integration.
+For every pull request and every commit Travis builds the project and runs the test suite (through `tox`), to make sure that no breaking changes are introduced by mistake.
+Code coverage of the tests is reported through [codecov](https://codecov.io/github/probabilistic-numerics/probnum?branch=master).
+Travis also automatically builds and publishes the [ProbNum documentation](https://probabilistic-numerics.github.io/probnum/modules.html).
+
+Changes to Travis can be made through the `.travis.yml` file, as well as through `tox.ini` since Travis relies on `tox` for both testing and building the documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ a good PR are:
 - makes minimal changes to the interface and core codebase
 
 If you would like to contribute but are unsure how, then writing examples, documentation or working on
-[open issues](https://github.com/probabilistic-numerics/probnum/issues) are a good way to start. See the 
-[contribution tutorials](https://probabilistic-numerics.github.io/probnum/development/contributing.html#contribution-tutorials) 
+[open issues](https://github.com/probabilistic-numerics/probnum/issues) are a good way to start. See the
+[contribution tutorials](https://probabilistic-numerics.github.io/probnum/development/contributing.html#contribution-tutorials)
 for detailed instructions.
 
 ## Getting Started
@@ -44,7 +44,6 @@ the continuous integration tool [Travis](https://travis-ci.org/probabilistic-num
 by [codecov](https://codecov.io/github/probabilistic-numerics/probnum?branch=master). Once you've cloned this repository, you
 can run the test suite on your machine via:
 ```bash
-cd probnum
 pytest
 ```
 
@@ -54,9 +53,8 @@ pytest
 [Travis](https://travis-ci.org/probabilistic-numerics/probnum). When implementing published methods give credit and
 include the appropriate citations. You can build the documentation locally via:
 ```bash
-cd probnum/docs
+cd docs
 make clean
 make html
 ```
-This creates a static web page under `docs/_build/html/` which you can view in your browser by opening `intro.html`.
-
+This creates a static web page under `./docs/_build/html/` which you can view in your browser by opening `./docs/_build/html/intro.html`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,17 +18,17 @@ for detailed instructions.
 ## Getting Started
 
 Begin by forking the repository on GitHub. You can then clone the fork to a local machine and get started.
-
-### Developer Environment Setup
 Running tests on your machine and building the documentation locally requires additional setup.
 
-#### External Programs
+### Required External Programs
+
 Building the documentation locally requires additional packages, which can be found in `.travis.yml`.
 At the time of writing, these packages are:
 - [pandoc](https://pandoc.org/): In Ubuntu, install via `sudo apt install pandoc`
 - [graphviz](https://graphviz.org/): In Ubuntu, install via `sudo apt install graphviz`
 
-#### tox
+### tox
+
 Probnum uses [tox](https://tox.readthedocs.io/en/latest/) through [Travis CI](#continuous-integration) to run tests and to build documentation.
 Under the hood, tox builds virtual environments following the specifications in `./tox.ini` in order to run tests accross multiple python versions, while making sure that all the necessary dependencies are installed.
 Using tox unifies the *local* development process with CI, such that local test results should match the outcomes of Travis' builds more closely.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ for detailed instructions.
 Begin by forking the repository on GitHub. You can then clone the fork to a local machine and get started.
 Running tests on your machine and building the documentation locally requires additional setup.
 
-### Required External Programs
+### Required External Tools
 
 Building the documentation locally requires additional packages, which can be found in `.travis.yml`.
 At the time of writing, these packages are:
@@ -30,44 +30,57 @@ At the time of writing, these packages are:
 ### tox
 
 Probnum uses [tox](https://tox.readthedocs.io/en/latest/) through [Travis CI](#continuous-integration) to run tests and to build documentation.
-Under the hood, tox builds virtual environments following the specifications in `./tox.ini` in order to run tests accross multiple python versions, while making sure that all the necessary dependencies are installed.
-Using tox unifies the *local* development process with CI, such that local test results should match the outcomes of Travis' builds more closely.
+Under the hood, tox builds virtual environments following the specifications in `./tox.ini` in order to run tests across multiple python versions, while making sure that all the necessary dependencies are installed.
+Using tox unifies the *local* development process with CI, such that local test results should match the outcomes of Travis's builds more closely.
 
 Tox can be installed directly from the Python Package Index (PyPI), e.g. through
 ```
 pip install -U tox
 ```
-Once tox and the required [external programs](#external-programs) are installed, you can run tests and build the documentation locally by simply calling
+Once tox and the required [external tools](#required-external-tools) are installed, you can run tests and build the documentation locally by simply calling
 ```
 tox
 ```
 
 **Word of caution:**
-Running `tox` runs all environments as specified in `tox.ini`, thus potentially running tests accross many different python versions.
+Running `tox` runs all environments as specified in `tox.ini`, thus potentially running tests across many different python versions.
 To run the full test suite make sure that you have all specified python versions installed.
-Alternatively, you can run a single specific environment through `tox -e <env>`, e.g. `tox -e py36` to run tests with Python3.6 or `tox -e docs` to just build the documentation.
+Alternatively, you can run a single specific environment through `tox -e <env>`, e.g. `tox -e py36` to run tests with Python 3.6 or `tox -e docs` to just build the documentation.
 
+## Code Quality
 
-### Testing
+Code quality is an essential component in a collaborative open-source project.
+
+- All code should be covered by tests within the [unittest](https://docs.python.org/3/library/unittest.html) framework. Every time a commit is
+made [Travis](https://travis-ci.org/probabilistic-numerics/probnum) builds the project and runs the test suite.
+- Documentation of code is essential for any collaborative project. ProbNum uses the
+[NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
+- Code should follow the [PEP8 style](https://www.python.org/dev/peps/pep-0008/) and the internal [style guide](https://github.com/probabilistic-numerics/probnum/blob/master/STYLEGUIDE.md).
+- Keep dependencies to a minimum.
+- Make sure to observe good coding practice.
+
+For all of the above the existing ProbNum code is a good reference.
+
+## Testing
 
 We use [unittest](https://docs.python.org/3/library/unittest.html) for testing and aim to cover as much code with tests as possible.
-Make sure to add tests for newly implemented code.
-To run the test suite on your machine via you have multiple options:
+Make sure to always add tests for newly implemented code.
+To run the test suite on your machine you have multiple options:
 
-- **Full test suite with tox:** Run the full suite accross different Python versions with
+- **Full test suite with tox:** Run the full suite across different Python versions with
   ```
   tox
   ```
-- **Single environment with tox:** Run tests via [tox](#tox) for a single Python environment. Example for Python3.6:
+- **Single environment with tox:** Run tests via [tox](https://probabilistic-numerics.github.io/probnum/development/contributing.html#tox) for a single Python environment. Example for Python 3.6:
   ```
   tox -e py36
   ```
-- **pytest:** Run tests with directly your local environment by calling
+- **pytest:** Run tests directly in your local environment by calling
   ```
   pytest
   ```
 
-### Documentation
+## Documentation
 
 [Documentation](https://probabilistic-numerics.github.io/probnum/modules.html) is automatically built using [Sphinx](https://www.sphinx-doc.org/en/master/) and [Travis](https://travis-ci.org/probabilistic-numerics/probnum).
 When implementing published methods give credit and include the appropriate citations.
@@ -83,21 +96,6 @@ cd docs
 make clean
 make html
 ```
-
-
-## Code Quality
-
-Code quality is an essential component in a collaborative open-source project.
-
-- All code should be covered by tests within the [unittest](https://docs.python.org/3/library/unittest.html) framework. Every time a commit is
-made [Travis](https://travis-ci.org/probabilistic-numerics/probnum) builds the project and runs the test suite.
-- Documentation of code is essential for any collaborative project. ProbNum uses the
-[NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
-- Code should follow the [PEP8 style](https://www.python.org/dev/peps/pep-0008/) and the internal [style guide](https://github.com/probabilistic-numerics/probnum/blob/master/STYLEGUIDE.md).
-- Keep dependencies to a minimum.
-- Make sure to observe good coding practice.
-
-For all of the above the existing ProbNum code is a good reference.
 
 ## Continuous Integration (CI)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,11 @@ For all of the above the existing ProbNum code is a good reference.
 
 We use [unittest](https://docs.python.org/3/library/unittest.html) for testing and aim to cover as much code with tests as possible.
 Make sure to add tests for newly implemented code.
-You can run the test suite on your machine via:
-```bash
-pytest
-```
+To run the test suite on your machine via you have multiple options:
+
+- **Full test suite with tox:** Run the full suite accross different Python versions with `tox`
+- **Single environment with tox:** Run tests via [tox](#tox) for a single Python environment. Example for Python3.6: `tox -e py36`
+- **pytest:** Run tests with directly your local environment by calling `pytest`
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,14 +68,17 @@ Make sure to always add tests for newly implemented code.
 To run the test suite on your machine you have multiple options:
 
 - **Full test suite with tox:** Run the full suite across different Python versions with
+  
   ```
   tox
   ```
 - **Single environment with tox:** Run tests via [tox](https://probabilistic-numerics.github.io/probnum/development/contributing.html#tox) for a single Python environment. Example for Python 3.6:
+  
   ```
   tox -e py36
   ```
 - **pytest:** Run tests directly in your local environment by calling
+  
   ```
   pytest
   ```

--- a/docs/source/development/example_notebook.md
+++ b/docs/source/development/example_notebook.md
@@ -39,9 +39,7 @@ Now that you've created your notebook, we have to add it in the right place on t
 
 In order to see the result build the documentation locally via:
 ```bash
-cd probnum/docs
-make clean
-make html
+tox -e docs
 ```
 If the notebook compiles successfully, you should see output similar to:
 ```bash

--- a/docs/source/development/example_notebook.md
+++ b/docs/source/development/example_notebook.md
@@ -37,7 +37,7 @@ Now that you've created your notebook, we have to add it in the right place on t
 
 ## Checking the Result
 
-In order to see the result build the documentation locally via:
+In order to view the resulting page from the notebook, build the documentation locally via:
 ```bash
 tox -e docs
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ whitelist_externals = make
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.6
+passenv = HOME
 deps =
      sphinx >= 1.7.5, <= 2.4.4
      sphinx_bootstrap_theme

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ whitelist_externals = make
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
-basepython = python3.6
+basepython = python3
 passenv = HOME
 deps =
      sphinx >= 1.7.5, <= 2.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py36,docs
+
+[testenv]
+deps = pytest
+commands = pytest
+whitelist_externals = make
+
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+basepython = python3.6
+deps =
+     sphinx >= 1.7.5, < 3
+     sphinx_bootstrap_theme
+     sphinx_automodapi
+     sphinx_automodapi
+     nbsphinx
+     jupyter
+     m2r
+changedir = docs
+commands =
+         make clean
+         make html

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,10 @@
 envlist = py36,docs
 
 [testenv]
-deps = pytest
-commands = pytest
+deps =
+     pytest
+     pytest-cov
+commands = pytest --cov=./
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = py36,docs
 
 [testenv]
 deps =
-     pytest
+     pytest >= 4.6
      pytest-cov
 commands = pytest --cov=./
 whitelist_externals = make
@@ -17,9 +17,8 @@ whitelist_externals = make
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.6
 deps =
-     sphinx >= 1.7.5, < 3
+     sphinx >= 1.7.5, <= 2.4.4
      sphinx_bootstrap_theme
-     sphinx_automodapi
      sphinx_automodapi
      nbsphinx
      jupyter
@@ -28,3 +27,7 @@ changedir = docs
 commands =
          make clean
          make html
+
+[travis]
+python =
+  3.6: py36, docs


### PR DESCRIPTION
See Issue #73 for more information and a thorough discussion.

Currently, this PR provides basic functionality to run tests and build documentation locally with tox.

Missing:
- [x] **Documentation:** Explanation on how to install and use tox
- [x] **Addition to TravisCI:** Make travis use tox
- [ ] **Version specification:** We might want to pin the specified dependencies inside the `tox.ini` to specific versions 