### PR TITLE
Pinned pylint to 2.6 and updated the configs accordingly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ exclude = '''
 [tool.pylint.messages_control]
 # Exceptions suggested from Black: bad-continuation, bad-whitespace
 disable = """
-bad-continuation,
-bad-whitespace,
-
 invalid-name,
 
 no-else-return,

--- a/tox.ini
+++ b/tox.ini
@@ -52,13 +52,13 @@ commands =
 [testenv:pylint]
 basepython = python3
 description = Code linting with pylint
-deps = pylint
+deps = pylint == 2.6
 commands =
          # pylint src
          pylint src/probnum/diffeq --disable="protected-access,abstract-class-instantiated,too-many-locals,too-few-public-methods,too-many-arguments,unused-argument,missing-module-docstring,missing-function-docstring"
          pylint src/probnum/filtsmooth --disable="duplicate-code,protected-access,no-self-use,too-many-locals,arguments-differ,too-many-arguments,unused-argument,missing-module-docstring,missing-function-docstring"
          pylint src/probnum/linalg --disable="attribute-defined-outside-init,too-many-statements,too-many-instance-attributes,too-complex,protected-access,too-many-lines,no-self-use,too-many-locals,redefined-builtin,arguments-differ,abstract-method,too-many-arguments,too-many-branches,duplicate-code,unused-argument,fixme,missing-module-docstring"
-         pylint src/probnum/prob --disable="too-many-instance-attributes,broad-except,arguments-differ,abstract-method,too-many-arguments,protected-access,duplicate-code,unused-argument,fixme,missing-module-docstring,missing-function-docstring"
+         pylint src/probnum/prob --disable="too-many-instance-attributes,broad-except,arguments-differ,abstract-method,too-many-arguments,protected-access,duplicate-code,unused-argument,fixme,missing-module-docstring,missing-function-docstring,raise-missing-from"
          pylint src/probnum/quad --disable="attribute-defined-outside-init,too-few-public-methods,redefined-builtin,arguments-differ,unused-argument,missing-module-docstring"
          pylint src/probnum/utils --disable="duplicate-code,missing-module-docstring,missing-function-docstring"
          pylint tests --disable="line-too-long,duplicate-code,missing-class-docstring,unnecessary-pass,unused-variable,protected-access,attribute-defined-outside-init,no-self-use,abstract-class-instantiated,too-many-arguments,too-many-instance-attributes,too-many-locals,unused-argument,fixme,missing-module-docstring,missing-function-docstring"


### PR DESCRIPTION
This fixes #170. To make the CI tests pass again, I also added an additional exception for "raise-missing-from" to `probnum.prob` (see #159 for all).