### PR TITLE
Travis Migration to travis-ci.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ for detailed instructions.
 
 ## Getting Started
 
-Begin by forking the repository on GitHub and cloning your fork to a local machine. Next, create a new branch in your 
-forked repository describing the feature you would like to implement. You can now get started writing code in your new 
+Begin by forking the repository on GitHub and cloning your fork to a local machine. Next, create a new branch in your
+forked repository describing the feature you would like to implement. You can now get started writing code in your new
 branch. Make sure to keep the following best practices regarding code quality in mind.
 
 ### Code Quality
@@ -37,35 +37,35 @@ For all of the above the existing ProbNum code is a good initial reference point
 
 ### Using Tox
 
-Probnum uses [tox](https://tox.readthedocs.io/en/latest/) in its [continuous integration (CI)](#continuous-integration) 
-pipeline to run tests and to build documentation. Under the hood, tox builds virtual environments following the 
-specifications in `./tox.ini` in order to run tests across multiple python versions, while making sure that all the 
-necessary dependencies are installed. Using tox unifies the *local* development process with CI, such that local test 
-results should match the outcomes of Travis's builds more closely. This ensures that your pull request can be merged 
+Probnum uses [tox](https://tox.readthedocs.io/en/latest/) in its [continuous integration (CI)](#continuous-integration)
+pipeline to run tests and to build documentation. Under the hood, tox builds virtual environments following the
+specifications in `./tox.ini` in order to run tests across multiple python versions, while making sure that all the
+necessary dependencies are installed. Using tox unifies the *local* development process with CI, such that local test
+results should match the outcomes of Travis's builds more closely. This ensures that your pull request can be merged
 seamlessly into ProbNum's codebase.
 
 Install tox from the Python Package Index (PyPI) via
 ```bash
 pip install -U tox
 ```
-Once tox and the required [external tools](#external-tools) below are installed, you can run tests and build the 
+Once tox and the required [external tools](#external-tools) below are installed, you can run tests and build the
 documentation locally by simply calling
 ```bash
 tox
 ```
-Note, to reduce runtime tox caches and reuses the virtual environment it creates the first time you run the command. If 
-you are frequently switching between branches or adjusting the build configuration make sure to force recreation of the 
+Note, to reduce runtime tox caches and reuses the virtual environment it creates the first time you run the command. If
+you are frequently switching between branches or adjusting the build configuration make sure to force recreation of the
 virtual environment via ``tox -r``, if you experience unexpected tox failures.
 
 **Word of caution:**
-Running `tox` runs all environments as specified in `tox.ini`, thus potentially running tests across many different 
+Running `tox` runs all environments as specified in `tox.ini`, thus potentially running tests across many different
 Python versions. To run the full test suite make sure that you have all specified Python versions installed.
-Alternatively, you can run a single specific environment through `tox -e <env>`, e.g. `tox -e py36` to run tests with 
+Alternatively, you can run a single specific environment through `tox -e <env>`, e.g. `tox -e py36` to run tests with
 Python 3.6 or `tox -e docs` to just build the documentation.
 
 ### External Tools
 
-Building the documentation locally requires additional packages (e.g. for inheritance diagrams), which can be found in 
+Building the documentation locally requires additional packages (e.g. for inheritance diagrams), which can be found in
 `.travis.yml`. These packages are currently:
 - [pandoc](https://pandoc.org/): In Ubuntu, install via `sudo apt install pandoc`
 - [graphviz](https://graphviz.org/): In Ubuntu, install via `sudo apt install graphviz`
@@ -74,43 +74,43 @@ Building the documentation locally requires additional packages (e.g. for inheri
 
 [![test coverage: latest](https://img.shields.io/codecov/c/gh/probabilistic-numerics/probnum/master?label=Coverage%3A%20latest&logo=codecov)](https://codecov.io/gh/probabilistic-numerics/probnum/branch/master)
 
-We use [unittest](https://docs.python.org/3/library/unittest.html) for testing and aim to cover as much code with tests 
-as possible. Make sure to always add tests for newly implemented code. To run the test suite on your machine you have 
+We use [unittest](https://docs.python.org/3/library/unittest.html) for testing and aim to cover as much code with tests
+as possible. Make sure to always add tests for newly implemented code. To run the test suite on your machine you have
 multiple options:
 
 - **Full test suite with tox:** Run the full suite across different Python versions with
-  
+
   ```bash
   tox
   ```
-  
+
 - **Single environment with tox:** Run tests for a single Python environment, e.g. for Python 3.6
-  
+
   ```bash
   tox -e py36
   ```
-  
+
 - **pytest:** Run tests directly in your local environment by calling
-  
+
   ```bash
   pytest
   ```
-Code coverage of the tests is reported via [codecov](https://codecov.io/github/probabilistic-numerics/probnum?branch=master). 
+Code coverage of the tests is reported via [codecov](https://codecov.io/github/probabilistic-numerics/probnum?branch=master).
 
 ## Documentation
 
 [![docs: stable](https://img.shields.io/readthedocs/probnum.svg?logo=read%20the%20docs&logoColor=white&label=Docs:%20stable)](https://probnum.readthedocs.io/en/stable/)
 [![docs: latest](https://img.shields.io/readthedocs/probnum.svg?logo=read%20the%20docs&logoColor=white&label=Docs:%20latest)](https://probnum.readthedocs.io/en/latest/)
 
-ProbNum's documentation is created with [Sphinx](https://www.sphinx-doc.org/en/master/) and automatically built and 
-hosted by [ReadTheDocs](https://readthedocs.org/projects/probnum/) for stable releases and the latest (`master` branch) 
+ProbNum's documentation is created with [Sphinx](https://www.sphinx-doc.org/en/master/) and automatically built and
+hosted by [ReadTheDocs](https://readthedocs.org/projects/probnum/) for stable releases and the latest (`master` branch)
 version.
 
 You can build the documentation locally via
 ```bash
 tox -e docs
 ```
-This creates a static web page under `./docs/_build/html/` which you can view in your browser by opening 
+This creates a static web page under `./docs/_build/html/` which you can view in your browser by opening
 `./docs/_build/html/intro.html`.
 
 Alternatively, if you want to build the docs in your current environment you can manually execute
@@ -122,12 +122,12 @@ make html
 
 ## Continuous Integration
 
-[![build status: latest](https://img.shields.io/travis/probabilistic-numerics/probnum/master.svg?logo=travis%20ci&logoColor=white&label=Travis%20CI:%20latest)](https://travis-ci.org/github/probabilistic-numerics/probnum/branches)
+[![build status: latest](https://img.shields.io/travis/probabilistic-numerics/probnum/master.svg?logo=travis%20ci&logoColor=white&label=Travis%20CI:%20latest)](https://travis-ci.com/github/probabilistic-numerics/probnum/branches)
 
-ProbNum uses [Travis CI](https://travis-ci.org/probabilistic-numerics/probnum) for continuous integration.
-For every pull request and every commit Travis builds the project and runs the test suite (through `tox`), to make sure 
-that no breaking changes are introduced by mistake. Travis also automatically triggers a 
-build of ProbNum's documentation. Changes to Travis can be made through the `.travis.yml` file, as well as through 
-`tox.ini` since Travis relies on `tox` for both testing and building the documentation. ProbNum also uses 
-[GitHub Actions](https://docs.github.com/en/actions) to verify that all pushes and pull requests are compliant with the 
+ProbNum uses [Travis CI](https://travis-ci.com/github/probabilistic-numerics/probnum) for continuous integration.
+For every pull request and every commit Travis builds the project and runs the test suite (through `tox`), to make sure
+that no breaking changes are introduced by mistake. Travis also automatically triggers a
+build of ProbNum's documentation. Changes to Travis can be made through the `.travis.yml` file, as well as through
+`tox.ini` since Travis relies on `tox` for both testing and building the documentation. ProbNum also uses
+[GitHub Actions](https://docs.github.com/en/actions) to verify that all pushes and pull requests are compliant with the
 [*Black*](https://github.com/psf/black) code style.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Probabilistic Numerics in Python
 
 
-[![Build Status](https://img.shields.io/travis/probabilistic-numerics/probnum/master.svg?logo=travis%20ci&logoColor=white&label=Travis%20CI)](https://travis-ci.org/probabilistic-numerics/probnum)
+[![Build Status](https://img.shields.io/travis/probabilistic-numerics/probnum/master.svg?logo=travis%20ci&logoColor=white&label=Travis%20CI)](https://travis-ci.com/github/probabilistic-numerics/probnum)
 [![Coverage Status](https://img.shields.io/codecov/c/gh/probabilistic-numerics/probnum/master?label=Coverage&logo=codecov&logoColor=white)](https://codecov.io/gh/probabilistic-numerics/probnum/branch/master)
 [![Documentation](https://img.shields.io/readthedocs/probnum.svg?logo=read%20the%20docs&logoColor=white&label=Documentation)](https://probnum.readthedocs.io)
 [![Benchmarks](http://img.shields.io/badge/Benchmarks-asv-blueviolet.svg?style=flat&logo=swift&logoColor=white)](https://probabilistic-numerics.github.io/probnum-benchmarks/benchmarks/)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,7 +83,7 @@ Indices
 
 
 .. |Travis Status| image:: https://img.shields.io/travis/probabilistic-numerics/probnum/master.svg?logo=travis%20ci&logoColor=white&label=Travis%20CI
-    :target: https://travis-ci.org/probabilistic-numerics/probnum
+    :target: https://travis-ci.com/github/probabilistic-numerics/probnum
     :alt: ProbNum's Travis CI Status
 
 .. |Coverage Status| image:: https://img.shields.io/codecov/c/gh/probabilistic-numerics/probnum/master?label=Coverage&logo=codecov&logoColor=white


### PR DESCRIPTION
Travis is migrating all its repositories from https://travis-ci.org to https://travis-ci.com by Dec 31st, 2020 (see also: https://docs.travis-ci.com/user/migrate/open-source-repository-migration)

> As you’ll no doubt have noticed, Travis CI has, for some time, been split between travis-ci.com and travis-ci.org. This was initially planned to enable open-source and commercial/private projects to be distinctly separate, but back in May 2018, we announced that open source builders would have the opportunity to build and test their projects under travis-ci.com, meaning your public and private repositories could be managed under one domain with a consistent interface and build environment.

In order to facilitate this change I performed the migration and updated any links in the repository. Builds will from now on be available at https://travis-ci.com/probabilistic-numerics/probnum. Build history can still be found at the old address and should be migrated eventually by Travis.