### PR TITLE
Reduced strictness of codecov via config file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  precision: 2
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 95%
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
Codecov checks often failed in PRs in the past where no or only minor changes were made to the codebase. The introduction of the config file reduces the strictness of codecov and should mostly avoid such issues in the future.