### PR TITLE
Build FilteringPosterior on the fly

### DIFF
--- a/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
+++ b/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
@@ -347,9 +347,9 @@ class GaussianIVPFilter(ODESolver):
         """Create an ODESolution object."""
 
         kalman_posterior = filtsmooth.FilteringPosterior(
-            times,
-            rvs,
-            self.prior_process.transition,
+            transition=self.prior_process.transition,
+            locations=times,
+            states=rvs,
             diffusion_model=self.diffusion_model,
         )
 

--- a/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
+++ b/src/probnum/diffeq/odefiltsmooth/ivpfiltsmooth.py
@@ -360,23 +360,27 @@ class GaussianIVPFilter(ODESolver):
         locations = odesol.kalman_posterior.locations
         rv_list = odesol.kalman_posterior.states
 
-        if self._calibrate_all_states_post_hoc:
-            # Constant diffusion model is the only way to go here.
-            s = self.diffusion_model.diffusion
+        kalman_posterior = filtsmooth.FilteringPosterior(
+            transition=self.prior_process.transition,
+            diffusion_model=self.diffusion_model,
+        )
 
-            for idx, (t, rv) in enumerate(zip(locations, rv_list)):
-                rv_list[idx] = randvars.Normal(
+        # Constant diffusion model is the only way to go here.
+        s = (
+            self.diffusion_model.diffusion
+            if self._calibrate_all_states_post_hoc
+            else 1.0
+        )
+
+        for idx, (t, rv) in enumerate(zip(locations, rv_list)):
+            kalman_posterior.append(
+                location=t,
+                state=randvars.Normal(
                     mean=rv.mean,
                     cov=s * rv.cov,
                     cov_cholesky=np.sqrt(s) * rv.cov_cholesky,
-                )
-
-        kalman_posterior = filtsmooth.FilteringPosterior(
-            locations,
-            rv_list,
-            self.prior_process.transition,
-            diffusion_model=self.diffusion_model,
-        )
+                ),
+            )
 
         if self.with_smoothing is True:
 
@@ -385,10 +389,10 @@ class GaussianIVPFilter(ODESolver):
                 rv_list, locations, _diffusion_list=squared_diffusion_list
             )
             kalman_posterior = filtsmooth.SmoothingPosterior(
-                locations,
-                rv_list,
-                self.prior_process.transition,
                 filtering_posterior=kalman_posterior,
+                transition=self.prior_process.transition,
+                locations=locations,
+                states=rv_list,
                 diffusion_model=self.diffusion_model,
             )
 

--- a/src/probnum/filtsmooth/_gaussfiltsmooth/_kalman.py
+++ b/src/probnum/filtsmooth/_gaussfiltsmooth/_kalman.py
@@ -198,7 +198,7 @@ class Kalman(BayesFiltSmooth):
         TimeSeriesRegressionProblem: a regression problem data class
         """
 
-        posterior = FilteringPosterior(transition=self.dynamics_model)
+        posterior = FilteringPosterior(transition=self.prior_process.transition)
         info_dicts = []
 
         for t, rv, info in self.filtered_states_generator(
@@ -270,7 +270,7 @@ class Kalman(BayesFiltSmooth):
                 realization_obtained=data, rv=curr_rv, _linearise_at=linearise_update_at
             )
 
-            yield curr_rv, info_dict
+            yield t, curr_rv, info_dict
             t_old = t
 
     def smooth(self, filter_posterior, _previous_posterior=None):
@@ -295,7 +295,7 @@ class Kalman(BayesFiltSmooth):
 
         return SmoothingPosterior(
             filtering_posterior=filter_posterior,
-            transition=self.dynamics_model,
+            transition=self.prior_process.transition,
             locations=filter_posterior.locations,
             states=rv_list,
         )

--- a/src/probnum/filtsmooth/_gaussfiltsmooth/_kalman.py
+++ b/src/probnum/filtsmooth/_gaussfiltsmooth/_kalman.py
@@ -201,10 +201,10 @@ class Kalman(BayesFiltSmooth):
         posterior = FilteringPosterior(transition=self.dynamics_model)
         info_dicts = []
 
-        for idx, (rv, info) in enumerate(
-            self.filtered_states_generator(regression_problem, _previous_posterior)
+        for t, rv, info in self.filtered_states_generator(
+            regression_problem, _previous_posterior
         ):
-            posterior.append(location=regression_problem.locations[idx], state=rv)
+            posterior.append(location=t, state=rv)
             info_dicts.append(info)
 
         return posterior, info_dicts

--- a/src/probnum/filtsmooth/_gaussfiltsmooth/_kalman.py
+++ b/src/probnum/filtsmooth/_gaussfiltsmooth/_kalman.py
@@ -198,20 +198,14 @@ class Kalman(BayesFiltSmooth):
         TimeSeriesRegressionProblem: a regression problem data class
         """
 
-        filtered_rvs = []
+        posterior = FilteringPosterior(transition=self.dynamics_model)
         info_dicts = []
 
-        for rv, info in self.filtered_states_generator(
-            regression_problem, _previous_posterior
+        for idx, (rv, info) in enumerate(
+            self.filtered_states_generator(regression_problem, _previous_posterior)
         ):
-            filtered_rvs.append(rv)
+            posterior.append(location=regression_problem.locations[idx], state=rv)
             info_dicts.append(info)
-
-        posterior = FilteringPosterior(
-            locations=regression_problem.locations,
-            states=filtered_rvs,
-            transition=self.prior_process.transition,
-        )
 
         return posterior, info_dicts
 
@@ -300,9 +294,8 @@ class Kalman(BayesFiltSmooth):
         )
 
         return SmoothingPosterior(
-            filter_posterior.locations,
-            rv_list,
-            self.prior_process.transition,
             filtering_posterior=filter_posterior,
-            diffusion_model=filter_posterior.diffusion_model,
+            transition=self.dynamics_model,
+            locations=filter_posterior.locations,
+            states=rv_list,
         )

--- a/src/probnum/filtsmooth/_gaussfiltsmooth/_kalmanposterior.py
+++ b/src/probnum/filtsmooth/_gaussfiltsmooth/_kalmanposterior.py
@@ -4,7 +4,7 @@ Contains the discrete time and function outputs. Provides dense output
 by being callable. Can function values can also be accessed by indexing.
 """
 import abc
-from typing import Optional, Union
+from typing import Iterable, Optional, Union
 
 import numpy as np
 from scipy import stats
@@ -48,9 +48,9 @@ class KalmanPosterior(TimeSeriesPosterior, abc.ABC):
 
     def __init__(
         self,
-        locations: np.ndarray,
-        states: _randomvariablelist._RandomVariableList,
         transition: GaussMarkovPriorTransitionArgType,
+        locations: Optional[Iterable[FloatArgType]] = None,
+        states: Optional[Iterable[randvars.RandomVariable]] = None,
         diffusion_model=None,
     ) -> None:
 
@@ -158,14 +158,13 @@ class SmoothingPosterior(KalmanPosterior):
 
     def __init__(
         self,
-        locations: np.ndarray,
-        states: _randomvariablelist._RandomVariableList,
-        transition: GaussMarkovPriorTransitionArgType,
         filtering_posterior: TimeSeriesPosterior,
-        diffusion_model=None,
+        transition: GaussMarkovPriorTransitionArgType,
+        locations: Iterable[FloatArgType],
+        states: Iterable[randvars.RandomVariable],
     ):
         self.filtering_posterior = filtering_posterior
-        super().__init__(locations, states, transition, diffusion_model=diffusion_model)
+        super().__init__(transition=transition, locations=locations, states=states)
 
     def interpolate(
         self,

--- a/src/probnum/filtsmooth/_gaussfiltsmooth/_kalmanposterior.py
+++ b/src/probnum/filtsmooth/_gaussfiltsmooth/_kalmanposterior.py
@@ -9,7 +9,7 @@ from typing import Iterable, Optional, Union
 import numpy as np
 from scipy import stats
 
-from probnum import _randomvariablelist, randvars, statespace, utils
+from probnum import randvars, statespace, utils
 from probnum.typing import (
     DenseOutputLocationArgType,
     FloatArgType,

--- a/src/probnum/filtsmooth/_gaussfiltsmooth/_kalmanposterior.py
+++ b/src/probnum/filtsmooth/_gaussfiltsmooth/_kalmanposterior.py
@@ -162,9 +162,15 @@ class SmoothingPosterior(KalmanPosterior):
         transition: GaussMarkovPriorTransitionArgType,
         locations: Iterable[FloatArgType],
         states: Iterable[randvars.RandomVariable],
+        diffusion_model=None,
     ):
         self.filtering_posterior = filtering_posterior
-        super().__init__(transition=transition, locations=locations, states=states)
+        super().__init__(
+            transition=transition,
+            locations=locations,
+            states=states,
+            diffusion_model=diffusion_model,
+        )
 
     def interpolate(
         self,

--- a/src/probnum/filtsmooth/_timeseriesposterior.py
+++ b/src/probnum/filtsmooth/_timeseriesposterior.py
@@ -47,7 +47,6 @@ class TimeSeriesPosterior(abc.ABC):
         location: FloatArgType,
         state: randvars.RandomVariable,
     ) -> None:
-        # TODO: Type-checks here?
         self._locations.append(location)
         self._states.append(state)
 

--- a/src/probnum/filtsmooth/_timeseriesposterior.py
+++ b/src/probnum/filtsmooth/_timeseriesposterior.py
@@ -41,6 +41,7 @@ class TimeSeriesPosterior(abc.ABC):
     ) -> None:
         self._locations = list(locations) if locations is not None else []
         self._states = list(states) if states is not None else []
+        self._frozen = False
 
     def _check_location(self, location: FloatArgType) -> FloatArgType:
         if len(self._locations) > 0 and location <= self._locations[-1]:
@@ -55,8 +56,18 @@ class TimeSeriesPosterior(abc.ABC):
         state: randvars.RandomVariable,
     ) -> None:
 
+        if self.frozen:
+            raise ValueError("Cannot append to frozen TimeSeriesPosterior object.")
+
         self._locations.append(self._check_location(location))
         self._states.append(state)
+
+    def freeze(self) -> None:
+        self._frozen = True
+
+    @property
+    def frozen(self):
+        return self._frozen
 
     @property
     def locations(self):

--- a/src/probnum/filtsmooth/_timeseriesposterior.py
+++ b/src/probnum/filtsmooth/_timeseriesposterior.py
@@ -1,7 +1,7 @@
 """Abstract Base Class for posteriors over states after applying filtering/smoothing."""
 
 import abc
-from typing import Optional, Union
+from typing import Iterable, Optional, Union
 
 import numpy as np
 
@@ -34,9 +34,30 @@ class TimeSeriesPosterior(abc.ABC):
         Posterior random variables.
     """
 
-    def __init__(self, locations: np.ndarray, states: np.ndarray) -> None:
-        self.locations = np.asarray(locations)
-        self.states = _randomvariablelist._RandomVariableList(states)
+    def __init__(
+        self,
+        locations: Optional[Iterable[FloatArgType]] = None,
+        states: Optional[Iterable[randvars.RandomVariable]] = None,
+    ) -> None:
+        self._locations = list(locations) if locations is not None else []
+        self._states = list(states) if states is not None else []
+
+    def append(
+        self,
+        location: FloatArgType,
+        state: randvars.RandomVariable,
+    ) -> None:
+        # TODO: Type-checks here?
+        self._locations.append(location)
+        self._states.append(state)
+
+    @property
+    def locations(self):
+        return np.asarray(self._locations)
+
+    @property
+    def states(self):
+        return _randomvariablelist._RandomVariableList(self._states)
 
     def __len__(self) -> int:
         """Length of the discrete-time solution.

--- a/src/probnum/filtsmooth/_timeseriesposterior.py
+++ b/src/probnum/filtsmooth/_timeseriesposterior.py
@@ -42,12 +42,20 @@ class TimeSeriesPosterior(abc.ABC):
         self._locations = list(locations) if locations is not None else []
         self._states = list(states) if states is not None else []
 
+    def _check_location(self, location: FloatArgType) -> FloatArgType:
+        if len(self._locations) > 0 and location <= self._locations[-1]:
+            _err_msg = "Locations have to be strictly ascending. "
+            _err_msg += f"Received {location} <= {self._locations[-1]}."
+            raise ValueError(_err_msg)
+        return location
+
     def append(
         self,
         location: FloatArgType,
         state: randvars.RandomVariable,
     ) -> None:
-        self._locations.append(location)
+
+        self._locations.append(self._check_location(location))
         self._states.append(state)
 
     @property

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalmanposterior.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalmanposterior.py
@@ -48,8 +48,8 @@ def test_append(posterior):
     copied_posterior = filtsmooth.SmoothingPosterior(
         filtering_posterior=posterior.filtering_posterior,
         transition=posterior.transition,
-        locations=[l for l in posterior.locations],
-        states=[s for s in posterior.states],
+        locations=posterior.locations.copy(),
+        states=posterior.states.copy(),
         diffusion_model=posterior.diffusion_model,
     )
 

--- a/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalmanposterior.py
+++ b/tests/test_filtsmooth/test_gaussfiltsmooth/test_kalmanposterior.py
@@ -38,6 +38,38 @@ def test_len(posterior):
     assert len(posterior.states) == len(posterior)
 
 
+def test_append(posterior):
+    with pytest.raises(ValueError):
+        non_sorted_location = posterior.locations[0] - 1.0
+        posterior.append(non_sorted_location, posterior.states[0])
+
+    # Copy posterior such that random appends to the posterior object do not influence
+    # later tests
+    copied_posterior = filtsmooth.SmoothingPosterior(
+        filtering_posterior=posterior.filtering_posterior,
+        transition=posterior.transition,
+        locations=[l for l in posterior.locations],
+        states=[s for s in posterior.states],
+        diffusion_model=posterior.diffusion_model,
+    )
+
+    len_before_append = len(copied_posterior)
+    sorted_location = copied_posterior.locations[-1] + 1.0
+    last_state = copied_posterior.states[-1]
+    copied_posterior.append(sorted_location, last_state)
+    assert len(copied_posterior) == len_before_append + 1
+    assert copied_posterior.locations[-1] == sorted_location
+    assert copied_posterior.states[-1] == last_state
+
+    copied_posterior.freeze()
+
+    sorted_location = copied_posterior.locations[-1] + 1.0
+    last_state = copied_posterior.states[-1]
+
+    with pytest.raises(ValueError):
+        copied_posterior.append(sorted_location, last_state)
+
+
 def test_locations(posterior, setup):
     """Locations are stored correctly."""
     _, regression_problem = setup


### PR DESCRIPTION
Builds the filtering posterior on the fly, i.e. directly builds up the `FilteringPosterior` object, which is returned in the end.
This happens by
- allowing for initializing an empty `TimeSeriesPosterior` object
- adding an `.append(loc, rv)` method to the `TimeSeriesPosterior` class