### PR TITLE
Quick tox improvements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36,docs
+envlist = py3,docs
 
 [travis]
 python =
@@ -35,11 +35,12 @@ commands =
 
 [testenv:black]
 description = Code linting with Black
+basepython = python3
 deps = black
 commands = black --check --diff .
 
 [testenv:format]
 description = Code formatting with Black (and possibly other tools in the future)
+basepython = python3
 deps = black
 commands = black .
-


### PR DESCRIPTION
Following our lunch discussion.

Instead of specifying `py36` for the default `tox` run, I relaxed it to `py3`. This way, people that do not have Python 3.6 available locally (because they use another Python 3.x version) do not run into a tox error, but `tox` just uses the `python3` that is available. The drawback is that the local *default* test run and the run on Travis now differ a bit more, but I don't think that this should lead to significant errors. I would suspect that there would be more issues because people don't know how to work with tox, than because of locally passing tests that fail on Travis-CI. We could also further reduce the chances for the latter issues by adding more Python versions to Travis, e.g. adding 3.7 and 3.8.