### PR TITLE
Return forwarded RV

### DIFF
--- a/src/probnum/statespace/discrete_transition.py
+++ b/src/probnum/statespace/discrete_transition.py
@@ -155,7 +155,7 @@ class DiscreteGaussian(trans.Transition):
             )
             gain = info_forwarded["gain"]
         info = {"rv_forwarded": rv_forwarded}
-        return condition_state_on_rv(rv_forwarded, rv_forwarded, rv, gain), info
+        return condition_state_on_rv(rv_obtained, rv_forwarded, rv, gain), info
 
     @lru_cache(maxsize=None)
     def proc_noise_cov_cholesky_fun(self, t):

--- a/src/probnum/statespace/integrator.py
+++ b/src/probnum/statespace/integrator.py
@@ -292,9 +292,6 @@ class IBM(Integrator, sde.LTISDE):
             t=t,
             _diffusion=_diffusion,
         )
-        # assert info is empty. Otherwise, we need to change
-        # things in info in which case we want to be warned.
-        assert not info
 
         return _apply_precon(self.precon(dt), rv), info
 
@@ -460,10 +457,6 @@ class IOUP(Integrator, sde.LTISDE):
             _diffusion=_diffusion,
         )
 
-        # assert info is empty. Otherwise, we need to change
-        # things in info in which case we want to be warned.
-        assert not info
-
         # Undo preconditioning and return
         rv = _apply_precon(self.precon(dt), rv)
         self.driftmat = self.precon(dt) @ self.driftmat @ self.precon.inverse(dt)
@@ -602,10 +595,6 @@ class Matern(Integrator, sde.LTISDE):
             t=t,
             _diffusion=_diffusion,
         )
-
-        # assert info is empty. Otherwise, we need to change
-        # things in info in which case we want to be warned.
-        assert not info
 
         # Undo preconditioning and return
         rv = _apply_precon(self.precon(dt), rv)

--- a/tests/test_statespace/test_integrator.py
+++ b/tests/test_statespace/test_integrator.py
@@ -199,10 +199,6 @@ def test_same_backward_outputs(both_transitions, diffusion):
     np.testing.assert_allclose(out_1.mean, out_2.mean)
     np.testing.assert_allclose(out_1.cov, out_2.cov)
 
-    # Both dicts are empty?
-    assert not info1
-    assert not info2
-
 
 @pytest.fixture
 def dt():


### PR DESCRIPTION
Where applicable, let `Transition`s return forwarded random variables in the `.backward()` call. Might be useful e.g. for computing marginal likelihoods during filtering/smoothing.