### PR TITLE
updated coverage settings for pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ envlist = py3, docs, benchmarks
 deps =
      pytest >= 4.6
      pytest-cov
-commands = pytest --doctest-modules --cov-report=xml --cov=probnum tests/
+commands =
+     pytest --doctest-modules
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py3, docs, benchmarks
 deps =
      pytest >= 4.6
      pytest-cov
-commands = pytest --cov-report=xml --cov=probnum tests/ --doctest-modules
+commands = pytest --doctest-modules --cov-report=xml --cov=probnum tests/
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
      pytest >= 4.6
      pytest-cov
 commands =
-     pytest --doctest-modules --cov=probnum --cov-append --cov-report=xml
+     pytest --doctest-modules --cov=probnum --no-cov-on-fail --cov-report=xml
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
      pytest >= 4.6
      pytest-cov
 commands =
-     pytest --doctest-modules
+     pytest --doctest-modules --cov=probnum/src --cov-append --cov-report=xml
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py3, docs, benchmarks
 deps =
      pytest >= 4.6
      pytest-cov
-commands = pytest --cov=./ --doctest-modules
+commands = pytest --cov-report=xml --cov=probnum tests/ --doctest-modules
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
      pytest >= 4.6
      pytest-cov
 commands =
-     pytest --doctest-modules --cov=probnum/src --cov-append --cov-report=xml
+     pytest --doctest-modules --cov=probnum --cov-append --cov-report=xml
 whitelist_externals = make
 
 [testenv:docs]


### PR DESCRIPTION
This PR fixes coverage reports. Currently coverage reports are not uploaded to codecov. Previously `doctests` also quietly were not run by `tox`. This PR fixes this issue as well.

This closes #139 .