### PR TITLE
Fix doctest collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@
 [tool.pytest.ini_options]
 addopts = "--verbose --doctest-modules"
 norecursedirs = [
+    ".*",
+    "*.egg*",
     "dist",
     "build",
     ".tox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,10 @@ norecursedirs = [
     ".tox"
 ]
 testpaths = [
+    "src",
     "tests"
 ]
+doctest_optionflags = "NUMBER NORMALIZE_WHITESPACE"
 
 # Configuration of the black code style checker
 # For more information about Black's usage of this file, see

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,17 @@
 # For more information about this pyproject.toml file, see
 # PEP 518: https://www.python.org/dev/peps/pep-0518/
 
+# PyTest configuration
+[tool.pytest.ini_options]
+addopts = "--verbose --doctest-modules"
+norecursedirs = [
+        "dist",
+    "build",
+    ".tox"
+]
+testpaths = [
+    "tests"
+]
 
 # Configuration of the black code style checker
 # For more information about Black's usage of this file, see

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 [tool.pytest.ini_options]
 addopts = "--verbose --doctest-modules"
 norecursedirs = [
-        "dist",
+    "dist",
     "build",
     ".tox"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,21 +76,6 @@ test_deps =
 # addopts = --verbose
 extras = True
 
-[tool:pytest]
-# Options for py.test:
-# Specify command line options as you would do when invoking py.test directly.
-# e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
-# in order to write a coverage file that can be read by Jenkins.
-addopts =
-    --verbose
-    --doctest-modules
-norecursedirs =
-    dist
-    build
-    .tox
-testpaths =
-    tests
-
 [aliases]
 dists = bdist_wheel
 

--- a/src/probnum/diffeq/odefiltsmooth/initialise.py
+++ b/src/probnum/diffeq/odefiltsmooth/initialise.py
@@ -42,6 +42,9 @@ def compute_all_derivatives(ivp, order=6):
 
     Examples
     --------
+    >>> import sys, pytest
+    >>> if sys.platform.startswith("win"):
+    ...     pytest.skip("This doctest does not run on windows since jax does not.")
     >>> from probnum.problems.zoo.diffeq import threebody_jax, vanderpol_jax
 
     Compute the initial values of the restricted three-body problem as follows

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py3, docs, benchmarks, black, isort, pylint
 
 [testenv]
 # Test dependencies are listed in setup.cfg under [options.extras_require]
+usedevelop = True
 extras = test_deps
 commands =
      pytest --doctest-modules --cov=probnum --no-cov-on-fail --cov-report=xml --color=yes


### PR DESCRIPTION
# In a Nutshell
For the last few commits doctests were not run anymore. This PR fixes the test collection.

# Fix in Detail
This problem occurred since I erroneously had removed the `src` directory from the test path in an attempt to fix an `ImportPathError` which is explained in detail here: https://github.com/tox-dev/tox/issues/373 as part of #263. Essentially 
when using `tox` with `pytest`, then the following scenario arises:

> the problem is - your test imports the installed module thats inside the virtualenv
> afterwards doctest-modules comes along and takes a look at the source modules trying to import them failing with a mismatch

The current recommended fix by the `tox` developers is to use the `testenv` option `usedevelop = True`.

# Other
Additionally I moved the pytest config out of `setup.cfg` in a steady migration towards `pyproject.toml`.

This closes #325 