### PR TITLE
Re-order the RandomVariable arguments for convenience

### DIFF
--- a/src/probnum/prob/randomvariable.py
+++ b/src/probnum/prob/randomvariable.py
@@ -50,7 +50,7 @@ class RandomVariable:
     --------
     """
 
-    def __init__(self, shape=None, dtype=None, distribution=None):
+    def __init__(self, distribution=None, shape=None, dtype=None):
         """Create a new random variable."""
         self._set_distribution(distribution)
         self._set_dtype(distribution, dtype)


### PR DESCRIPTION
I have the impression, that in most occurrence in our codebase `RandomVariable`s are built with 
```python
from probnum.prob import RandomVariable, Normal
X = RandomVariable(distribution=Normal(0, 1))
```

I'm strongly in favor of changing the order of the `RandomVariable.__init__` arguments such that the first argument is the distribution. The result is a less verbose handling, looking as follows:
```python
from probnum.prob import RandomVariable, Normal
X = RandomVariable(Normal(0, 1))
```

I found <10 occurrences in which the RV is not built out of a distribution, but a `shape`, but in all of those the name of the function argument ("shape") got passed explicitly.
Also, all tests pass, so this should not break anything :) 