### PR TITLE
Remove star imports from diffeq and filtsmooth (and filtsmooth.statespace)

### DIFF
--- a/src/probnum/diffeq/__init__.py
+++ b/src/probnum/diffeq/__init__.py
@@ -1,10 +1,20 @@
 """Differential Equations."""
 
-from .ode import *
-from .odefiltsmooth import *
+from .ode import (
+    IVP,
+    ODE,
+    fitzhughnagumo,
+    logistic,
+    lotkavolterra,
+    rigidbody,
+    seir,
+    threebody,
+    vanderpol,
+)
+from .odefiltsmooth import GaussianIVPFilter, ivp2ekf0, ivp2ekf1, ivp2ukf, probsolve_ivp
 from .odesolution import ODESolution
-from .odesolver import *
-from .steprule import *
+from .odesolver import ODESolver
+from .steprule import AdaptiveSteps, ConstantSteps, StepRule
 
 # Public classes and functions. Order is reflected in documentation.
 __all__ = [

--- a/src/probnum/diffeq/ode/__init__.py
+++ b/src/probnum/diffeq/ode/__init__.py
@@ -1,6 +1,14 @@
-from .ivp import *
-from .ivp_examples import *
-from .ode import *
+from .ivp import IVP
+from .ivp_examples import (
+    fitzhughnagumo,
+    logistic,
+    lotkavolterra,
+    rigidbody,
+    seir,
+    threebody,
+    vanderpol,
+)
+from .ode import ODE
 
 __all__ = [
     "ODE",

--- a/src/probnum/diffeq/odefiltsmooth/__init__.py
+++ b/src/probnum/diffeq/odefiltsmooth/__init__.py
@@ -7,6 +7,6 @@ Local import, because with a global import this does not seem
 to work.
 """
 
-from .ivp2filter import *
-from .ivpfiltsmooth import *
-from .odefiltsmooth import *
+from .ivp2filter import ivp2ekf0, ivp2ekf1, ivp2ukf
+from .ivpfiltsmooth import GaussianIVPFilter
+from .odefiltsmooth import probsolve_ivp

--- a/src/probnum/filtsmooth/__init__.py
+++ b/src/probnum/filtsmooth/__init__.py
@@ -1,8 +1,19 @@
 """Bayesian Filtering and Smoothing."""
 
-from .bayesfiltsmooth import *
-from .filtsmoothposterior import *
-from .gaussfiltsmooth import *
+from .bayesfiltsmooth import BayesFiltSmooth
+from .filtsmoothposterior import FiltSmoothPosterior
+from .gaussfiltsmooth import (
+    ContinuousEKFComponent,
+    ContinuousUKFComponent,
+    DiscreteEKFComponent,
+    DiscreteUKFComponent,
+    FixedPointStopping,
+    IteratedKalman,
+    Kalman,
+    KalmanPosterior,
+    StoppingCriterion,
+    UnscentedTransform,
+)
 
 # Public classes and functions. Order is reflected in documentation.
 __all__ = [

--- a/src/probnum/filtsmooth/gaussfiltsmooth/__init__.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/__init__.py
@@ -1,7 +1,7 @@
-from .extendedkalman import *
-from .iterated_kalman import *
-from .kalman import *
-from .kalmanposterior import *
-from .stoppingcriterion import *
-from .unscentedkalman import *
-from .unscentedtransform import *
+from .extendedkalman import ContinuousEKFComponent, DiscreteEKFComponent
+from .iterated_kalman import IteratedKalman
+from .kalman import Kalman
+from .kalmanposterior import KalmanPosterior
+from .stoppingcriterion import StoppingCriterion
+from .unscentedkalman import ContinuousUKFComponent, DiscreteUKFComponent
+from .unscentedtransform import UnscentedTransform

--- a/src/probnum/filtsmooth/gaussfiltsmooth/__init__.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/__init__.py
@@ -2,6 +2,6 @@ from .extendedkalman import ContinuousEKFComponent, DiscreteEKFComponent
 from .iterated_kalman import IteratedKalman
 from .kalman import Kalman
 from .kalmanposterior import KalmanPosterior
-from .stoppingcriterion import StoppingCriterion
+from .stoppingcriterion import FixedPointStopping, StoppingCriterion
 from .unscentedkalman import ContinuousUKFComponent, DiscreteUKFComponent
 from .unscentedtransform import UnscentedTransform

--- a/src/probnum/filtsmooth/statespace/__init__.py
+++ b/src/probnum/filtsmooth/statespace/__init__.py
@@ -12,7 +12,13 @@ from .discrete_transition import (
 )
 from .integrator import IBM, IOUP, Integrator, Matern
 from .preconditioner import NordsieckLikeCoordinates
-from .sde import LTISDE, SDE, LinearSDE
+from .sde import (
+    LTISDE,
+    SDE,
+    LinearSDE,
+    linear_sde_statistics,
+    matrix_fraction_decomposition,
+)
 from .transition import Transition, generate
 
 __all__ = [
@@ -29,5 +35,7 @@ __all__ = [
     "DiscreteLTIGaussian",
     "Preconditioner",
     "NordsieckLikeCoordinates",
+    "linear_sde_statistics",
+    "matrix_fraction_decomposition",
     "generate",
 ]

--- a/src/probnum/filtsmooth/statespace/__init__.py
+++ b/src/probnum/filtsmooth/statespace/__init__.py
@@ -11,7 +11,7 @@ from .discrete_transition import (
     DiscreteLTIGaussian,
 )
 from .integrator import IBM, IOUP, Integrator, Matern
-from .preconditioner import NordsieckLikeCoordinates
+from .preconditioner import NordsieckLikeCoordinates, Preconditioner
 from .sde import (
     LTISDE,
     SDE,

--- a/src/probnum/filtsmooth/statespace/__init__.py
+++ b/src/probnum/filtsmooth/statespace/__init__.py
@@ -5,11 +5,15 @@ space models, which are the basis for Bayesian filtering and smoothing,
 but also probabilistic ODE solvers.
 """
 
-from .discrete_transition import *
-from .integrator import *
-from .preconditioner import *
-from .sde import *
-from .transition import *
+from .discrete_transition import (
+    DiscreteGaussian,
+    DiscreteLinearGaussian,
+    DiscreteLTIGaussian,
+)
+from .integrator import IBM, IOUP, Integrator, Matern
+from .preconditioner import NordsieckLikeCoordinates
+from .sde import LTISDE, SDE, LinearSDE
+from .transition import Transition, generate
 
 __all__ = [
     "Transition",
@@ -25,4 +29,5 @@ __all__ = [
     "DiscreteLTIGaussian",
     "Preconditioner",
     "NordsieckLikeCoordinates",
+    "generate",
 ]

--- a/src/probnum/filtsmooth/statespace/sde.py
+++ b/src/probnum/filtsmooth/statespace/sde.py
@@ -29,6 +29,7 @@ class SDE(transition.Transition):
         self.dispmatfun = dispmatfun
         self.jacobfun = jacobfun
         self.precon = None
+        super().__init__()
 
     def transition_realization(
         self,

--- a/src/probnum/filtsmooth/statespace/sde.py
+++ b/src/probnum/filtsmooth/statespace/sde.py
@@ -28,7 +28,6 @@ class SDE(transition.Transition):
         self.driftfun = driftfun
         self.dispmatfun = dispmatfun
         self.jacobfun = jacobfun
-        self.precon = None
         super().__init__()
 
     def transition_realization(

--- a/tests/test_diffeq/test_odefiltsmooth/test_ivp2filter.py
+++ b/tests/test_diffeq/test_odefiltsmooth/test_ivp2filter.py
@@ -70,13 +70,13 @@ class TestIvp2Ekf1(Ivp2FilterTestCase):
     """
 
     def test_ivp2ekf1_output(self):
-        filtsmooth_object = pnd.ivp2filter.ivp2ekf1(self.ivp, self.prior, self.evlvar)
+        filtsmooth_object = pnd.ivp2ekf1(self.ivp, self.prior, self.evlvar)
         self.assertIsInstance(
             filtsmooth_object.measurement_model, pnfs.DiscreteEKFComponent
         )
 
     def test_ekf1_measmod(self):
-        kalman = pnd.ivp2filter.ivp2ekf1(self.ivp, self.prior, self.evlvar)
+        kalman = pnd.ivp2ekf1(self.ivp, self.prior, self.evlvar)
         random_time, random_eval = np.random.rand(), np.random.rand(
             self.prior.dimension
         )
@@ -89,7 +89,7 @@ class TestIvp2Ekf1(Ivp2FilterTestCase):
         self.assertAllClose(expected, received.mean)
 
     def test_ekf1_initialdistribution(self):
-        filtsmooth_object = pnd.ivp2filter.ivp2ekf1(self.ivp, self.prior, self.evlvar)
+        filtsmooth_object = pnd.ivp2ekf1(self.ivp, self.prior, self.evlvar)
         expected_initval = np.array(
             [
                 self.ivp.initrv.mean,
@@ -108,13 +108,13 @@ class TestIvpUkf(Ivp2FilterTestCase):
     """
 
     def test_ivp2ukf_output(self):
-        filtsmooth_object = pnd.ivp2filter.ivp2ukf(self.ivp, self.prior, self.evlvar)
+        filtsmooth_object = pnd.ivp2ukf(self.ivp, self.prior, self.evlvar)
         self.assertIsInstance(
             filtsmooth_object.measurement_model, pnfs.DiscreteUKFComponent
         )
 
     def test_ukf_measmod(self):
-        kalman = pnd.ivp2filter.ivp2ukf(self.ivp, self.prior, self.evlvar)
+        kalman = pnd.ivp2ukf(self.ivp, self.prior, self.evlvar)
         random_time, random_eval = np.random.rand(), np.random.rand(
             self.prior.dimension
         )
@@ -127,7 +127,7 @@ class TestIvpUkf(Ivp2FilterTestCase):
         self.assertAllClose(expected, received.mean)
 
     def test_ukf_initialdistribution(self):
-        filtsmooth_object = pnd.ivp2filter.ivp2ukf(self.ivp, self.prior, self.evlvar)
+        filtsmooth_object = pnd.ivp2ukf(self.ivp, self.prior, self.evlvar)
         expected_initval = np.array(
             [
                 self.ivp.initrv.mean,


### PR DESCRIPTION
The name says it all.

No more star imports in `__init__.py` files (in diffeq and filtsmooth). This avoids weird exports of `statespace.numpy` and the like. 