### PR TITLE
Refactor linop testing using pytest-cases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ full =
 test =
     pytest>=4.6
     pytest-cov
+    pytest-cases>=3.2.1
     # Optional dependencies of ProbNum
     GPy
     matplotlib

--- a/src/probnum/linops/_arithmetic.py
+++ b/src/probnum/linops/_arithmetic.py
@@ -8,7 +8,12 @@ import scipy.sparse
 import probnum.utils
 from probnum.type import ScalarArgType, ShapeArgType
 
-from ._linear_operator import BinaryOperandType, LinearOperator, MatrixMult, ScalarMult
+from ._linear_operator import (  # pylint: disable=cyclic-import
+    BinaryOperandType,
+    LinearOperator,
+    MatrixMult,
+    ScalarMult,
+)
 
 
 def add(op1: BinaryOperandType, op2: BinaryOperandType) -> LinearOperator:
@@ -349,7 +354,7 @@ class InverseLinearOperator(MatrixMult):
     def __init__(self, linop: LinearOperator):
         self._linop = linop
 
-        super().__init__(A=np.inv(self._linop.todense()))
+        super().__init__(A=np.linalg.inv(self._linop.todense()))
 
     def inv(self) -> LinearOperator:
         return self._linop

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -252,7 +252,9 @@ class LinearOperator(scipy.sparse.linalg.LinearOperator):
         LinAlgError : If :meth:`trace` is called on a non-square matrix.
         """
         if not self.is_square:
-            raise np.linalg.LinAlgError("The trace is only defined on square operators")
+            raise np.linalg.LinAlgError(
+                "The trace is only defined on square operators."
+            )
 
         _identity = np.eye(self.shape[0], dtype=self.dtype)
         trace = probnum.utils.as_numpy_scalar(0, dtype=self.dtype)

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -365,11 +365,11 @@ class LinearOperator(scipy.sparse.linalg.LinearOperator):
             return matmul(other, self)
         else:
             if len(other.shape) == 1:
-                return self.rmatvec(other)
+                return self.rmatvec(np.conj(other))
             elif len(other.shape) == 2 and other.shape[0] == 1:
-                return self.rmatvec(other[0, :])[None, :]
+                return self.rmatvec(np.conj(other[0, :]))[None, :]
             elif len(other.shape) == 2:
-                return self.rmatmat(other)
+                return np.conj(self.rmatmat(np.conj(other.T)).T)
             else:
                 raise ValueError(
                     f"Expected 1-d or 2-d array, matrix or random variable, got "

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -486,7 +486,7 @@ class Identity(ScalarMult):
 
     # Properties
     def rank(self):
-        return probnum.utils.as_numpy_scalar(self.shape[0], dtype=np.int_)
+        return probnum.utils.as_numpy_scalar(self.shape[0], dtype=np.intp)
 
     def eigvals(self):
         return np.ones(self.shape[0])

--- a/src/probnum/randvars/_normal.py
+++ b/src/probnum/randvars/_normal.py
@@ -607,7 +607,6 @@ class Normal(_random_variable.ContinuousRandomVariable[_ValueType]):
                 A + damping_factor * np.eye(A.shape[0], dtype=self.dtype),
                 lower=True,
             ),
-            dtype=self.dtype,
         )
 
     def _symmetric_kronecker_identical_factors_sample(

--- a/tests/test_linops/test_kronecker.py
+++ b/tests/test_linops/test_kronecker.py
@@ -1,117 +1,70 @@
 """Tests for Kronecker-type linear operators."""
 
-import unittest
-
 import numpy as np
+import pytest
+import pytest_cases
 
-from probnum import linops
-from tests.testing import NumpyAssertions
+import probnum as pn
 
 
-class LinearOperatorKroneckerTestCase(unittest.TestCase, NumpyAssertions):
-    """Test Kronecker-type operators."""
+@pytest_cases.parametrize_with_cases(
+    "linop,matrix",
+    cases=".test_linops_cases.kronecker_cases",
+    has_tag="symmetric_kronecker",
+)
+def test_symmetric_kronecker_commutative(
+    linop: pn.linops.SymmetricKronecker, matrix: np.ndarray
+):
+    linop_commuted = pn.linops.SymmetricKronecker(linop.B, linop.A)
 
-    def setUp(self):
-        self.kronecker_matrices = [
-            (np.array([[4, 1, 4], [2, 3, 2]]), np.array([[-1, 4], [2, 1]])),
-            (np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9]]), np.array([[1, 4]])),
-        ]
-        self.symmkronecker_matrices = [
-            (np.array([[4, 1], [2, 3]]), np.array([[-1, 4], [2, 1]])),
-            (
-                np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9], [1, 0, 2]]),
-                np.array([[1, 4, 0], [-3, -0.4, -100], [0.18, -2, 10]]),
-            ),
-        ]
+    np.testing.assert_array_equal(linop.todense(), linop_commuted.todense())
+    np.testing.assert_almost_equal(linop_commuted.todense(), matrix)
 
-    def test_vec2svec_dimension(self):
-        """Check faulty dimension for Q."""
-        for n in [-1, 0, 1.1, np.inf, np.nan]:
-            with self.subTest():
-                with self.assertRaises(
-                    ValueError,
-                    msg="Invalid input dimension n should raise a ValueError.",
-                ):
-                    linops.Svec(dim=n)
 
-    def test_symmetrize(self):
-        """The Symmetrize operators should symmetrize vectors and columns of
-        matrices."""
-        for n in [1, 2, 3, 5, 12]:
-            with self.subTest():
-                x = np.random.uniform(size=n * n)
-                X = np.reshape(x, (n, n))
-                y = linops.Symmetrize(dim=n) @ x
+@pytest.mark.parametrize(
+    "A,B", [(np.array([[5, 1], [1, 10]]), np.array([[-2, 0.1], [0.1, 8]]))]
+)
+def test_symmetric_kronecker_symmetric_factors(A, B):
+    """Dense matrix from symmetric Kronecker product of two symmetric matrices must
+    be symmetric."""
+    linop = pn.linops.SymmetricKronecker(A, B)
+    linop_transpose = linop.T
+    linop_dense = linop.todense()
 
-                self.assertArrayEqual(
-                    y.reshape(n, n), 0.5 * (X + X.T), msg="Matrix not symmetric."
-                )
+    np.testing.assert_array_equal(linop_dense, linop_dense.T)
+    np.testing.assert_array_equal(linop_dense, linop_transpose.todense())
 
-                Z = np.random.uniform(size=(9, 5))
-                W = linops.Symmetrize(dim=3) @ Z
 
-                self.assertArrayEqual(
-                    W,
-                    np.vstack([linops.Symmetrize(dim=3) @ col for col in Z.T]).T,
-                    msg="Matrix columns were not symmetrized.",
-                )
+@pytest.mark.parametrize("n", [-1, 0, 1.1, np.inf, np.nan])
+def test_vec2svec_dimension(n):
+    """Check faulty dimension for Q."""
+    with pytest.raises(ValueError):
+        pn.linops.Svec(dim=n)
 
-                self.assertArrayEqual(
-                    np.shape(W),
-                    np.shape(Z),
-                    msg="Symmetrized matrix columns do not have the right shape.",
-                )
 
-    def test_kronecker_transpose(self):
-        """Kronecker product transpose property: (A (x) B)^T = A^T (x) B^T."""
-        for A, B in self.kronecker_matrices:
-            with self.subTest():
-                W = linops.Kronecker(A=A, B=B)
-                V = linops.Kronecker(A=A.T, B=B.T)
+@pytest.mark.parametrize("n", [1, 2, 3, 5, 12])
+def test_symmetrize(n):
+    np.random.seed(42)
 
-                self.assertAllClose(W.T.todense(), V.todense())
+    x = np.random.uniform(size=n * n)
+    X = np.reshape(x, (n, n))
+    y = pn.linops.Symmetrize(dim=n) @ x
 
-    def test_kronecker_explicit(self):
-        """Test the Kronecker operator against explicit matrix representations."""
-        for A, B in self.kronecker_matrices:
-            with self.subTest():
-                W = linops.Kronecker(A=A, B=B)
-                AkronB = np.kron(A, B)
+    np.testing.assert_array_equal(
+        y.reshape(n, n), 0.5 * (X + X.T), err_msg="Matrix not symmetric."
+    )
 
-                self.assertAllClose(W.todense(), AkronB)
+    Z = np.random.uniform(size=(9, 5))
+    W = pn.linops.Symmetrize(dim=3) @ Z
 
-    def test_symmkronecker_todense_symmetric(self):
-        """Dense matrix from symmetric Kronecker product of two symmetric matrices must
-        be symmetric."""
-        C = np.array([[5, 1], [1, 10]])
-        D = np.array([[-2, 0.1], [0.1, 8]])
-        Ws = linops.SymmetricKronecker(A=C, B=C)
-        Ws_dense = Ws.todense()
-        self.assertArrayEqual(
-            Ws_dense,
-            Ws_dense.T,
-            msg="Symmetric Kronecker product of symmetric matrices is not symmetric.",
-        )
+    np.testing.assert_array_equal(
+        W,
+        np.vstack([pn.linops.Symmetrize(dim=3) @ col for col in Z.T]).T,
+        err_msg="Matrix columns were not symmetrized.",
+    )
 
-    def test_symmkronecker_explicit(self):
-        """Test the symmetric Kronecker operator against explicit matrix
-        representations."""
-        pass
-
-    def test_symmkronecker_transpose(self):
-        """Kronecker product transpose property: (A (x) B)^T = A^T (x) B^T."""
-        for A, B in self.symmkronecker_matrices:
-            with self.subTest():
-                W = linops.SymmetricKronecker(A=A, B=B)
-                V = linops.SymmetricKronecker(A=A.T, B=B.T)
-
-                self.assertAllClose(W.T.todense(), V.todense())
-
-    def test_symmkronecker_commutation(self):
-        """Symmetric Kronecker products fulfill A (x)_s B = B (x)_s A"""
-        for A, B in self.symmkronecker_matrices:
-            with self.subTest():
-                W = linops.SymmetricKronecker(A=A, B=B)
-                V = linops.SymmetricKronecker(A=B, B=A)
-
-                self.assertAllClose(W.todense(), V.todense())
+    np.testing.assert_array_equal(
+        np.shape(W),
+        np.shape(Z),
+        err_msg="Symmetrized matrix columns do not have the right shape.",
+    )

--- a/tests/test_linops/test_linearoperators.py
+++ b/tests/test_linops/test_linearoperators.py
@@ -3,55 +3,22 @@ import itertools
 import unittest
 
 import numpy as np
-import scipy.sparse
 
 from probnum import linops
 from tests.testing import NumpyAssertions
 
 
-class LinearOperatorTestCase(unittest.TestCase, NumpyAssertions):
-    """General test case for linear operators."""
+class LinearOperatorArithmeticTestCase(unittest.TestCase, NumpyAssertions):
+    """Test linear operator arithmetic."""
 
     def setUp(self):
         """Resources for tests."""
         # Random Seed
         np.random.seed(42)
 
-        # Scalars, arrays and operators
+        # Scalars and arrays
         self.scalars = [0, int(1), 0.1, -4.2, np.nan, np.inf]
         self.arrays = [np.random.normal(size=[5, 4]), np.array([[3, 4], [1, 5]])]
-
-        def mv(v):
-            return np.array([2 * v[0], v[0] + 3 * v[1]])
-
-        self.mv = mv
-        self.ops = [
-            linops.MatrixMult(np.array([[-1.5, 3], [0, -230]])),
-            linops.LinearOperator(shape=(2, 2), matvec=mv),
-            linops.Identity(shape=4),
-            linops.Kronecker(
-                A=linops.MatrixMult(np.array([[2, -3.5], [12, 6.5]])),
-                B=linops.Identity(shape=3),
-            ),
-            linops.SymmetricKronecker(
-                A=linops.MatrixMult(np.array([[1, -2], [-2.2, 5]])),
-                B=linops.MatrixMult(np.array([[1, -3], [0, -0.5]])),
-            ),
-        ]
-
-    def test_linop_construction(self):
-        """Create linear operators via various construction methods."""
-
-        # Custom linear operator
-        linops.LinearOperator(shape=(2, 2), matvec=self.mv)
-
-        # Scipy linear operator
-        scipy_linop = scipy.sparse.linalg.LinearOperator(shape=(2, 2), matvec=self.mv)
-        linops.aslinop(scipy_linop)
-
-
-class LinearOperatorArithmeticTestCase(LinearOperatorTestCase):
-    """Test linear operator arithmetic."""
 
     def test_scalar_mult(self):
         """Matrix linear operator multiplication with scalars."""
@@ -69,99 +36,3 @@ class LinearOperatorArithmeticTestCase(LinearOperatorTestCase):
                 Bop = linops.MatrixMult(B)
 
                 self.assertAllClose((Aop + Bop).todense(), A + B)
-
-    def test_matvec(self):
-        """Matrix vector multiplication for linear operators."""
-        np.random.seed(1)
-        for op in self.ops:
-            with self.subTest():
-                A = op.todense()
-                x = np.random.normal(size=op.shape[1])
-
-                self.assertAllClose(A @ x, op @ x)
-                self.assertAllClose(
-                    A @ x[:, None],
-                    op @ x[:, None],
-                    msg="Matrix-vector multiplication with (n,1) vector failed.",
-                )
-
-
-class LinearOperatorFunctionsTestCase(LinearOperatorTestCase):
-    """Test functions of linear operators."""
-
-    def test_transpose_dense(self):
-        """Test whether a transposed linear operators dense representation is equal to
-        its dense representation transposed."""
-        for op in self.ops:
-            with self.subTest():
-                A = op.todense()
-                Atrans = op.T.todense()
-                self.assertAllClose(Atrans, A.T)
-
-    def test_inv_dense(self):
-        """Test whether the inverse in its dense representation matches the inverse of
-        the dense representation."""
-        for op in self.ops:
-            with self.subTest():
-                try:
-                    A = op.todense()
-                    Ainvop = op.inv()
-                    self.assertAllClose(Ainvop.todense(), np.linalg.inv(A))
-                except (NotImplementedError, AttributeError):
-                    pass
-
-    def test_cond_dense(self):
-        """Test whether the condition number of the linear operator matches the
-        condition number of the dense representation."""
-        for A in self.ops:
-            with self.subTest():
-                try:
-                    self.assertApproxEqual(
-                        A.cond(), np.linalg.cond(A.todense()), significant=7
-                    )
-                except NotImplementedError:
-                    pass
-
-    def test_det_dense(self):
-        """Test whether the determinant of the linear operator matches the determinant
-        of the dense representation."""
-        for A in self.ops:
-            with self.subTest():
-                try:
-                    self.assertApproxEqual(
-                        A.det(), np.linalg.det(A.todense()), significant=7
-                    )
-                except NotImplementedError:
-                    pass
-
-    def test_logabsdet_dense(self):
-        """Test whether the log-determinant of the linear operator matches the
-        log- determinant of the dense representation."""
-        for A in self.ops:
-            with self.subTest():
-                try:
-                    self.assertApproxEqual(
-                        A.logabsdet(), np.linalg.slogdet(A.todense())[1], significant=7
-                    )
-                except NotImplementedError:
-                    pass
-
-    def test_trace_only_square(self):
-        """Test that the trace can only be computed for square matrices."""
-        nonsquare_op = linops.MatrixMult(np.array([[-1.5, 3, 1], [0, -230, 0]]))
-        with self.assertRaises(ValueError):
-            nonsquare_op.trace()
-
-    def test_trace_dense(self):
-        """Check whether the trace matches the trace of the dense representation."""
-        for A in self.ops:
-            with self.subTest():
-                self.assertApproxEqual(
-                    A.trace(), np.trace(A.todense()).item(), significant=7
-                )
-
-    def test_adjoint(self):
-        pass
-
-    def test_todense(self):
-        pass

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -187,14 +187,14 @@ def test_eigvals(linop: pn.linops.LinearOperator, matrix: np.ndarray):
 @pytest.mark.parametrize("p", [None, 2])
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
 def test_cond(linop: pn.linops.LinearOperator, matrix: np.ndarray, p: Union[None, int]):
-    linop_det = linop.cond(p=p)
-    matrix_det = np.linalg.cond(matrix, p=p)
+    linop_cond = linop.cond(p=p)
+    matrix_cond = np.linalg.cond(matrix, p=p)
 
-    assert isinstance(linop_det, np.number)
-    assert linop_det.shape == ()
-    assert linop_det.dtype == matrix_det.dtype
+    assert isinstance(linop_cond, np.number)
+    assert linop_cond.shape == ()
+    assert linop_cond.dtype == matrix_cond.dtype
 
-    np.testing.assert_allclose(linop_det, matrix_det)
+    np.testing.assert_allclose(linop_cond, matrix_cond)
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -170,7 +170,7 @@ def test_logabsdet(linop: pn.linops.LinearOperator, matrix: np.ndarray):
         np.testing.assert_allclose(linop_logabsdet, matrix_logabsdet)
     else:
         with pytest.raises(np.linalg.LinAlgError):
-            linop.det()
+            linop.logabsdet()
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -76,7 +76,7 @@ def test_rank(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     linop_rank = linop.rank()
     matrix_rank = np.linalg.matrix_rank(matrix)
 
-    assert isinstance(linop_rank, np.int_)
+    assert isinstance(linop_rank, np.intp)
     assert linop_rank.shape == ()
     assert linop_rank.dtype == matrix_rank.dtype
 

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -61,6 +61,35 @@ def test_matvec(
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_rmatvec(
+    linop: pn.linops.LinearOperator,
+    matrix: np.ndarray,
+    random_state: np.random.RandomState,
+):
+    vec = random_state.normal(size=linop.shape[0])
+
+    # Shape (n,)
+    linop_matvec = vec @ linop
+    matrix_matvec = vec @ matrix
+
+    assert linop_matvec.ndim == 1
+    assert linop_matvec.shape == matrix_matvec.shape
+    assert linop_matvec.dtype == matrix_matvec.dtype
+
+    np.testing.assert_allclose(linop_matvec, matrix_matvec)
+
+    # Shape (1, n)
+    linop_matvec_n1 = vec[None, :] @ linop
+    matrix_matvec_n1 = vec[None, :] @ matrix
+
+    assert linop_matvec_n1.ndim == 2
+    assert linop_matvec_n1.shape == matrix_matvec_n1.shape
+    assert linop_matvec_n1.dtype == matrix_matvec_n1.dtype
+
+    np.testing.assert_allclose(linop_matvec_n1, matrix_matvec_n1)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
 def test_todense(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     linop_dense = linop.todense()
 

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -1,0 +1,192 @@
+import pathlib
+from typing import Union
+
+import numpy as np
+import pytest
+import pytest_cases
+
+import probnum as pn
+
+case_modules = [
+    ".test_linops_cases." + path.stem
+    for path in (pathlib.Path(__file__).parent / "test_linops_cases").glob("*_cases.py")
+]
+
+
+@pytest.fixture(
+    scope="function",
+    params=[pytest.param(seed, id=f"seed{seed}") for seed in [1, 42, 256]],
+)
+def random_state(request) -> np.random.RandomState:
+    return np.random.RandomState(seed=request.param)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_case_valid(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    assert isinstance(linop, pn.linops.LinearOperator)
+    assert isinstance(matrix, np.ndarray)
+
+    assert linop.ndim == matrix.ndim == 2
+    assert linop.shape == matrix.shape
+    assert linop.dtype == matrix.dtype
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_matvec(
+    linop: pn.linops.LinearOperator,
+    matrix: np.ndarray,
+    random_state: np.random.RandomState,
+):
+    vec = random_state.normal(size=linop.shape[1])
+
+    # Shape (n,)
+    linop_matvec = linop @ vec
+    matrix_matvec = matrix @ vec
+
+    assert linop_matvec.ndim == 1
+    assert linop_matvec.shape == matrix_matvec.shape
+    assert linop_matvec.dtype == matrix_matvec.dtype
+
+    np.testing.assert_allclose(linop_matvec, matrix_matvec)
+
+    # Shape (n, 1)
+    linop_matvec_n1 = linop @ vec[:, None]
+    matrix_matvec_n1 = matrix @ vec[:, None]
+
+    assert linop_matvec_n1.ndim == 2
+    assert linop_matvec_n1.shape == matrix_matvec_n1.shape
+    assert linop_matvec_n1.dtype == matrix_matvec_n1.dtype
+
+    np.testing.assert_allclose(linop_matvec_n1, matrix_matvec_n1)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_todense(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    linop_dense = linop.todense()
+
+    assert isinstance(linop_dense, np.ndarray)
+    assert linop_dense.shape == matrix.shape
+    assert linop_dense.dtype == matrix.dtype
+
+    np.testing.assert_allclose(linop_dense, matrix)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_rank(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    linop_rank = linop.rank()
+    matrix_rank = np.linalg.matrix_rank(matrix)
+
+    assert isinstance(linop_rank, np.int_)
+    assert linop_rank.shape == ()
+    assert linop_rank.dtype == matrix_rank.dtype
+
+    assert linop_rank == matrix_rank
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_eigvals(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    if linop.is_square:
+        linop_eigvals = linop.eigvals()
+        matrix_eigvals = np.linalg.eigvals(matrix)
+
+        assert isinstance(linop_eigvals, np.ndarray)
+        assert linop_eigvals.shape == matrix_eigvals.shape
+        assert linop_eigvals.dtype == matrix_eigvals.dtype
+
+        np.testing.assert_allclose(linop_eigvals, matrix_eigvals)
+    else:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.eigvals()
+
+
+@pytest.mark.parametrize("p", [None, 2])
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_cond(linop: pn.linops.LinearOperator, matrix: np.ndarray, p: Union[None, int]):
+    linop_det = linop.cond(p=p)
+    matrix_det = np.linalg.cond(matrix, p=p)
+
+    assert isinstance(linop_det, np.number)
+    assert linop_det.shape == ()
+    assert linop_det.dtype == matrix_det.dtype
+
+    np.testing.assert_allclose(linop_det, matrix_det)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_det(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    if linop.is_square:
+        linop_det = linop.det()
+        matrix_det = np.linalg.det(matrix)
+
+        assert isinstance(linop_det, np.number)
+        assert linop_det.shape == ()
+        assert linop_det.dtype == matrix_det.dtype
+
+        np.testing.assert_allclose(linop_det, matrix_det)
+    else:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.det()
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_logabsdet(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    if linop.is_square:
+        linop_logabsdet = linop.logabsdet()
+        _, matrix_logabsdet = np.linalg.slogdet(matrix)
+
+        assert isinstance(linop_logabsdet, np.inexact)
+        assert linop_logabsdet.shape == ()
+        assert linop_logabsdet.dtype == matrix_logabsdet.dtype
+
+        np.testing.assert_allclose(linop_logabsdet, matrix_logabsdet)
+    else:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.det()
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_trace(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    if linop.is_square:
+        linop_trace = linop.trace()
+        matrix_trace = np.trace(matrix)
+
+        assert isinstance(linop_trace, np.number)
+        assert linop_trace.shape == ()
+        assert linop_trace.dtype == matrix_trace.dtype
+
+        np.testing.assert_allclose(linop_trace, matrix_trace)
+    else:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.trace()
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_transpose(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    linop_transpose = linop.T
+    matrix_transpose = matrix.T
+
+    assert isinstance(linop_transpose, pn.linops.LinearOperator)
+    assert linop_transpose.shape == matrix_transpose.shape
+    assert linop_transpose.dtype == matrix_transpose.dtype
+
+    np.testing.assert_allclose(linop_transpose.todense(), matrix_transpose)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_inv(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    if linop.is_square:
+        try:
+            linop_inv = linop.inv()
+        except np.linalg.LinAlgError:
+            return
+
+        matrix_inv = np.linalg.inv(matrix)
+
+        assert isinstance(linop_inv, pn.linops.LinearOperator)
+        assert linop_inv.shape == matrix_inv.shape
+        assert linop_inv.dtype == matrix_inv.dtype
+
+        np.testing.assert_allclose(linop_inv.todense(), matrix_inv, atol=1e-12)
+    else:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.inv()

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -1,0 +1,51 @@
+from typing import Tuple
+
+import numpy as np
+import pytest
+import pytest_cases
+
+import probnum as pn
+
+
+@pytest.mark.parametrize(
+    "A,B",
+    [
+        (np.array([[2, -3.5], [12, 6.5]]), np.eye(3)),
+        (np.array([[1, -2], [-2.2, 5]]), np.array([[1, -3], [0, -0.5]])),
+        (np.array([[4, 1, 4], [2, 3, 2]]), np.array([[-1, 4], [2, 1]])),
+        (np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9]]), np.array([[1, 4]])),
+        (np.array([[4, 1], [2, 3]]), np.array([[-1, 4], [2, 1]])),
+        (
+            np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9], [1, 0, 2]]),
+            np.array([[1, 4, 0], [-3, -0.4, -100], [0.18, -2, 10]]),
+        ),
+    ],
+)
+def case_kronecker(
+    A: np.ndarray, B: np.ndarray
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.Kronecker(A, B)
+    matrix = np.kron(A, B)
+
+    return linop, matrix
+
+
+@pytest.mark.parametrize(
+    "A,B",
+    [
+        (np.array([[1, -2], [-2.2, 5]]), np.array([[1, -3], [0, -0.5]])),
+        (np.array([[4, 1], [2, 3]]), np.array([[-1, 4], [2, 1]])),
+        (
+            np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9], [1, 0, 2]]),
+            np.array([[1, 4, 0], [-3, -0.4, -100], [0.18, -2, 10]]),
+        ),
+    ],
+)
+@pytest_cases.case(tags=["symmetric_kronecker"])
+def case_symmetric_kronecker(
+    A: np.ndarray, B: np.ndarray
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.SymmetricKronecker(A, B)
+    matrix = (np.kron(A, B) + np.kron(B, A)) / 2
+
+    return linop, matrix

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -19,6 +19,10 @@ import probnum as pn
             np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9], [1, 0, 2]]),
             np.array([[1, 4, 0], [-3, -0.4, -100], [0.18, -2, 10]]),
         ),
+        (
+            np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9], [1, 0, 2]]),
+            np.array([[1, 4, 0], [-3, -0.4, -100]]),
+        ),
     ],
 )
 def case_kronecker(
@@ -47,5 +51,26 @@ def case_symmetric_kronecker(
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     linop = pn.linops.SymmetricKronecker(A, B)
     matrix = (np.kron(A, B) + np.kron(B, A)) / 2
+
+    return linop, matrix
+
+
+@pytest.mark.parametrize(
+    "A",
+    [
+        np.array([[1, -2], [-2.2, 5]]),
+        np.array([[1, -3], [0, -0.5]]),
+        np.array([[4, 1], [2, 3]]),
+        np.array([[-1, 4], [2, 1]]),
+        np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9], [1, 0, 2]]),
+        np.array([[1, 4, 0], [-3, -0.4, -100], [0.18, -2, 10]]),
+    ],
+)
+@pytest_cases.case(tags=["symmetric_kronecker"])
+def case_symmetric_kronecker_identical_factors(
+    A: np.ndarray,
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.SymmetricKronecker(A)
+    matrix = np.kron(A, A)
 
     return linop, matrix

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -1,0 +1,27 @@
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+import probnum as pn
+
+matrices = [np.array([[-1.5, 3], [0, -230]]), np.array([[2, 0], [1, 3]])]
+
+
+@pytest.mark.parametrize("matrix", matrices)
+def case_matvec(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.LinearOperator(
+        shape=matrix.shape, dtype=matrix.dtype, matvec=lambda x: matrix @ x
+    )
+
+    return linop, matrix
+
+
+@pytest.mark.parametrize("matrix", matrices)
+def case_matrix(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    return pn.linops.MatrixMult(matrix), matrix
+
+
+@pytest.mark.parametrize("n", [3, 4, 8, 12, 15])
+def case_identity(n: int) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    return pn.linops.Identity(shape=n), np.eye(n)

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -5,7 +5,11 @@ import pytest
 
 import probnum as pn
 
-matrices = [np.array([[-1.5, 3], [0, -230]]), np.array([[2, 0], [1, 3]])]
+matrices = [
+    np.array([[-1.5, 3], [0, -230]]),
+    np.array([[2, 0], [1, 3]]),
+    np.array([[2, 0, -1.5], [1, 3, -230]]),
+]
 
 
 @pytest.mark.parametrize("matrix", matrices)


### PR DESCRIPTION
This PR refactors the current tests (excluding arithmetic tests) for linear operators to use pytest and pytest-cases.
It also makes existing tests stricter and adds new tests.