### PR TITLE
Fix warning in `.inv()` of `LinearOperator`s of type `Matrix` wrapping `scipy.sparse.spmatrix` 

### DIFF
--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -904,7 +904,7 @@ class Matrix(LinearOperator):
             matmul = LinearOperator.broadcast_matmat(lambda x: self.A @ x)
             rmatmul = LinearOperator.broadcast_rmatmat(lambda x: x @ self.A)
             todense = self.A.toarray
-            inverse = lambda: Matrix(scipy.sparse.linalg.inv(self.A.tocsc()))
+            inverse = self._sparse_inv
             trace = lambda: self.A.diagonal().sum()
         else:
             self.A = np.asarray(A)
@@ -952,6 +952,12 @@ class Matrix(LinearOperator):
             return self
 
         return Matrix(A_astype)
+
+    def _sparse_inv(self) -> "Matrix":
+        try:
+            return Matrix(scipy.sparse.linalg.inv(self.A))
+        except RuntimeError as err:
+            raise np.linalg.LinAlgError(str(err)) from err
 
 
 class Identity(LinearOperator):

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -955,7 +955,7 @@ class Matrix(LinearOperator):
 
     def _sparse_inv(self) -> "Matrix":
         try:
-            return Matrix(scipy.sparse.linalg.inv(self.A))
+            return Matrix(scipy.sparse.linalg.inv(self.A.tocsc()))
         except RuntimeError as err:
             raise np.linalg.LinAlgError(str(err)) from err
 

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -904,7 +904,7 @@ class Matrix(LinearOperator):
             matmul = LinearOperator.broadcast_matmat(lambda x: self.A @ x)
             rmatmul = LinearOperator.broadcast_rmatmat(lambda x: x @ self.A)
             todense = self.A.toarray
-            inverse = lambda: Matrix(scipy.sparse.linalg.inv(self.A))
+            inverse = lambda: Matrix(scipy.sparse.linalg.inv(self.A.tocsc()))
             trace = lambda: self.A.diagonal().sum()
         else:
             self.A = np.asarray(A)

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -46,3 +46,14 @@ def case_sparse_matrix(
     matrix.setdiag(2)
 
     return pn.linops.Matrix(matrix), matrix.toarray()
+
+
+@pytest.mark.parametrize("rng", [np.random.default_rng(42)])
+def case_sparse_matrix_singular(
+    rng: np.random.Generator,
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    matrix = scipy.sparse.rand(
+        10, 10, density=0.01, format="csr", dtype=np.double, random_state=rng
+    )
+
+    return pn.linops.Matrix(matrix), matrix.toarray()

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+import scipy.sparse
 
 import probnum as pn
 
@@ -33,3 +34,15 @@ def case_matrix(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.ndarra
 @pytest.mark.parametrize("n", [3, 4, 8, 12, 15])
 def case_identity(n: int) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     return pn.linops.Identity(shape=n), np.eye(n)
+
+
+@pytest.mark.parametrize("rng", [np.random.default_rng(42)])
+def case_sparse_matrix(
+    rng: np.random.Generator,
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    matrix = scipy.sparse.rand(
+        10, 10, density=0.1, format="csr", dtype=np.double, random_state=rng
+    )
+    matrix.setdiag(2)
+
+    return pn.linops.Matrix(matrix), matrix.toarray()

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -41,9 +41,10 @@ def case_sparse_matrix(
     rng: np.random.Generator,
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     matrix = scipy.sparse.rand(
-        10, 10, density=0.1, format="csr", dtype=np.double, random_state=rng
+        10, 10, density=0.1, format="coo", dtype=np.double, random_state=rng
     )
     matrix.setdiag(2)
+    matrix = matrix.tocsr()
 
     return pn.linops.Matrix(matrix), matrix.toarray()
 


### PR DESCRIPTION
The function `scipy.sparse.linalg.inv()` emits a warning when given an `spmatrix` in a format other that 'csc'.
This PR
* converts the matrix to 'csc' format prior to calling the inversion routine.
* adds test cases for `Matrix` wrapping `scipy.sparse.spmatrix`
