### PR TITLE
Resolve utils pylint

### DIFF
--- a/src/probnum/utils/argutils.py
+++ b/src/probnum/utils/argutils.py
@@ -16,10 +16,15 @@ __all__ = ["as_shape", "as_random_state", "as_numpy_scalar"]
 
 
 def as_random_state(x: RandomStateArgType) -> RandomStateType:
+    """
+    Transform a variable or RandomStateArgType into
+    the random state format that is used internally.
+    """
     return scipy._lib._util.check_random_state(x)
 
 
 def as_shape(x: ShapeArgType) -> ShapeType:
+    """Transform a variable of ShapeArgType into a ShapeType (which is used internally)."""
     if isinstance(x, (int, numbers.Integral, np.integer)):
         return (int(x),)
     elif isinstance(x, tuple) and all(isinstance(item, int) for item in x):
@@ -39,6 +44,7 @@ def as_shape(x: ShapeArgType) -> ShapeType:
 
 
 def as_numpy_scalar(x: ScalarArgType, dtype: DTypeArgType = None) -> np.generic:
+    """Transform a variable of ScalarArgType into a NumPy scalar (which is preferred internally)."""
     is_scalar = np.isscalar(x)
     is_scalar_array = isinstance(x, np.ndarray) and x.ndim == 0
 

--- a/src/probnum/utils/argutils.py
+++ b/src/probnum/utils/argutils.py
@@ -22,27 +22,26 @@ def as_random_state(seed: RandomStateArgType) -> RandomStateType:
     Transform a variable or RandomStateArgType into
     the random state format that is used internally.
     """
-    return scipy._lib._util.check_random_state(seed=seed)
+    return scipy._lib._util.check_random_state(seed=seed)  # pylint: disable=protected-access
 
 
 def as_shape(shape: ShapeArgType) -> ShapeType:
     """Transform a variable of ShapeArgType into a ShapeType (which is used internally)."""
     if isinstance(shape, (int, numbers.Integral, np.integer)):
         return (int(shape),)
-    elif isinstance(shape, tuple) and all(isinstance(item, int) for item in shape):
+    if isinstance(shape, tuple) and all(isinstance(item, int) for item in shape):
         return shape
-    else:
-        try:
-            _ = iter(shape)
-        except TypeError as err:
-            raise TypeError(
-                f"The given shape {shape} must be an integer or an iterable of integers."
-            ) from err
+    try:
+        _ = iter(shape)
+    except TypeError as err:
+        raise TypeError(
+            f"The given shape {shape} must be an integer or an iterable of integers."
+        ) from err
 
-        if not all(isinstance(item, (int, numbers.Integral, np.integer)) for item in shape):
-            raise TypeError(f"The given shape {shape} must only contain integer values.")
+    if not all(isinstance(item, (int, numbers.Integral, np.integer)) for item in shape):
+        raise TypeError(f"The given shape {shape} must only contain integer values.")
 
-        return tuple(int(item) for item in shape)
+    return tuple(int(item) for item in shape)
 
 
 def as_numpy_scalar(scalar: ScalarArgType, dtype: DTypeArgType = None) -> np.generic:

--- a/src/probnum/utils/argutils.py
+++ b/src/probnum/utils/argutils.py
@@ -1,3 +1,5 @@
+"""Utility functions to process function arguments."""
+
 import numbers
 
 import numpy as np

--- a/src/probnum/utils/argutils.py
+++ b/src/probnum/utils/argutils.py
@@ -17,40 +17,40 @@ from probnum.types import (
 __all__ = ["as_shape", "as_random_state", "as_numpy_scalar"]
 
 
-def as_random_state(x: RandomStateArgType) -> RandomStateType:
+def as_random_state(seed: RandomStateArgType) -> RandomStateType:
     """
     Transform a variable or RandomStateArgType into
     the random state format that is used internally.
     """
-    return scipy._lib._util.check_random_state(x)
+    return scipy._lib._util.check_random_state(seed=seed)
 
 
-def as_shape(x: ShapeArgType) -> ShapeType:
+def as_shape(shape: ShapeArgType) -> ShapeType:
     """Transform a variable of ShapeArgType into a ShapeType (which is used internally)."""
-    if isinstance(x, (int, numbers.Integral, np.integer)):
-        return (int(x),)
-    elif isinstance(x, tuple) and all(isinstance(item, int) for item in x):
-        return x
+    if isinstance(shape, (int, numbers.Integral, np.integer)):
+        return (int(shape),)
+    elif isinstance(shape, tuple) and all(isinstance(item, int) for item in shape):
+        return shape
     else:
         try:
-            _ = iter(x)
-        except TypeError as e:
+            _ = iter(shape)
+        except TypeError as err:
             raise TypeError(
-                f"The given shape {x} must be an integer or an iterable of integers."
-            ) from e
+                f"The given shape {shape} must be an integer or an iterable of integers."
+            ) from err
 
-        if not all(isinstance(item, (int, numbers.Integral, np.integer)) for item in x):
-            raise TypeError(f"The given shape {x} must only contain integer values.")
+        if not all(isinstance(item, (int, numbers.Integral, np.integer)) for item in shape):
+            raise TypeError(f"The given shape {shape} must only contain integer values.")
 
-        return tuple(int(item) for item in x)
+        return tuple(int(item) for item in shape)
 
 
-def as_numpy_scalar(x: ScalarArgType, dtype: DTypeArgType = None) -> np.generic:
+def as_numpy_scalar(scalar: ScalarArgType, dtype: DTypeArgType = None) -> np.generic:
     """Transform a variable of ScalarArgType into a NumPy scalar (which is preferred internally)."""
-    is_scalar = np.isscalar(x)
-    is_scalar_array = isinstance(x, np.ndarray) and x.ndim == 0
+    is_scalar = np.isscalar(scalar)
+    is_scalar_array = isinstance(scalar, np.ndarray) and scalar.ndim == 0
 
     if not (is_scalar or is_scalar_array):
         raise ValueError("The given input is not a scalar.")
 
-    return np.asarray(x, dtype=dtype)[()]
+    return np.asarray(scalar, dtype=dtype)[()]

--- a/src/probnum/utils/argutils.py
+++ b/src/probnum/utils/argutils.py
@@ -22,7 +22,8 @@ def as_random_state(seed: RandomStateArgType) -> RandomStateType:
     Transform a variable or RandomStateArgType into
     the random state format that is used internally.
     """
-    return scipy._lib._util.check_random_state(seed=seed)  # pylint: disable=protected-access
+    # pylint: disable=protected-access
+    return scipy._lib._util.check_random_state(seed=seed)
 
 
 def as_shape(shape: ShapeArgType) -> ShapeType:

--- a/src/probnum/utils/arrayutils.py
+++ b/src/probnum/utils/arrayutils.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def atleast_1d(*rvs):
+def atleast_1d(*randvars):
     """
     Convert arrays or random variables to arrays or random variables
     with at least one dimension.
@@ -39,22 +39,22 @@ def atleast_1d(*rvs):
 
     """
     res = []
-    for rv in rvs:
-        if isinstance(rv, scipy.sparse.spmatrix):
-            result = rv
-        elif isinstance(rv, np.ndarray):
-            result = np.atleast_1d(rv)
-        elif isinstance(rv, probnum.RandomVariable):
+    for randvar in randvars:
+        if isinstance(randvar, scipy.sparse.spmatrix):
+            result = randvar
+        elif isinstance(randvar, np.ndarray):
+            result = np.atleast_1d(randvar)
+        elif isinstance(randvar, probnum.RandomVariable):
             raise NotImplementedError
         else:
-            result = rv
+            result = randvar
         res.append(result)
     if len(res) == 1:
         return res[0]
     return res
 
 
-def atleast_2d(*rvs):
+def atleast_2d(*randvars):
     """
     View inputs as arrays with at least two dimensions.
 
@@ -77,15 +77,15 @@ def atleast_2d(*rvs):
     atleast_1d
     """
     res = []
-    for rv in rvs:
-        if isinstance(rv, scipy.sparse.spmatrix):
-            result = rv
-        elif isinstance(rv, np.ndarray):
-            result = np.atleast_2d(rv)
-        elif isinstance(rv, probnum.RandomVariable):
+    for randvar in randvars:
+        if isinstance(randvar, scipy.sparse.spmatrix):
+            result = randvar
+        elif isinstance(randvar, np.ndarray):
+            result = np.atleast_2d(randvar)
+        elif isinstance(randvar, probnum.RandomVariable):
             raise NotImplementedError
         else:
-            result = rv
+            result = randvar
         res.append(result)
     if len(res) == 1:
         return res[0]

--- a/src/probnum/utils/arrayutils.py
+++ b/src/probnum/utils/arrayutils.py
@@ -125,7 +125,7 @@ def assert_is_1d_ndarray(arr):
     """
     if not isinstance(arr, np.ndarray):
         raise ValueError("Please enter arr of shape (d,)")
-    elif len(arr.shape) != 1:
+    if len(arr.shape) != 1:
         raise ValueError("Please enter arr of shape (d,)")
 
 
@@ -137,5 +137,5 @@ def assert_is_2d_ndarray(arr):
     """
     if not isinstance(arr, np.ndarray):
         raise ValueError("Please enter arr of shape (n, d)")
-    elif arr.ndim != 2:
+    if arr.ndim != 2:
         raise ValueError("Please enter arr of shape (n, d)")

--- a/src/probnum/utils/arrayutils.py
+++ b/src/probnum/utils/arrayutils.py
@@ -51,8 +51,7 @@ def atleast_1d(*rvs):
         res.append(result)
     if len(res) == 1:
         return res[0]
-    else:
-        return res
+    return res
 
 
 def atleast_2d(*rvs):
@@ -90,8 +89,7 @@ def atleast_2d(*rvs):
         res.append(result)
     if len(res) == 1:
         return res[0]
-    else:
-        return res
+    return res
 
 
 def as_colvec(vec):

--- a/src/probnum/utils/fctutils.py
+++ b/src/probnum/utils/fctutils.py
@@ -9,8 +9,6 @@ __all__ = ["assert_evaluates_to_scalar"]
 
 
 def assert_evaluates_to_scalar(fct, valid_input):
-    """
-    Checks whether the output of a function is a scalar.
-    """
+    """Checks whether the output of a function is a scalar."""
     if not np.isscalar(fct(valid_input)):
         raise ValueError("Function does not evaluate to scalar.")

--- a/src/probnum/utils/fctutils.py
+++ b/src/probnum/utils/fctutils.py
@@ -1,6 +1,4 @@
-"""
-Utility functions for functions, methods and the like.
-"""
+"""Utility functions for functions, methods and the like."""
 
 import numpy as np
 

--- a/src/probnum/utils/randomutils.py
+++ b/src/probnum/utils/randomutils.py
@@ -7,6 +7,8 @@ import numpy as np
 
 def derive_random_seed(*args: Union[np.random.RandomState, np.random.Generator]) -> int:
     """Turn a random state or a generator into a random seed."""
+    # pylint: disable=no-member
+
     def _sample(rng: Union[np.random.RandomState, np.random.Generator]) -> int:
         if isinstance(rng, np.random.RandomState):
             return rng.randint(0, 2 ** 32, size=None, dtype=int)

--- a/src/probnum/utils/randomutils.py
+++ b/src/probnum/utils/randomutils.py
@@ -1,3 +1,5 @@
+"""Utility functions related to random states and random number generators."""
+
 from typing import Union
 
 import numpy as np

--- a/src/probnum/utils/randomutils.py
+++ b/src/probnum/utils/randomutils.py
@@ -10,10 +10,9 @@ def derive_random_seed(*args: Union[np.random.RandomState, np.random.Generator])
     def _sample(rng: Union[np.random.RandomState, np.random.Generator]) -> int:
         if isinstance(rng, np.random.RandomState):
             return rng.randint(0, 2 ** 32, size=None, dtype=int)
-        elif isinstance(rng, np.random.Generator):
+        if isinstance(rng, np.random.Generator):
             return rng.integers(0, 2 ** 32, size=None, dtype=int, endpoint=False)
-        else:
-            raise ValueError("Unsupported type of random number generator")
+        raise ValueError("Unsupported type of random number generator")
 
     seed = _sample(args[0])
 

--- a/src/probnum/utils/randomutils.py
+++ b/src/probnum/utils/randomutils.py
@@ -4,6 +4,7 @@ import numpy as np
 
 
 def derive_random_seed(*args: Union[np.random.RandomState, np.random.Generator]) -> int:
+    """Turn a random state or a generator into a random seed."""
     def _sample(rng: Union[np.random.RandomState, np.random.Generator]) -> int:
         if isinstance(rng, np.random.RandomState):
             return rng.randint(0, 2 ** 32, size=None, dtype=int)

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,5 @@ commands =
          pylint src/probnum/linalg --disable="attribute-defined-outside-init,too-many-statements,too-many-instance-attributes,too-complex,protected-access,too-many-lines,no-self-use,too-many-locals,redefined-builtin,arguments-differ,abstract-method,too-many-arguments,too-many-branches,duplicate-code,unused-argument,fixme,missing-module-docstring"
          pylint src/probnum/quad --disable="attribute-defined-outside-init,too-few-public-methods,redefined-builtin,arguments-differ,unused-argument,missing-module-docstring"
          pylint src/probnum/random_variables --disable="missing-function-docstring"
-         pylint src/probnum/utils --disable="duplicate-code,missing-module-docstring,missing-function-docstring"
          pylint benchmarks --disable="missing-function-docstring"  # not a work in progress, but final
          pylint tests --disable="line-too-long,duplicate-code,missing-class-docstring,unnecessary-pass,unused-variable,protected-access,attribute-defined-outside-init,no-self-use,abstract-class-instantiated,too-many-arguments,too-many-instance-attributes,too-many-locals,unused-argument,fixme,missing-module-docstring,missing-function-docstring"


### PR DESCRIPTION
the `utils` module is pylint-clean now. The only nontrivial changes were:
* I renamed some variables that were not pep8 conform (`x` is now `seed`/`shape`, `rv` is now `randvar` according to the styleguide)
* I changed the no-else-return that pylint complains about. I know that this might be controversial but IMO, if we stick to pylint as a code checker we pick pylint's view in controversial questions ;) 

I believe that @marvinpfoertner is the author of many of these functions (at least of the `argutils` module)? If not, I will request another review. 