### PR TITLE
Vectorise ah qh

### DIFF
--- a/src/probnum/diffeq/odefiltsmooth/prior.py
+++ b/src/probnum/diffeq/odefiltsmooth/prior.py
@@ -301,10 +301,16 @@ class IBM(ODEPrior):
         step = stop - start
         indices = np.arange(0, self.ordint + 1)
         col_idcs, row_idcs = np.meshgrid(indices, indices)
-        exponent = 2*self.ordint + 1 - row_idcs - col_idcs
-        factorial_rows = factorial(self.ordint - row_idcs)  # factorial() handles matrices but is slow(ish)
+        exponent = 2 * self.ordint + 1 - row_idcs - col_idcs
+        factorial_rows = factorial(
+            self.ordint - row_idcs
+        )  # factorial() handles matrices but is slow(ish)
         factorial_cols = factorial(self.ordint - col_idcs)
-        qh_1d = self.diffconst ** 2 * step ** exponent / (exponent * factorial_rows * factorial_cols)
+        qh_1d = (
+            self.diffconst ** 2
+            * step ** exponent
+            / (exponent * factorial_rows * factorial_cols)
+        )
         qh = np.kron(np.eye(self.spatialdim), qh_1d)
         return self.precond @ qh @ self.precond.T
 

--- a/src/probnum/diffeq/odefiltsmooth/prior.py
+++ b/src/probnum/diffeq/odefiltsmooth/prior.py
@@ -246,6 +246,9 @@ class IBM(ODEPrior):
         Closed form solution to the Chapman-Kolmogorov equations
         for the integrated Brownian motion.
 
+        .. math::`X_t `
+
+
         This is more stable than the matrix-exponential implementation
         in :meth:`super().chapmankolmogorov` which is relevant for
         combinations of large order :math:`q` and small steps :math:`h`.
@@ -266,6 +269,13 @@ class IBM(ODEPrior):
     def _trans_ibm(self, start, stop):
         """
         Computes closed form solution for the transition matrix A(h).
+
+        .. math:: `[A(h)]_{ij} = \\mathbb{I}_{i\leq j} \\frac{h^{j-i}}{((j-i)!}`
+
+
+        .. math:: `[Q(h)]_{ij} = \\sigma^2 \\frac{h^{2q+1-i-j}}{((2q+1-i-j)!(q-j)!(q-i)!}`
+
+
         """
         step = stop - start
 

--- a/src/probnum/diffeq/odefiltsmooth/prior.py
+++ b/src/probnum/diffeq/odefiltsmooth/prior.py
@@ -268,15 +268,13 @@ class IBM(ODEPrior):
         Computes closed form solution for the transition matrix A(h).
         """
         step = stop - start
-        ah_1d = np.array(
-            [
-                [
-                    self._trans_ibm_element(step, row, col)
-                    for col in range(self.ordint + 1)
-                ]
-                for row in range(self.ordint + 1)
-            ]
-        )
+
+        ah_1d = np.diag(np.ones(self.ordint + 1), 0)
+        for i in range(self.ordint):
+            offdiagonal = (
+                step ** (i + 1) / np.math.factorial(i + 1) * np.ones(self.ordint - i)
+            )
+            ah_1d += np.diag(offdiagonal, i + 1)
         ah = np.kron(np.eye(self.spatialdim), ah_1d)
         return self.precond @ ah @ self.invprecond
 


### PR DESCRIPTION
For the IBM, the computation of A(h) and Q(h) is now fully vectorised. The corresponding unittests go down from 8s to roughly 5-6s (which is the only performance tests I have tried). Notably, for A(h) looping over the diagonal elements (diagonal->first offdiagonal->second offdiagonal etc.) is faster than a fully vectorised, numpy based implementation (5.5s vs 7s). I suppose this is because scipy.special.factorial---albeit being able to handle matrices as inputs---is much slower than np.math.factorial (see https://stackoverflow.com/questions/21753841/factorial-in-numpy-and-scipy).