### PR TITLE
Fixed pygments version to avoid readthedocs build failures

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,18 @@ sphinx_rtd_theme
 sphinx_automodapi
 m2r
 
-# Packages handling notebooks
+# Sphinx dependencies
+Pygments>=2.6.1
+
+# Sphinx extensions
+sphinx-rtd-theme
+sphinx-automodapi
+sphinx-autodoc-typehints
+sphinx-gallery
+
+# Markdown conversion
+m2r2
+
+# Jupyter notebooks
 nbsphinx
 jupyter


### PR DESCRIPTION
ReadtheDocs is now set up to also build PR branches. During this change a build failure related to the pygments version appeared. This PR fixes a minimal version.