### PR TITLE
updated developer docs to pytest

### DIFF
--- a/docs/source/development/unit_testing.ipynb
+++ b/docs/source/development/unit_testing.ipynb
@@ -77,82 +77,75 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## The `unittest` Framework\n",
+    "## The `pytest` Framework\n",
     "\n",
-    "ProbNum uses [unittest](https://docs.python.org/3/library/unittest.html) as its testing framework.\n",
+    "ProbNum uses [pytest](https://docs.pytest.org/) as its testing framework.\n",
     "\n",
     "### Writing a Unit Test\n",
     "\n",
-    "Tests are organized into folders and classes which roughly mirror the structure of the repository. The main components of a test case are the *test fixtures*, which set up and tear down any required resources and the *test cases* which are the actual functions implementing tests. Below is a basic example of a test case written using `unittest`."
+    "A test is a simple function which checks whether your code does what it is\n",
+    "supposed to. Whenever you find yourself running a snippet of code to check whether your\n",
+    "implementation works, you should probably write a test. Here is a simple example."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import unittest\n",
-    "import numpy as np\n",
+    "def add(x, y):\n",
+    "    return x + y\n",
     "\n",
-    "\n",
-    "class ExampleTestCase(unittest.TestCase):\n",
-    "    \n",
-    "    def setUp(self):\n",
-    "        np.random.seed(42)\n",
-    "        # Set up a variable which will be reused across multiple tests.\n",
-    "        self.A = np.array([1, 2, 3])\n",
-    "\n",
-    "    def test_first_entry(self):\n",
-    "        \"\"\"Check that the first entry of A is 1.\"\"\"\n",
-    "        self.assertEqual(self.A[0], 1)\n",
-    "        \n",
-    "    def test_all_entries(self):\n",
-    "        \"\"\"Check whether A's entries are 1, 2 and 3.\"\"\"\n",
-    "        for i in [1, 2, 3]:\n",
-    "            # Iterate over multiple similar tests\n",
-    "            with self.subTest():\n",
-    "                self.assertEqual(self.A[i], i)"
+    "def test_symmetric():\n",
+    "    assert add(3, 5) == add(5, 3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Assertions\n",
-    "\n",
-    "Assertion statements defined in `unittest.TestCase` define the actual \"test\" of a `test_*` function. If they fail, the associated test fails. Some commonly used statements are:\n",
-    "\n",
-    "| Method                      | Checks that                |\n",
-    "|:----------------------------|:---------------------------|\n",
-    "| `assertEqual(a, b)`         | `a == b`                   |\n",
-    "| `assertNotEqual(a, b)`      | `a != b`                   |\n",
-    "| `assertTrue(x)`             | `bool(x) is True`          |\n",
-    "| `assertFalse(x)`            | `bool(x) is False`         |\n",
-    "| `assertIn(a, b)`            | `a in b`                   |\n",
-    "| `assertNotIn(a, b)`         | `a not in b`               |\n",
-    "| `assertIsInstance(a, b)`    | `isinstance(a, b)`         |\n",
-    "| `assertNotIsInstance(a, b)` | `not isinstance(a, b)`     |\n",
-    "| `assertRaises(exc)`         | exception `exc` is raised. |\n",
-    "\n",
-    "For a complete list see the [unittest.TestCase documentation](https://docs.python.org/3/library/unittest.html#unittest.TestCase)."
+    "Often we want to run a test for different combinations of\n",
+    "parameters. You can do so by parametrizing tests via a decorator."
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
    "source": [
+    "import pytest\n",
+    "\n",
+    "@pytest.mark.parametrize(\"x,y\", [(3, 5), (-1, 1), (0, 1.2)])\n",
+    "def test_symmetric(x, y):\n",
+    "    assert add(x, y) == add(y, x)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Read more about test parametrization and fixtures [here](https://docs.pytest\n",
+    ".org/en/stable/parametrize.html).\n",
+    "\n",
     "### NumPy Assertions\n",
     "\n",
-    "Often assertions which compare arrays are needed for tests. The class `tests.testing.NumpyAssertions` wraps assert statements used in NumPy, e.g. \n",
-    "\n",
-    "| Method                                             | Checks that                                                 |\n",
-    "|:---------------------------------------------------|:------------------------------------------------------------|\n",
-    "| `assertApproxEqual(a, b, significant=7)`           | scalars are equal up to significant digits.                 |\n",
-    "| `assertAllClose(a, b, rtol, atol, equal_nan=True)` | arrays are the same within a desired tolerance.             |\n",
-    "| `assertArrayEqual(a, b)`                           | arrays have the same shape and elements.                    |\n",
-    "| `assertArrayLess(a, b)`                            | all elements of `a` are strictly smaller than those of `b`. |"
-   ]
+    "Often assertions which compare arrays are needed for tests. The module [numpy\n",
+    ".testing](https://numpy.org/doc/stable/reference/routines.testing.html) offers\n",
+    "support for commonly used tests involving numeric arrays, such as\n",
+    "comparison of all elements up to a certain tolerance."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This PR updates the developer documentation to reference `pytest` instead of `unittest`. this is in line with our recent decision to switch the testing framework.