### PR TITLE
Automated versioning based on package metadata

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,31 +17,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.x"
-      - name: Find and replace version
-        run: |
-          # from refs/tags/v1.2.3 get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
-          PLACEHOLDER='version = '
-          VERSION_FILE='setup.cfg'
-
-          # ensure the placeholder is there. If grep doesn't find the placeholder
-          # it exits with exit code 1 and github actions aborts the build.
-          grep "$PLACEHOLDER" "$VERSION_FILE"
-          sed -i "s/^version =.*$/version = ${VERSION}/" "$VERSION_FILE"
-        shell: bash
-      - name: Commit version bump
-        run: |
-          # from refs/tags/v1.2.3 get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
-
-          git config --local user.name "bumpversion-bot"
-          git add setup.cfg
-          git commit -m "Automatic version bump to ${VERSION}. Triggered on release via GitHub Actions."
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          force: false
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ benchmarks/probnum/*
 
 ######### IDEs #########
 
-# IntelliJ: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+## IntelliJ: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839 ##
 
 # User-specific stuff
 .idea/
@@ -130,3 +130,7 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+
+## VSCode ##
+.vscode/

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@
 
 [metadata]
 name = probnum
-version = 0.1.3
 description = Probabilistic Numerics in Python.
 url = https://github.com/probabilistic-numerics/probnum
 author = ProbNum Authors
@@ -30,6 +29,8 @@ classifiers =
 zip_safe = False
 packages = find:
 include_package_data = True
+setup_requires =
+  setuptools_scm
 package_dir =
     =src
 # Dependencies of the project (semicolon/line-separated):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
-    Setup file for probnum.
-    Use setup.cfg to configure the project.
+"""Setup file for probnum.
+
+Use setup.cfg to configure the project.
 """
 import sys
 
@@ -16,4 +16,4 @@ except VersionConflict:
 
 
 if __name__ == "__main__":
-    setup()
+    setup(use_scm_version=True)


### PR DESCRIPTION
Versioning was previously handled by a commit triggered on release of a new version. This was broken (see #293) due to a lack of permissions. This mechanism is now replaced by [`setuptools_scm`](https://github.com/pypa/setuptools_scm/), which reads the version from the git tag, which is automatically created when a release is triggered.

Closes #293