### PR TITLE
Bumped and pinned Black, and applied it once to the codebase

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,7 +189,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "probnum.tex", "ProbNum's Documentation", [author], "manual"),
+    (master_doc, "probnum.tex", "ProbNum's Documentation", [author], "manual")
 ]
 
 # -- Options for manual page output ---------------------------------------
@@ -212,7 +212,7 @@ texinfo_documents = [
         "probnum",
         "Probabilistic Numerics in Python.",
         "Miscellaneous",
-    ),
+    )
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/src/probnum/filtsmooth/gaussfiltsmooth/_utils.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/_utils.py
@@ -2,10 +2,7 @@
 Utility functions for Gaussian filtering and smoothing.
 """
 
-from probnum.filtsmooth.statespace import (
-    ContinuousModel,
-    DiscreteModel,
-)
+from probnum.filtsmooth.statespace import ContinuousModel, DiscreteModel
 
 
 def is_cont_disc(dynamod, measmod):

--- a/src/probnum/filtsmooth/gaussfiltsmooth/extendedkalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/extendedkalman.py
@@ -10,10 +10,7 @@ from probnum.filtsmooth.gaussfiltsmooth.gaussfiltsmooth import (
 )
 from probnum.prob import RandomVariable
 from probnum.prob.distributions import Normal
-from probnum.filtsmooth.statespace import (
-    LinearSDEModel,
-    DiscreteGaussianModel,
-)
+from probnum.filtsmooth.statespace import LinearSDEModel, DiscreteGaussianModel
 
 from probnum.filtsmooth.gaussfiltsmooth._utils import is_cont_disc, is_disc_disc
 

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -9,10 +9,7 @@ from probnum.filtsmooth.gaussfiltsmooth.gaussfiltsmooth import (
     linear_discrete_update,
 )
 from probnum.prob import RandomVariable, Normal
-from probnum.filtsmooth.statespace import (
-    LinearSDEModel,
-    DiscreteGaussianLinearModel,
-)
+from probnum.filtsmooth.statespace import LinearSDEModel, DiscreteGaussianLinearModel
 
 from probnum.filtsmooth.gaussfiltsmooth._utils import is_cont_disc, is_disc_disc
 

--- a/src/probnum/prob/distributions/dirac.py
+++ b/src/probnum/prob/distributions/dirac.py
@@ -107,7 +107,7 @@ class Dirac(Distribution):
             while marginalizing over all other entries.
         """
         return Dirac(
-            support=self.parameters["support"][key], random_state=self.random_state,
+            support=self.parameters["support"][key], random_state=self.random_state
         )
 
     def reshape(self, newshape):

--- a/src/probnum/prob/distributions/distribution.py
+++ b/src/probnum/prob/distributions/distribution.py
@@ -163,7 +163,7 @@ class Distribution:
 
     @random_state.setter
     def random_state(self, seed):
-        """ Get or set the RandomState object of the underlying distribution.
+        """Get or set the RandomState object of the underlying distribution.
 
         This can be either None or an existing RandomState object. If None (or
         np.random), use the RandomState singleton used by np.random. If already a

--- a/src/probnum/prob/distributions/normal.py
+++ b/src/probnum/prob/distributions/normal.py
@@ -161,7 +161,7 @@ class Normal(Distribution):
             reshaped_cov = reshaped_cov.reshape(1, 1)
 
         return Normal(
-            mean=reshaped_mean, cov=reshaped_cov, random_state=self.random_state,
+            mean=reshaped_mean, cov=reshaped_cov, random_state=self.random_state
         )
 
     def _reshape_inplace(self, newshape):
@@ -381,8 +381,8 @@ def _both_are_multivariate(mean, cov):
     Checks whether mean and kernels correspond to the
     MULTI- or MATRIXVARIATE normal distribution.
     """
-    mean_is_multivar = isinstance(mean, (np.ndarray, scipy.sparse.spmatrix,))
-    cov_is_multivar = isinstance(cov, (np.ndarray, scipy.sparse.spmatrix,))
+    mean_is_multivar = isinstance(mean, (np.ndarray, scipy.sparse.spmatrix))
+    cov_is_multivar = isinstance(cov, (np.ndarray, scipy.sparse.spmatrix))
     return mean_is_multivar and cov_is_multivar and len(mean.shape) == 1
 
 
@@ -391,8 +391,8 @@ def _both_are_matrixvariate(mean, cov):
     Checks whether mean and kernels correspond to the
     MULTI- or MATRIXVARIATE normal distribution.
     """
-    mean_is_multivar = isinstance(mean, (np.ndarray, scipy.sparse.spmatrix,))
-    cov_is_multivar = isinstance(cov, (np.ndarray, scipy.sparse.spmatrix,))
+    mean_is_multivar = isinstance(mean, (np.ndarray, scipy.sparse.spmatrix))
+    cov_is_multivar = isinstance(cov, (np.ndarray, scipy.sparse.spmatrix))
     return mean_is_multivar and cov_is_multivar and len(mean.shape) > 1
 
 

--- a/src/probnum/prob/randomvariable.py
+++ b/src/probnum/prob/randomvariable.py
@@ -173,7 +173,7 @@ class RandomVariable:
 
     @random_state.setter
     def random_state(self, seed):
-        """ Get or set the RandomState object of the underlying distribution.
+        """Get or set the RandomState object of the underlying distribution.
 
         This can be either None or an existing :class:`~numpy.random.RandomState`
         object. If None (or np.random), use the :class:`~numpy.random.RandomState`

--- a/tests/test_prob/test_distributions/test_normal.py
+++ b/tests/test_prob/test_distributions/test_normal.py
@@ -566,7 +566,7 @@ class MatrixvariateNormalTestCase(unittest.TestCase, NumpyAssertions):
 
     def test_transpose(self):
         dist = prob.Normal(
-            mean=np.random.uniform(size=(2, 2)), cov=_random_spd_matrix(4),
+            mean=np.random.uniform(size=(2, 2)), cov=_random_spd_matrix(4)
         )
         dist_t = dist.transpose()
 

--- a/tests/test_utils/test_arrayutils.py
+++ b/tests/test_utils/test_arrayutils.py
@@ -26,7 +26,7 @@ class TestAssertIsArray(unittest.TestCase):
         self.assertEqual(1, 1)
 
     def test_assert_is_2d_ndarray_fail(self):
-        arr_wrong1 = np.random.rand(4,)
+        arr_wrong1 = np.random.rand(4)
         with self.assertRaises(ValueError):
             arrayutils.assert_is_2d_ndarray(arr_wrong1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,13 +28,13 @@ commands =
 [testenv:black]
 description = Code linting with Black
 basepython = python3
-deps = black
+deps = black == 20.8b0
 commands = black --check --diff .
 
 [testenv:format]
 description = Code formatting with Black (and possibly other tools in the future)
 basepython = python3
-deps = black
+deps = {[testenv:black]deps}
 commands = black .
 
 [testenv:benchmarks]


### PR DESCRIPTION
Solves #184, so the CI should not fail anymore.

I pinned Black to the latest version 20.8b0 (so the version that would be installed by a new user when freshly installing Black). I would advise everybody (pinging @JonathanWenger @pnkraemer @marvinpfoertner) to install the latest Black version locally (`pip install black==20.8b0`) in order to reduce the mismatch between CI checks and the local formatting.