### PR TITLE
[WIP] Implement indexing, slicing, masking and advanced indexing for random variables and distributions

### DIFF
--- a/src/probnum/prob/distributions/dirac.py
+++ b/src/probnum/prob/distributions/dirac.py
@@ -90,6 +90,11 @@ class Dirac(Distribution):
                 A=self.parameters["support"], reps=tuple([*size, *np.repeat(1, ndims)])
             )
 
+    def __getitem__(self, key):
+        return Dirac(
+            support=self.parameters["support"][key], random_state=self.random_state,
+        )
+
     def reshape(self, newshape):
         try:
             # Reshape support

--- a/src/probnum/prob/distributions/distribution.py
+++ b/src/probnum/prob/distributions/distribution.py
@@ -416,3 +416,6 @@ class Distribution:
                 self.__class__.__name__
             )
         )
+
+    def __getitem__(self, key):
+        raise NotImplementedError

--- a/src/probnum/prob/distributions/normal.py
+++ b/src/probnum/prob/distributions/normal.py
@@ -112,6 +112,20 @@ class Normal(Distribution):
     def var(self):
         raise NotImplementedError
 
+    def __getitem__(self, key):
+        if not isinstance(key, tuple):
+            key = (key,)
+
+        # Select entries from mean
+        mean = self.mean()[key]
+
+        # Select submatrix from covariance matrix
+        cov = self.cov().reshape(self.mean().shape + self.mean().shape)
+        cov = cov[key][tuple([slice(None)] * mean.ndim) + key]
+        cov = cov.reshape(mean.size, mean.size)
+
+        return Normal(mean=mean, cov=cov, random_state=self.random_state,)
+
     # Binary arithmetic
 
     def __add__(self, other):
@@ -382,6 +396,9 @@ class _UnivariateNormal(Normal):
         self.parameters["mean"] = np.reshape(self.parameters["mean"], newshape=newshape)
         self.parameters["cov"] = np.reshape(self.parameters["cov"], newshape=newshape)
         self._shape = newshape
+
+    def __getitem__(self, key):
+        raise NotImplementedError
 
 
 class _MultivariateNormal(Normal):

--- a/src/probnum/prob/randomvariable.py
+++ b/src/probnum/prob/randomvariable.py
@@ -238,6 +238,9 @@ class RandomVariable:
         )
         return combined_rv
 
+    def __getitem__(self, key):
+        return RandomVariable(distribution=self.distribution[key])
+
     def __add__(self, other):
         return self._rv_from_binary_operation(other=other, op=operator.add)
 


### PR DESCRIPTION
This PR enables full numpy-style indexing for random variables and distributions (currently Normal and Dirac) as in

https://numpy.org/doc/stable/reference/arrays.indexing.html

Closes #11.

Still ToDo:

- [ ] Reshaping for Normals

- [ ] Transposition