### PR TITLE
Implement filtsmooth methods as generators

### DIFF
--- a/benchmarks/filtsmooth.py
+++ b/benchmarks/filtsmooth.py
@@ -84,7 +84,7 @@ class Smoothing:
             measurement_model=linearized_measmod,
             initrv=statespace_components["initrv"],
         )
-        self.filtering_posterior = self.kalman_filter.filter(regression_problem)
+        self.filtering_posterior, _ = self.kalman_filter.filter(regression_problem)
 
     def time_smooth(self, linearization_implementation):
         self.kalman_filter.smooth(filter_posterior=self.filtering_posterior)
@@ -143,7 +143,7 @@ class DenseGridOperations:
             measurement_model=linearized_measmod,
             initrv=statespace_components["initrv"],
         )
-        self.filtering_posterior = self.kalman_filter.filter(regression_problem)
+        self.filtering_posterior, _ = self.kalman_filter.filter(regression_problem)
         self.smoothing_posterior = self.kalman_filter.smooth(
             filter_posterior=self.filtering_posterior
         )

--- a/docs/source/tutorials/filtsmooth/linear_gaussian_filtering_smoothing.ipynb
+++ b/docs/source/tutorials/filtsmooth/linear_gaussian_filtering_smoothing.ipynb
@@ -301,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "state_posterior = kalman_filter.filtsmooth(regression_problem)"
+    "state_posterior, _ = kalman_filter.filtsmooth(regression_problem)"
    ]
   },
   {
@@ -2618,7 +2618,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "state_posterior = kalman_filter.filtsmooth(regression_problem)"
+    "state_posterior, _ = kalman_filter.filtsmooth(regression_problem)"
    ]
   },
   {

--- a/docs/source/tutorials/filtsmooth/nonlinear_gaussian_filtering_smoothing.ipynb
+++ b/docs/source/tutorials/filtsmooth/nonlinear_gaussian_filtering_smoothing.ipynb
@@ -389,7 +389,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "state_posterior = kalman_filter.filtsmooth(regression_problem)"
+    "state_posterior, _ = kalman_filter.filtsmooth(regression_problem)"
    ]
   },
   {
@@ -6436,7 +6436,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "state_posterior = kalman_filter.filter(regression_problem)"
+    "state_posterior, _ = kalman_filter.filter(regression_problem)"
    ]
   },
   {

--- a/docs/source/tutorials/filtsmooth/particle_filtering.ipynb
+++ b/docs/source/tutorials/filtsmooth/particle_filtering.ipynb
@@ -250,7 +250,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "posterior = pf.filter(regression_problem)"
+    "posterior, _ = pf.filter(regression_problem)"
    ]
   },
   {
@@ -2780,7 +2780,7 @@
     "    locations=locs,\n",
     ")\n",
     "\n",
-    "ode_posterior = ode_pf.filter(regression_problem)"
+    "ode_posterior, _ = ode_pf.filter(regression_problem)"
    ]
   },
   {

--- a/src/probnum/diffeq/odefiltsmooth/initialize.py
+++ b/src/probnum/diffeq/odefiltsmooth/initialize.py
@@ -132,7 +132,7 @@ def initialize_odefilter_with_rk(
     kalman = filtsmooth.Kalman(prior, measmod, initrv)
 
     regression_problem = problems.RegressionProblem(observations=ys, locations=ts)
-    out = kalman.filtsmooth(regression_problem)
+    out, _ = kalman.filtsmooth(regression_problem)
 
     estimated_initrv = out.states[0]
 

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -225,6 +225,8 @@ class Kalman(BayesFiltSmooth):
         ------
         filtrv
             Random variable returned from prediction and update of the Kalman filter.
+        info_dict
+            Dictionary containing filtering information
 
         See Also
         --------

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -70,9 +70,6 @@ class Kalman(BayesFiltSmooth):
         ):
             pass
 
-        if smoothing_post is None or info_dicts is None:
-            raise ValueError("Iterated filter did not perform a single iteration.")
-
         return smoothing_post, info_dicts
 
     def iterated_filtsmooth_posterior_generator(

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -58,12 +58,11 @@ class Kalman(BayesFiltSmooth):
         RegressionProblem: a regression problem data class
         """
 
-        result = None
         for iter_result in self.iterated_filtsmooth_generator(
             regression_problem, stopcrit
         ):
-            result = iter_result
-        return result
+            pass
+        return iter_result  # pylint: disable=undefined-loop-variable
 
     def iterated_filtsmooth_generator(
         self,

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -48,9 +48,8 @@ class Kalman(BayesFiltSmooth):
         ----------
         regression_problem
         init_posterior
-            Initial posterior to linearize at. Defaults to computing a (non-iterated)
-            smoothing posterior, which amounts to linearizing at the prediction
-            random variable.
+            Initial posterior to linearize at. If not specified, linearizes
+            at the prediction random variable.
         stopcrit: StoppingCriterion
             A stopping criterion for iterated filtering.
 

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -107,15 +107,16 @@ class Kalman(BayesFiltSmooth):
         if stopcrit is None:
             stopcrit = StoppingCriterion()
 
-        info_dicts = []
         if init_posterior is None:
             # Initialise iterated smoother
-            init_posterior, info_dicts = self.filtsmooth(
+            new_posterior, info_dicts = self.filtsmooth(
                 regression_problem,
                 _previous_posterior=None,
             )
+        else:
+            new_posterior = init_posterior
+            info_dicts = []
 
-        new_posterior = init_posterior
         yield new_posterior, info_dicts
         new_mean = new_posterior.states.mean
         old_mean = np.inf * np.ones(new_mean.shape)

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -116,6 +116,7 @@ class Kalman(BayesFiltSmooth):
     def filtsmooth(
         self,
         regression_problem: problems.RegressionProblem,
+        return_info_dicts: bool = False,
         _previous_posterior: Optional[TimeSeriesPosterior] = None,
     ):
         """Apply Gaussian filtering and smoothing to a data set.
@@ -123,6 +124,8 @@ class Kalman(BayesFiltSmooth):
         Parameters
         ----------
         regression_problem
+        return_info_dicts
+            If True, returns information collected during filtering. Defaults to False.
         _previous_posterior: KalmanPosterior
             If specified, approximate Gaussian filtering and smoothing linearises at this, prescribed posterior.
             This is used for iterated filtering and smoothing. For standard filtering, this can be ignored.
@@ -131,16 +134,25 @@ class Kalman(BayesFiltSmooth):
         -------
         KalmanPosterior
             Posterior distribution of the filtered output
+        info_dicts
+            Only if ``returns_info_dicts`` is ``True``: list of dictionaries containing
+            filtering information
 
         See Also
         --------
         RegressionProblem: a regression problem data class
         """
-        filter_posterior = self.filter(
-            regression_problem, _previous_posterior=_previous_posterior
+        filter_result = self.filter(
+            regression_problem,
+            return_info_dicts=return_info_dicts,
+            _previous_posterior=_previous_posterior,
         )
-        smooth_posterior = self.smooth(filter_posterior)
-        return smooth_posterior
+        if return_info_dicts:
+            filter_posterior, info_dicts = filter_result
+            smooth_posterior = self.smooth(filter_posterior)
+            return smooth_posterior, info_dicts
+
+        return self.smooth(filter_result)
 
     def filter(
         self,

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -230,7 +230,9 @@ class Kalman(BayesFiltSmooth):
         _linearise_update_at = (
             None if _previous_posterior is None else _previous_posterior(times[0])
         )
-        filtrv, info_dict = self.update(
+
+        info_dict = {"pred_rv": self.initrv, "info_pred": {}}
+        filtrv, info_dict["info_upd"] = self.update(
             data=dataset[0],
             rv=self.initrv,
             time=times[0],

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -181,7 +181,7 @@ class Kalman(BayesFiltSmooth):
             This is used for iterated filtering and smoothing. For standard filtering, this can be ignored.
 
         Returns
-        ------
+        -------
         KalmanPosterior
             Posterior distribution of the filtered output
         info_dicts

--- a/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
+++ b/src/probnum/filtsmooth/gaussfiltsmooth/kalman.py
@@ -65,7 +65,7 @@ class Kalman(BayesFiltSmooth):
 
         smoothing_post = init_posterior
         info_dicts = None
-        for smoothing_post, info_dicts in self.iterated_filtsmooth_generator(
+        for smoothing_post, info_dicts in self.iterated_filtsmooth_posterior_generator(
             regression_problem, smoothing_post, stopcrit
         ):
             pass
@@ -75,7 +75,7 @@ class Kalman(BayesFiltSmooth):
 
         return smoothing_post, info_dicts
 
-    def iterated_filtsmooth_generator(
+    def iterated_filtsmooth_posterior_generator(
         self,
         regression_problem: problems.RegressionProblem,
         init_posterior: Optional[SmoothingPosterior] = None,
@@ -195,7 +195,9 @@ class Kalman(BayesFiltSmooth):
         filtered_rvs = []
         info_dicts = []
 
-        for rv, info in self.filter_generator(regression_problem, _previous_posterior):
+        for rv, info in self.filtered_states_generator(
+            regression_problem, _previous_posterior
+        ):
             filtered_rvs.append(rv)
             info_dicts.append(info)
 
@@ -207,7 +209,7 @@ class Kalman(BayesFiltSmooth):
 
         return posterior, info_dicts
 
-    def filter_generator(
+    def filtered_states_generator(
         self,
         regression_problem: problems.RegressionProblem,
         _previous_posterior: Optional[TimeSeriesPosterior] = None,

--- a/tests/test_diffeq/test_odefiltsmooth/test_kalman_odesolution.py
+++ b/tests/test_diffeq/test_odefiltsmooth/test_kalman_odesolution.py
@@ -169,7 +169,7 @@ def test_sampling_shapes_1d(locs, size):
     regression_problem = problems.RegressionProblem(
         observations=data, locations=locations
     )
-    posterior = kalman.filtsmooth(regression_problem)
+    posterior, _ = kalman.filtsmooth(regression_problem)
 
     size = utils.as_shape(size)
     if locs is None:

--- a/tests/test_filtsmooth/filtsmooth_testcases.py
+++ b/tests/test_filtsmooth/filtsmooth_testcases.py
@@ -87,7 +87,7 @@ class LinearisedDiscreteTransitionTestCase(unittest.TestCase, NumpyAssertions):
         method = filtsmooth.Kalman(ekf_dyna, ekf_meas, statespace_components["initrv"])
 
         # Compute filter/smoother solution
-        posterior = method.filtsmooth(regression_problem)
+        posterior, _ = method.filtsmooth(regression_problem)
         filtms = posterior.filtering_posterior.states.mean
         smooms = posterior.states.mean
 

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_iterated_kalman.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_iterated_kalman.py
@@ -28,10 +28,10 @@ def test_rmse_filt_smooth(setup):
 
     stopcrit = filtsmooth.StoppingCriterion(atol=1e-1, rtol=1e-1, maxit=10)
 
-    posterior = kalman.filter(regression_problem)
+    posterior, _ = kalman.filter(regression_problem)
     posterior = kalman.smooth(posterior)
 
-    iterated_posterior = kalman.iterated_filtsmooth(
+    iterated_posterior, _ = kalman.iterated_filtsmooth(
         regression_problem, stopcrit=stopcrit
     )
 

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
@@ -41,7 +41,7 @@ def test_rmse_filt_smooth(setup):
 
 
 def test_info_dict(setup):
-    """TODO."""
+    """Assert that the info dicts are returned correctly if specified."""
 
     np.random.seed(12345)
     kalman, regression_problem = setup

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
@@ -38,3 +38,15 @@ def test_rmse_filt_smooth(setup):
     obs_rmse = np.mean(np.abs(regression_problem.observations - truth[:, :2]))
 
     assert smooms_rmse < filtms_rmse < obs_rmse
+
+
+def test_info_dicts(setup):
+    """Assert that smoothing beats filtering beats nothing."""
+
+    np.random.seed(12345)
+    kalman, regression_problem = setup
+
+    posterior, info_dicts = kalman.filtsmooth(regression_problem)
+
+    assert isinstance(info_dicts, list)
+    assert len(posterior) == len(info_dicts)

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
@@ -28,7 +28,7 @@ def test_rmse_filt_smooth(setup):
     kalman, regression_problem = setup
     truth = regression_problem.solution
 
-    posterior = kalman.filtsmooth(regression_problem)
+    posterior, _ = kalman.filtsmooth(regression_problem)
 
     filtms = posterior.filtering_posterior.states.mean
     smooms = posterior.states.mean
@@ -38,16 +38,3 @@ def test_rmse_filt_smooth(setup):
     obs_rmse = np.mean(np.abs(regression_problem.observations - truth[:, :2]))
 
     assert smooms_rmse < filtms_rmse < obs_rmse
-
-
-def test_info_dict(setup):
-    """Assert that the info dicts are returned correctly if specified."""
-
-    np.random.seed(12345)
-    kalman, regression_problem = setup
-
-    posterior, info_dicts = kalman.filtsmooth(
-        regression_problem, return_info_dicts=True
-    )
-
-    assert len(posterior) == len(info_dicts)

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalman.py
@@ -38,3 +38,16 @@ def test_rmse_filt_smooth(setup):
     obs_rmse = np.mean(np.abs(regression_problem.observations - truth[:, :2]))
 
     assert smooms_rmse < filtms_rmse < obs_rmse
+
+
+def test_info_dict(setup):
+    """TODO."""
+
+    np.random.seed(12345)
+    kalman, regression_problem = setup
+
+    posterior, info_dicts = kalman.filtsmooth(
+        regression_problem, return_info_dicts=True
+    )
+
+    assert len(posterior) == len(info_dicts)

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalmanposterior.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalmanposterior.py
@@ -29,7 +29,8 @@ def setup(problem):
 def posterior(setup):
     """Kalman smoothing posterior."""
     kalman, regression_problem = setup
-    return kalman.filtsmooth(regression_problem)
+    posterior, _ = kalman.filtsmooth(regression_problem)
+    return posterior
 
 
 def test_len(posterior):
@@ -159,7 +160,7 @@ def test_sampling_shapes_1d(locs, size):
     regression_problem = problems.RegressionProblem(
         observations=data, locations=locations
     )
-    posterior = kalman.filtsmooth(regression_problem)
+    posterior, _ = kalman.filtsmooth(regression_problem)
 
     size = utils.as_shape(size)
     if locs is None:

--- a/tests/test_filtsmooth/test_particlefiltsmooth/test_particle_filter.py
+++ b/tests/test_filtsmooth/test_particlefiltsmooth/test_particle_filter.py
@@ -77,7 +77,8 @@ def test_random_state(particle_filter):
 
 @pytest.fixture
 def pf_output(particle_filter, regression_problem):
-    return particle_filter.filter(regression_problem)
+    posterior, _ = particle_filter.filter(regression_problem)
+    return posterior
 
 
 @all_importance_distributions


### PR DESCRIPTION
This PR implements Kalman filtering methods as generators in order to make partial results accessible.