### PR TITLE
Fixed kalman initial data points

### DIFF
--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -44,6 +44,7 @@ class Kalman(BayesFiltSmooth):
             Data set that is filtered.
         times : array_like, shape (N,)
             Temporal locations of the data points.
+            The zeroth element in times and dataset is the location of the initial random variable.
 
         Returns
         -------
@@ -68,6 +69,7 @@ class Kalman(BayesFiltSmooth):
             Data set that is filtered.
         times : array_like, shape (N,)
             Temporal locations of the data points.
+            The zeroth element in times and dataset is the location of the initial random variable.
 
         Returns
         -------

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -79,14 +79,24 @@ class Kalman(BayesFiltSmooth):
         # _linearise_at is not used here, only in IteratedKalman.filter_step
         # which is overwritten by IteratedKalman
         dataset, times = np.asarray(dataset), np.asarray(times)
-        filtrv = self.initrv
-        rvs = [filtrv]
+        rvs = []
+
+        # initial update
+        filtrv, _ = self.filter_step(
+            start=times[0],
+            stop=times[0],
+            current_rv=self.initrv,
+            data=dataset[0],
+            _intermediate_step=_intermediate_step,
+        )
+        rvs.append(filtrv)
+        print(dataset.shape, times.shape)
         for idx in range(1, len(times)):
             filtrv, _ = self.filter_step(
                 start=times[idx - 1],
                 stop=times[idx],
                 current_rv=filtrv,
-                data=dataset[idx - 1],
+                data=dataset[idx],
                 _intermediate_step=_intermediate_step,
             )
             rvs.append(filtrv)

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -9,7 +9,22 @@ from probnum.random_variables import Normal
 
 
 class Kalman(BayesFiltSmooth):
-    """Gaussian filtering and smoothing, i.e. Kalman-like filters and smoothers."""
+    """Gaussian filtering and smoothing, i.e. Kalman-like filters and smoothers.
+
+    Parameters
+    ----------
+    dynamics_model
+        Prior dynamics. Usually an LTISDE object or an Integrator, but LinearSDE, ContinuousEKFComponent,
+        or ContinuousUKFComponent are also valid. Describes a random process in :math:`K` dimensions.
+        If an integrator, `K=spatialdim*(ordint+1)` for some spatialdim and ordint.
+    measurement_model
+        Measurement model. Usually an DiscreteLTIGaussian, but any DiscreteLinearGaussian is acceptable.
+        This model maps the `K` dimensional prior state (see above) to the `L` dimensional space in which the observation ``live''.
+        For 2-dimensional observations, `L=2`.
+        If an DiscreteLTIGaussian, the measurement matrix is :math:`L \times K` dimensional, the forcevec is `L` dimensional and the meascov is `L \times L` dimensional.
+    initrv
+        Initial random variable for the prior. This is a `K` dimensional Gaussian distribution (not `L`, because it belongs to the prior)
+    """
 
     def __init__(self, dynamics_model, measurement_model, initrv):
         """Check that the initial distribution is Gaussian."""

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -16,12 +16,12 @@ class Kalman(BayesFiltSmooth):
     dynamics_model
         Prior dynamics. Usually an LTISDE object or an Integrator, but LinearSDE, ContinuousEKFComponent,
         or ContinuousUKFComponent are also valid. Describes a random process in :math:`K` dimensions.
-        If an integrator, `K=spatialdim*(ordint+1)` for some spatialdim and ordint.
+        If an integrator, `K=spatialdim(ordint+1)` for some spatialdim and ordint.
     measurement_model
         Measurement model. Usually an DiscreteLTIGaussian, but any DiscreteLinearGaussian is acceptable.
-        This model maps the `K` dimensional prior state (see above) to the `L` dimensional space in which the observation ``live''.
+        This model maps the `K` dimensional prior state (see above) to the `L` dimensional space in which the observation ''live''.
         For 2-dimensional observations, `L=2`.
-        If an DiscreteLTIGaussian, the measurement matrix is :math:`L \times K` dimensional, the forcevec is `L` dimensional and the meascov is `L \times L` dimensional.
+        If an DiscreteLTIGaussian, the measurement matrix is :math:`L \\times K` dimensional, the forcevec is `L` dimensional and the meascov is `L \\times L` dimensional.
     initrv
         Initial random variable for the prior. This is a `K` dimensional Gaussian distribution (not `L`, because it belongs to the prior)
     """
@@ -83,13 +83,8 @@ class Kalman(BayesFiltSmooth):
 
         # initial update: since start=stop, prediction will not change the RV.
         # This is relied on here but may lead to future problems.
-        filtrv, _ = self.filter_step(
-            start=times[0],
-            stop=times[0],
-            current_rv=self.initrv,
-            data=dataset[0],
-            _intermediate_step=_intermediate_step,
-        )
+        filtrv, *_ = self.update(times[0], self.initrv, dataset[0])
+
         rvs.append(filtrv)
         print(dataset.shape, times.shape)
         for idx in range(1, len(times)):

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -81,7 +81,8 @@ class Kalman(BayesFiltSmooth):
         dataset, times = np.asarray(dataset), np.asarray(times)
         rvs = []
 
-        # initial update
+        # initial update: since start=stop, prediction will not change the RV.
+        # This is relied on here but may lead to future problems.
         filtrv, _ = self.filter_step(
             start=times[0],
             stop=times[0],

--- a/src/probnum/filtsmooth/statespace/transition.py
+++ b/src/probnum/filtsmooth/statespace/transition.py
@@ -232,12 +232,18 @@ def generate(dynmod, measmod, initrv, times, num_steps=5):
     -------
     states : np.ndarray; shape (len(times), dynmod.dimension)
         True states according to dynamic model.
-    obs : np.ndarray; shape (len(times)-1, measmod.dimension)
+    obs : np.ndarray; shape (len(times), measmod.dimension)
         Observations according to measurement model.
     """
     states = np.zeros((len(times), _read_dimension(dynmod, initrv)))
-    obs = np.zeros((len(times) - 1, _read_dimension(measmod, initrv)))
+    obs = np.zeros((len(times), _read_dimension(measmod, initrv)))
+
+    # initial observation point
     states[0] = initrv.sample()
+    next_obs_rv, _ = measmod.transition_realization(real=states[0], start=times[0])
+    obs[0] = next_obs_rv.sample()
+
+    # all future points
     for idx in range(1, len(times)):
         start, stop = times[idx - 1], times[idx]
         step = (stop - start) / num_steps
@@ -246,7 +252,7 @@ def generate(dynmod, measmod, initrv, times, num_steps=5):
         )
         states[idx] = next_state_rv.sample()
         next_obs_rv, _ = measmod.transition_realization(real=states[idx], start=stop)
-        obs[idx - 1] = next_obs_rv.sample()
+        obs[idx] = next_obs_rv.sample()
     return states, obs
 
 

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/filtsmooth_testcases.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/filtsmooth_testcases.py
@@ -218,7 +218,7 @@ class LinearisedDiscreteTransitionTestCase(unittest.TestCase, NumpyAssertions):
         normaliser = np.sqrt(comp.size)
         filtrmse = np.linalg.norm(filtms[:, 0] - comp) / normaliser
         smoormse = np.linalg.norm(smooms[:, 0] - comp) / normaliser
-        obs_rmse = np.linalg.norm(obs[:, 0] - comp[1:]) / normaliser
+        obs_rmse = np.linalg.norm(obs[:, 0] - comp) / normaliser
 
         # If desired, visualise.
         if VISUALISE:

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
@@ -40,7 +40,7 @@ class TestKalmanDiscreteDiscrete(CarTrackingDDTestCase):
         normaliser = np.sqrt(self.states[1:, :2].size)
         filtrmse = np.linalg.norm(filtms[1:, :2] - self.states[1:, :2]) / normaliser
         smoormse = np.linalg.norm(smooms[1:, :2] - self.states[1:, :2]) / normaliser
-        obs_rmse = np.linalg.norm(self.obs - self.states[1:, :2]) / normaliser
+        obs_rmse = np.linalg.norm(self.obs[1:] - self.states[1:, :2]) / normaliser
 
         if VISUALISE is True:
             plt.title(
@@ -85,12 +85,12 @@ class TestKalmanContinuousDiscrete(OrnsteinUhlenbeckCDTestCase):
 
         self.assertEqual(filtms[1:].shape, self.states[1:].shape)
         self.assertEqual(smooms[1:].shape, self.states[1:].shape)
-        self.assertEqual(self.obs.shape, self.states[1:].shape)
+        self.assertEqual(self.obs[1:].shape, self.states[1:].shape)
 
         normaliser = np.sqrt(self.states[1:].size)
         filtrmse = np.linalg.norm(filtms[1:] - self.states[1:]) / normaliser
         smoormse = np.linalg.norm(smooms[1:] - self.states[1:]) / normaliser
-        obs_rmse = np.linalg.norm(self.obs - self.states[1:]) / normaliser
+        obs_rmse = np.linalg.norm(self.obs[1:] - self.states[1:]) / normaliser
 
         if VISUALISE is True:
             plt.title(

--- a/tests/test_filtsmooth/test_statespace/test_transition.py
+++ b/tests/test_filtsmooth/test_statespace/test_transition.py
@@ -26,7 +26,7 @@ class TestGenerate(unittest.TestCase):
         states, obs = pnfss.generate(mocktrans, mocktrans, initrv, times)
         self.assertEqual(states.shape[0], len(times))
         self.assertEqual(states.shape[1], TEST_NDIM)
-        self.assertEqual(obs.shape[0], len(times) - 1)
+        self.assertEqual(obs.shape[0], len(times))
         self.assertEqual(obs.shape[1], TEST_NDIM)
 
 


### PR DESCRIPTION
Fixes #303 and introduces minor documentation for Kalman filter initialisation, which was missing (as pointed out by Nina). 

The main difference to before is that the initial random variable in the filter is the location of the first data point! (Which makes a million times more sense?!). The rest is making sure that all the shape tests (which now break ofc) are corrected. 