### PR TITLE
Fix Travis and tox to properly test python 3.6, 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,19 @@
 language: python
 jobs:
   include:
-    - name: "test py36"
+    - name: "Tests (Python 3.6)"
       python: 3.6
       env: TOXENV=py36
-    - name: "test py37"
+    - name: "Tests (Python 3.7)"
       python: 3.7
       env: TOXENV=py37
-    - name: "test py38"
+    - name: "Tests (Python 3.8)"
       python: 3.8
       env: TOXENV=py38
-    - name: "docs"
+    - name: "Docs"
       python: 3.6
       env: TOXENV=docs
-    - name: "benchmarks"
+    - name: "Benchmarks"
       python: 3.6
       env: TOXENV=benchmarks
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,27 @@
 
 # Set the build language to Python
 language: python
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
+jobs:
+  include:
+    - name: "test py36"
+      python: 3.6
+      env: TOXENV=py36
+    - name: "test py37"
+      python: 3.7
+      env: TOXENV=py37
+    - name: "test py38"
+      python: 3.8
+      env: TOXENV=py38
+    - name: "docs"
+      python: 3.6
+      env: TOXENV=docs
+    - name: "benchmarks"
+      python: 3.6
+      env: TOXENV=benchmarks
 install:
   - sudo apt-get install pandoc # pandoc for jupyter notebooks
   - sudo apt install graphviz # graphviz for class inheritance diagrams in docs
-  - pip install tox-travis
+  - pip install tox
 script:
   - tox
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,6 @@
 [tox]
 envlist = py3, docs, benchmarks
 
-[travis]
-python =
-  3.6: py36, docs, benchmarks
-  3.7: py37
-  3.8: py38
-
 [testenv]
 deps =
      pytest >= 4.6


### PR DESCRIPTION
Closes #127 

I moved away from tox-travis and just specify the jobs directly, including the python version and tox environment. As a byproduct the Travis-CI even got a bit better organized.