### PR TITLE
Adjusted tox config such that asv fails on benchmark error

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,11 +40,11 @@ commands = black .
 [testenv:benchmarks]
 description = Dry run the benchmarks to check for errors
 basepython = python3
-deps = asv
+deps = git+https://github.com/airspeed-velocity/asv.git@master#egg=asv
 changedir = benchmarks
 commands =
 		 asv machine --yes
-		 asv dev
+		 asv run -e --quick --strict --show-stderr --python=same
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,11 +40,11 @@ commands = black .
 [testenv:benchmarks]
 description = Dry run the benchmarks to check for errors
 basepython = python3
-deps = git+https://github.com/airspeed-velocity/asv.git@master#egg=asv
+deps = git+https://github.com/airspeed-velocity/asv.git@a131ca742daf53c4521fbfefeb53507b5c140c84#egg=asv
 changedir = benchmarks
 commands =
 		 asv machine --yes
-		 asv run -e --quick --strict --show-stderr --python=same
+		 asv run -e --quick --dry-run --strict --show-stderr --python=same
 
 
 


### PR DESCRIPTION
With the current CI setup while benchmarks were run in `dev` mode with airspeed velocity, asv did not actually return non-zero exit code on failure. This is only possible with the newest version on Github and its `--strict` flag. This PR now ensures that the tox environment for the benchmarks actually fails if there is a breaking code change in the benchmarks.