### PR TITLE
Refactor odesolver

### DIFF
--- a/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
+++ b/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
@@ -56,7 +56,7 @@ class GaussianIVPFilter(odesolver.ODESolver):
         return filt_rv, errorest
 
     def postprocess(self, times, rvs):
-        """Rescale covariances with sigma square estimate"""
+        """Rescale covariances with sigma square estimate and (if specified), smooth the estimate."""
         rvs = [
             RandomVariable(distribution=Normal(rv.mean(), self.sigma_squared_global * rv.cov()))
             for rv in rvs

--- a/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
+++ b/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
@@ -39,7 +39,7 @@ class GaussianIVPFilter(odesolver.ODESolver):
         self.with_smoothing = with_smoothing
         super().__init__(ivp)
 
-    def pre_accepted_callback(self, time, current_guess, current_error):
+    def method_callback(self, time, current_guess, current_error):
         """Update the sigma-squared (ssq) estimate."""
         self.sigma_squared_global = (
             self.sigma_squared_global

--- a/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
+++ b/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
@@ -41,7 +41,10 @@ class GaussianIVPFilter(odesolver.ODESolver):
 
     def pre_accepted_callback(self, time, current_guess, current_error):
         """Update the sigma-squared (ssq) estimate."""
-        self.sigma_squared_global = self.sigma_squared_global + (self.sigma_squared_current - self.sigma_squared_global) / self.num_steps
+        self.sigma_squared_global = (
+            self.sigma_squared_global
+            + (self.sigma_squared_current - self.sigma_squared_global) / self.num_steps
+        )
 
     def step(self, t, t_new, current_rv, **kwargs):
         """Gaussian IVP filter step as nonlinear Kalman filtering with zero data."""
@@ -58,7 +61,9 @@ class GaussianIVPFilter(odesolver.ODESolver):
     def postprocess(self, times, rvs):
         """Rescale covariances with sigma square estimate and (if specified), smooth the estimate."""
         rvs = [
-            RandomVariable(distribution=Normal(rv.mean(), self.sigma_squared_global * rv.cov()))
+            RandomVariable(
+                distribution=Normal(rv.mean(), self.sigma_squared_global * rv.cov())
+            )
             for rv in rvs
         ]
         odesol = super().postprocess(times, rvs)

--- a/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
+++ b/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
@@ -54,7 +54,6 @@ class GaussianIVPFilter(odesolver.ODESolver):
         )
         return filt_rv, errorest
 
-
     def postprocess(self, times, rvs):
         """Rescale covariances with sigma square estimate"""
         rvs = [

--- a/src/probnum/diffeq/odefiltsmooth/odefiltsmooth.py
+++ b/src/probnum/diffeq/odefiltsmooth/odefiltsmooth.py
@@ -228,10 +228,9 @@ def probsolve_ivp(
     gfilt, firststep, stprl = _create_solver_inputs(
         ivp, method, which_prior, tol, step, firststep, precond_step, **kwargs
     )
-    solver = GaussianIVPFilter(ivp, gfilt)
+    with_smoothing = method[-2] == "s"
+    solver = GaussianIVPFilter(ivp, gfilt, with_smoothing=with_smoothing)
     solution = solver.solve(firststep=firststep, steprule=stprl, **kwargs)
-    if method in ["eks0", "eks1", "uks"]:
-        solution = solver.odesmooth(solution, **kwargs)
     return solution
 
 

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -39,13 +39,13 @@ class ODESolver(ABC):
 
             if steprule.is_accepted(stepsize, errorest):
                 self.num_steps += 1
-                self.pre_accepted_callback(
-                    time=t_new, current_guess=proposed_rv, current_error=errorest
-                )
                 t = t_new
                 current_rv = proposed_rv
                 times.append(t)
                 rvs.append(current_rv)
+                self.method_callback(
+                    time=t_new, current_guess=proposed_rv, current_error=errorest
+                )
 
             suggested_stepsize = self._suggest_step(stepsize, errorest, steprule)
             stepsize = min(suggested_stepsize, self.ivp.tmax - t)
@@ -91,7 +91,7 @@ class ODESolver(ABC):
         """
         return ODESolution(times, rvs, self)
 
-    def pre_accepted_callback(self, time, current_guess, current_error):
+    def method_callback(self, time, current_guess, current_error):
         """
         Optional callback. Can be overwritten.
         Do this as soon as it is clear that the current guess is accepted, but before storing it.

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -25,3 +25,6 @@ class ODESolver(ABC):
         """Every ODE solver needs a step() method that returns a new random variable and an error estimate"""
         raise NotImplementedError
 
+    def pre_accepted_callback(self, time, current_guess, current_error):
+        """Do this as soon as it is clear that the current guess is accepted, but before storing it. No return."""
+        pass

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -24,8 +24,8 @@ class ODESolver(ABC):
         Parameters
         ----------
         firststep : float
-            First step for adaptive step size rule.
-        steprule : StepRule
+            First step for adaptive step-size rule.
+        steprule : :class:`StepRule`
             Step-size selection rule, e.g. constant steps or adaptive steps.
         """
         t, current_rv = self.initialise()

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -3,6 +3,9 @@ Abstract ODESolver class. Interface for Runge-Kutta, ODEFilter.
 """
 
 from abc import ABC, abstractmethod
+import warnings
+
+from probnum.diffeq.odesolution import ODESolution
 
 
 class ODESolver(ABC):
@@ -10,14 +13,63 @@ class ODESolver(ABC):
     Interface for ODESolver.
     """
 
-    # solve() will be made non-abstract soon
+    def __init__(self, ivp):
+        self.ivp = ivp
+        self.num_steps = 0
+
+    def solve(self, firststep, steprule, **kwargs):
+        """
+        Solve an IVP.
+
+        Parameters
+        ----------
+        firststep : float
+            First step for adaptive step size rule.
+        steprule : StepRule
+            Step-size selection rule, e.g. constant steps or adaptive steps.
+        """
+        t, current_rv = self.initialise()
+        times, rvs = [t], [current_rv]
+        stepsize = firststep
+
+        while t < self.ivp.tmax:
+
+            t_new = t + stepsize
+            proposed_rv, errorest = self.step(t, t_new, current_rv, **kwargs)
+
+            if steprule.is_accepted(stepsize, errorest):
+                self.num_steps += 1
+                self.pre_accepted_callback(time=t_new, current_guess=proposed_rv, current_error=errorest)
+                t = t_new
+                current_rv = proposed_rv
+                times.append(t)
+                rvs.append(current_rv)
+
+            suggested_stepsize = self._suggest_step(stepsize, errorest, steprule)
+            stepsize = min(suggested_stepsize, self.ivp.tmax - t)
+
+        odesol = self.postprocess(times=times, rvs=rvs)
+        return odesol
+
+    def _suggest_step(self, step, errorest, steprule):
+        """
+        Suggests step according to steprule and warns if
+        step is extremely small.
+
+        Raises
+        ------
+        RuntimeWarning
+            If suggested step is smaller than :math:`10^{-15}`.
+        """
+        step = steprule.suggest(step, errorest)
+        if step < 1e-15:
+            warnmsg = "Stepsize is num. zero (%.1e)" % step
+            warnings.warn(message=warnmsg, category=RuntimeWarning)
+        return step
+
     @abstractmethod
-    def solve(self, ivp, minstep, maxstep, **kwargs):
-        """
-        Every ODE solver has a solve() method.
-        Optional: callback function. Allows  e.g. printing variables
-        at runtime.
-        """
+    def initialise(self):
+        """Returns t0 and y0 (for the solver, which might be different to ivp.y0)"""
         raise NotImplementedError
 
     @abstractmethod
@@ -25,6 +77,27 @@ class ODESolver(ABC):
         """Every ODE solver needs a step() method that returns a new random variable and an error estimate"""
         raise NotImplementedError
 
+    def postprocess(self, times, rvs):
+        """
+        Turn list of random variables into an ODE solution object and potentially do more.
+        Overwrite for instance via
+
+        >>> def postprocess(self, times, rvs):
+        >>> # do something with times and rvs
+        >>> odesol = super().postprocess(times, rvs)
+        >>> # do something with odesol
+        >>> return odesol
+        """
+        return ODESolution(times, rvs, self)
+
     def pre_accepted_callback(self, time, current_guess, current_error):
-        """Do this as soon as it is clear that the current guess is accepted, but before storing it. No return."""
+        """
+        Optional callback. Can be overwritten.
+        Do this as soon as it is clear that the current guess is accepted, but before storing it.
+        No return. For example: tune hyperparameters.
+        """
         pass
+
+    def interpolate(self, t, **kwargs):
+        """Evaluate the ODE solution object at time t by interpolating between nearby solutions."""
+        raise NotImplementedError  # filling this interface is out of scope for this PR

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -55,8 +55,7 @@ class ODESolver(ABC):
 
     def _suggest_step(self, step, errorest, steprule):
         """
-        Suggests step according to steprule and warns if
-        step is extremely small.
+        Suggests step according to steprule and warns if step is extremely small.
 
         Raises
         ------

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -99,7 +99,3 @@ class ODESolver(ABC):
         No return. For example: tune hyperparameters (sigma).
         """
         pass
-
-    def interpolate(self, t, **kwargs):
-        """Evaluate the ODE solution object at time t by interpolating between nearby solutions."""
-        raise NotImplementedError  # filling this interface is out of scope for this PR---just a teaser ;)

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -39,7 +39,9 @@ class ODESolver(ABC):
 
             if steprule.is_accepted(stepsize, errorest):
                 self.num_steps += 1
-                self.pre_accepted_callback(time=t_new, current_guess=proposed_rv, current_error=errorest)
+                self.pre_accepted_callback(
+                    time=t_new, current_guess=proposed_rv, current_error=errorest
+                )
                 t = t_new
                 current_rv = proposed_rv
                 times.append(t)

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -10,6 +10,7 @@ class ODESolver(ABC):
     Interface for ODESolver.
     """
 
+    # solve() will be made non-abstract soon
     @abstractmethod
     def solve(self, ivp, minstep, maxstep, **kwargs):
         """
@@ -18,3 +19,9 @@ class ODESolver(ABC):
         at runtime.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def step(self, start, stop, current, **kwargs):
+        """Every ODE solver needs a step() method that returns a new random variable and an error estimate"""
+        raise NotImplementedError
+

--- a/src/probnum/diffeq/odesolver.py
+++ b/src/probnum/diffeq/odesolver.py
@@ -96,10 +96,10 @@ class ODESolver(ABC):
         """
         Optional callback. Can be overwritten.
         Do this as soon as it is clear that the current guess is accepted, but before storing it.
-        No return. For example: tune hyperparameters.
+        No return. For example: tune hyperparameters (sigma).
         """
         pass
 
     def interpolate(self, t, **kwargs):
         """Evaluate the ODE solution object at time t by interpolating between nearby solutions."""
-        raise NotImplementedError  # filling this interface is out of scope for this PR
+        raise NotImplementedError  # filling this interface is out of scope for this PR---just a teaser ;)

--- a/tests/test_diffeq/test_odesolver.py
+++ b/tests/test_diffeq/test_odesolver.py
@@ -1,0 +1,38 @@
+
+import numpy as np
+import unittest
+from probnum.diffeq import logistic, ODESolver, ConstantSteps
+from probnum.prob import RandomVariable, Dirac
+
+
+class MockODESolver(ODESolver):
+
+    def initialise(self):
+        return self.ivp.t0, self.ivp.initrv
+
+    def step(self, start, stop, current):
+        h = stop-start
+        x = current.mean()
+        xnew = x + h * self.ivp(start, x)
+        return RandomVariable(Dirac(xnew)), np.nan  # return nan to ensure that errorest is not used
+
+
+class ODESolverTestCase(unittest.TestCase):
+    """An ODE Solver has to work with just step() and initialise() provided"""
+    def setUp(self):
+        y0 = RandomVariable(distribution=Dirac(0.3))
+        ivp = logistic([0, 4], initrv=y0)
+        self.solver = MockODESolver(ivp)
+        self.step = 0.2
+
+    def test_solve(self):
+        steprule = ConstantSteps(self.step)
+        odesol = self.solver.solve(firststep=self.step, steprule=steprule)  # this is the actual part of the test
+
+        # quick check that the result is sensible
+        self.assertAlmostEqual(odesol.t[-1], self.solver.ivp.tmax)
+        self.assertAlmostEqual(odesol.y[-1].mean(), 1.0, places=2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_diffeq/test_odesolver.py
+++ b/tests/test_diffeq/test_odesolver.py
@@ -1,5 +1,7 @@
 import unittest
+
 import numpy as np
+
 from probnum.diffeq import logistic, ODESolver, ConstantSteps
 from probnum.prob import RandomVariable, Dirac
 

--- a/tests/test_diffeq/test_odesolver.py
+++ b/tests/test_diffeq/test_odesolver.py
@@ -1,5 +1,5 @@
-import numpy as np
 import unittest
+import numpy as np
 from probnum.diffeq import logistic, ODESolver, ConstantSteps
 from probnum.prob import RandomVariable, Dirac
 


### PR DESCRIPTION
solve() is part of ODESolver now. I needed to put some hotfixes into ODESolution because now it cant depend on filtering methods in all generality anymore. This will be resolved in the future, I suggest. 

To implement a new ODESolver, one has to provide an initialise() method (which returns t0 and  y0) and a step method (which returns a guess and an error estimate). To ensure that this is enough, I wrote a test where those two are implemented for Euler. Other changes:
* _suggest_step and other attributes/methods are moved to ODEsolver, too
* smoothing is part of postprocess

If you have any questions, please comment :) 