### PR TITLE
Stabilise matrix inversion in discrete transitions

### DIFF
--- a/src/probnum/statespace/discrete_transition.py
+++ b/src/probnum/statespace/discrete_transition.py
@@ -333,7 +333,7 @@ class DiscreteLinearGaussian(DiscreteGaussian):
         new_cov = H @ crosscov + _diffusion * R
         info = {"crosscov": crosscov}
         if compute_gain:
-            gain = crosscov @ np.linalg.inv(new_cov)
+            gain = scipy.linalg.solve(new_cov.T, crosscov.T, assume_a="sym").T
             info["gain"] = gain
         return randvars.Normal(new_mean, cov=new_cov), info
 
@@ -353,8 +353,9 @@ class DiscreteLinearGaussian(DiscreteGaussian):
         crosscov = rv.cov @ H.T
         info = {"crosscov": crosscov}
         if compute_gain:
-            gain = crosscov @ np.linalg.inv(new_cov)
-            info["gain"] = gain
+            info["gain"] = scipy.linalg.cho_solve(
+                (new_cov_cholesky, True), crosscov.T
+            ).T
         return (
             randvars.Normal(new_mean, cov=new_cov, cov_cholesky=new_cov_cholesky),
             info,
@@ -418,9 +419,9 @@ class DiscreteLinearGaussian(DiscreteGaussian):
         # no initial gain was provided.
         # Recall that above, gain was set to zero in this setting.
         if np.linalg.norm(gain) == 0.0:
-            gain = big_triu[:output_dim, output_dim:].T @ np.linalg.inv(
-                big_triu[:output_dim, :output_dim].T
-            )
+            R1 = big_triu[:output_dim, :output_dim]
+            R12 = big_triu[:output_dim, output_dim:]
+            gain = scipy.linalg.solve_triangular(R1, R12, lower=False).T
 
         new_mean = rv.mean + gain @ (rv_obtained.mean - state_trans @ rv.mean - shift)
         new_cov_cholesky = tril_to_positive_tril(new_chol_triu.T)

--- a/src/probnum/statespace/discrete_transition.py
+++ b/src/probnum/statespace/discrete_transition.py
@@ -3,6 +3,7 @@ import typing
 from typing import Callable, Optional
 
 import numpy as np
+import scipy.linalg
 
 from probnum import randvars
 from probnum.type import FloatArgType, IntArgType


### PR DESCRIPTION
This PR replaces all `inv` and `solve` by more appropriate replacements. This has a surprisingly big impact on the square-root transitions in terms of stability and dealing with really ill-conditioned matrices. 

(This impact I noticed when working with the code, there is no proof I can show here :)) 