### PR TITLE
Speed up pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,11 +63,11 @@ deps = pylint == 2.6
 ignore_errors = true
 commands =
          # pylint src
-         pylint src/probnum/diffeq --disable="protected-access,abstract-class-instantiated,too-many-locals,too-few-public-methods,too-many-arguments,unused-argument,missing-module-docstring,missing-function-docstring"
-         pylint src/probnum/filtsmooth --disable="duplicate-code,no-self-use,too-many-locals,too-many-arguments,unused-argument,missing-module-docstring,missing-function-docstring"
-         pylint src/probnum/linalg --disable="attribute-defined-outside-init,too-many-statements,too-many-instance-attributes,too-complex,protected-access,too-many-lines,no-self-use,too-many-locals,redefined-builtin,arguments-differ,abstract-method,too-many-arguments,too-many-branches,duplicate-code,unused-argument,fixme,missing-module-docstring"
-         pylint src/probnum/quad --disable="attribute-defined-outside-init,too-few-public-methods,redefined-builtin,arguments-differ,unused-argument,missing-module-docstring"
-         pylint src/probnum/random_variables --disable="missing-function-docstring"
-         pylint src/probnum/utils --disable="duplicate-code,missing-module-docstring,missing-function-docstring"
-         pylint benchmarks --disable="missing-function-docstring"  # not a work in progress, but final
-         pylint tests --disable="line-too-long,duplicate-code,missing-class-docstring,unnecessary-pass,unused-variable,protected-access,attribute-defined-outside-init,no-self-use,abstract-class-instantiated,too-many-arguments,too-many-instance-attributes,too-many-locals,unused-argument,fixme,missing-module-docstring,missing-function-docstring"
+         pylint src/probnum/diffeq --disable="protected-access,abstract-class-instantiated,too-many-locals,too-few-public-methods,too-many-arguments,unused-argument,missing-module-docstring,missing-function-docstring" --jobs=0
+         pylint src/probnum/filtsmooth --disable="duplicate-code,no-self-use,too-many-locals,too-many-arguments,unused-argument,missing-module-docstring,missing-function-docstring" --jobs=0
+         pylint src/probnum/linalg --disable="attribute-defined-outside-init,too-many-statements,too-many-instance-attributes,too-complex,protected-access,too-many-lines,no-self-use,too-many-locals,redefined-builtin,arguments-differ,abstract-method,too-many-arguments,too-many-branches,duplicate-code,unused-argument,fixme,missing-module-docstring" --jobs=0
+         pylint src/probnum/quad --disable="attribute-defined-outside-init,too-few-public-methods,redefined-builtin,arguments-differ,unused-argument,missing-module-docstring" --jobs=0
+         pylint src/probnum/random_variables --disable="missing-function-docstring" --jobs=0
+         pylint src/probnum/utils --disable="duplicate-code,missing-module-docstring,missing-function-docstring" --jobs=0
+         pylint benchmarks --disable="missing-function-docstring"  # not a work in progress, but final --jobs=0
+         pylint tests --disable="line-too-long,duplicate-code,missing-class-docstring,unnecessary-pass,unused-variable,protected-access,attribute-defined-outside-init,no-self-use,abstract-class-instantiated,too-many-arguments,too-many-instance-attributes,too-many-locals,unused-argument,fixme,missing-module-docstring,missing-function-docstring" --jobs=0

--- a/tox.ini
+++ b/tox.ini
@@ -69,5 +69,5 @@ commands =
          pylint src/probnum/quad --disable="attribute-defined-outside-init,too-few-public-methods,redefined-builtin,arguments-differ,unused-argument,missing-module-docstring" --jobs=0
          pylint src/probnum/random_variables --disable="missing-function-docstring" --jobs=0
          pylint src/probnum/utils --disable="duplicate-code,missing-module-docstring,missing-function-docstring" --jobs=0
-         pylint benchmarks --disable="missing-function-docstring"  # not a work in progress, but final --jobs=0
+         pylint benchmarks --disable="missing-function-docstring" --jobs=0  # not a work in progress, but final
          pylint tests --disable="line-too-long,duplicate-code,missing-class-docstring,unnecessary-pass,unused-variable,protected-access,attribute-defined-outside-init,no-self-use,abstract-class-instantiated,too-many-arguments,too-many-instance-attributes,too-many-locals,unused-argument,fixme,missing-module-docstring,missing-function-docstring" --jobs=0


### PR DESCRIPTION
Running pylint (`tox -e pylint`) is awfully slow, at least on my machine. However, seems like it can be executed in parallel (https://stackoverflow.com/questions/51488322/why-pylint-is-too-slow-while-pep8-just-takes-a-second-to-check-the-same-code)

The speed-up gained by adding `--jobs=0` (which auto-detects the number of CPUs) is ~50s vs ~75s, which is not the world, but better than nothing. Seems like the biggest speed-up here was in the tests: ~30s vs ~10s. 

Do we want to have this in `tox.ini`? If so, please review :) 