### PR TITLE
Kernel embeddings for Matern kernels

### DIFF
--- a/src/probnum/kernels/__init__.py
+++ b/src/probnum/kernels/__init__.py
@@ -5,6 +5,7 @@ from ._kernel import Kernel
 from ._linear import Linear
 from ._matern import Matern
 from ._polynomial import Polynomial
+from ._product_matern import ProductMatern
 from ._rational_quadratic import RatQuad
 from ._white_noise import WhiteNoise
 
@@ -17,6 +18,7 @@ __all__ = [
     "ExpQuad",
     "RatQuad",
     "Matern",
+    "ProductMatern",
 ]
 
 # Set correct module paths. Corrects links and module paths in documentation.
@@ -27,3 +29,4 @@ Polynomial.__module__ = "probnum.kernels"
 ExpQuad.__module__ = "probnum.kernels"
 RatQuad.__module__ = "probnum.kernels"
 Matern.__module__ = "probnum.kernels"
+ProductMatern.__module__ = "probnum.kernels"

--- a/src/probnum/kernels/_matern.py
+++ b/src/probnum/kernels/_matern.py
@@ -96,11 +96,12 @@ class Matern(Kernel[_InputType]):
             )
         elif self.nu == 3.5:
             scaled_pdists = np.sqrt(7) * pdists
+            # Horner's method is used to compute the polynomial part. This yields
+            # a substantial speed improvement over the naive implementation.
             kernmat = (
                 1.0
-                + scaled_pdists
-                + scaled_pdists ** 2 * 2.0 / 5.0
-                + scaled_pdists ** 3 / 15
+                + (1.0 + (2.0 / 5.0 + scaled_pdists / 15.0) * scaled_pdists)
+                * scaled_pdists
             ) * np.exp(-scaled_pdists)
         elif self.nu == np.inf:
             kernmat = np.exp(-(pdists ** 2) / 2.0)

--- a/src/probnum/kernels/_matern.py
+++ b/src/probnum/kernels/_matern.py
@@ -94,6 +94,14 @@ class Matern(Kernel[_InputType]):
             kernmat = (1.0 + scaled_pdists + scaled_pdists ** 2 / 3.0) * np.exp(
                 -scaled_pdists
             )
+        elif self.nu == 3.5:
+            scaled_pdists = np.sqrt(7) * pdists
+            kernmat = (
+                1.0
+                + scaled_pdists
+                + scaled_pdists ** 2 * 2.0 / 5.0
+                + scaled_pdists ** 3 / 15
+            ) * np.exp(-scaled_pdists)
         elif self.nu == np.inf:
             kernmat = np.exp(-(pdists ** 2) / 2.0)
         else:

--- a/src/probnum/kernels/_product_matern.py
+++ b/src/probnum/kernels/_product_matern.py
@@ -17,7 +17,24 @@ class ProductMatern(Kernel[_InputType]):
     """Product Matern kernel.
 
     Covariance function defined as a product of one-dimensional Matern
-    kernels.
+    kernels: :math:`k(x_0, x_1) = \prod_{i=1}^d k_i(x_{0,i}, x_{1,i}`,
+    where :math:`x_0 = (x_{0,i}, \ldots, x_{0,d})` and :math:`x_0 = (x_{0,i}, \ldots, x_{0,d})`
+    and :math:`k_i` are one-dimensional Matern kernels.
+
+    Parameters
+    ----------
+    input_dim :
+        Input dimension of the kernel.
+    lengthscales :
+        Lengthscales of the one-dimensional Matern kernels. Describes the input scale on
+        which the process varies.
+    nus :
+        Hyperparameters controlling differentiability of the one-dimensional Matern
+        kernels.
+
+    See Also
+    --------
+    Matern : Stationary Matern kernel.
     """
 
     def __init__(

--- a/src/probnum/kernels/_product_matern.py
+++ b/src/probnum/kernels/_product_matern.py
@@ -35,6 +35,8 @@ class ProductMatern(Kernel[_InputType]):
                 Matern(input_dim=1, lengthscale=lengthscales[dim], nu=nus[dim])
             )
         self.one_d_materns = one_d_materns
+        self.nus = nus
+        self.lengthscales = lengthscales
 
         super().__init__(input_dim=input_dim, output_dim=1)
 

--- a/src/probnum/kernels/_product_matern.py
+++ b/src/probnum/kernels/_product_matern.py
@@ -1,11 +1,11 @@
 """Product Matern kernel."""
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 import probnum.utils as _utils
-from probnum.type import IntArgType
+from probnum.type import IntArgType, ScalarArgType
 
 from ._kernel import Kernel
 from ._matern import Matern
@@ -17,7 +17,7 @@ class ProductMatern(Kernel[_InputType]):
     """Product Matern kernel.
 
     Covariance function defined as a product of one-dimensional Matern
-    kernels: :math:`k(x_0, x_1) = \\prod_{i=1}^d k_i(x_{0,i}, x_{1,i}`,
+    kernels: :math:`k(x_0, x_1) = \\prod_{i=1}^d k_i(x_{0,i}, x_{1,i})`,
     where :math:`x_0 = (x_{0,i}, \\ldots, x_{0,d})` and :math:`x_0 = (x_{0,i}, \\ldots,
     x_{0,d})` and :math:`k_i` are one-dimensional Matern kernels.
 
@@ -36,6 +36,7 @@ class ProductMatern(Kernel[_InputType]):
     See Also
     --------
     Matern : Stationary Matern kernel.
+    ExpQuad : Exponentiated Quadratic / RBF kernel.
 
     Examples
     --------
@@ -53,7 +54,10 @@ class ProductMatern(Kernel[_InputType]):
     """
 
     def __init__(
-        self, input_dim: IntArgType, lengthscales: np.ndarray, nus: np.ndarray
+        self,
+        input_dim: IntArgType,
+        lengthscales: Union[np.ndarray, ScalarArgType],
+        nus: Union[np.ndarray, ScalarArgType],
     ):
         # If only single lengthcsale or nu is given, use this in every dimension
         if np.isscalar(lengthscales) or lengthscales.size == 1:

--- a/src/probnum/kernels/_product_matern.py
+++ b/src/probnum/kernels/_product_matern.py
@@ -18,8 +18,8 @@ class ProductMatern(Kernel[_InputType]):
 
     Covariance function defined as a product of one-dimensional Matern
     kernels: :math:`k(x_0, x_1) = \prod_{i=1}^d k_i(x_{0,i}, x_{1,i}`,
-    where :math:`x_0 = (x_{0,i}, \ldots, x_{0,d})` and :math:`x_0 = (x_{0,i}, \ldots, x_{0,d})`
-    and :math:`k_i` are one-dimensional Matern kernels.
+    where :math:`x_0 = (x_{0,i}, \ldots, x_{0,d})` and :math:`x_0 = (x_{0,i}, \ldots,
+    x_{0,d})` and :math:`k_i` are one-dimensional Matern kernels.
 
     Parameters
     ----------
@@ -27,14 +27,29 @@ class ProductMatern(Kernel[_InputType]):
         Input dimension of the kernel.
     lengthscales :
         Lengthscales of the one-dimensional Matern kernels. Describes the input scale on
-        which the process varies.
+        which the process varies. If a scalar, the same lengthscale is used in each
+        dimension.
     nus :
         Hyperparameters controlling differentiability of the one-dimensional Matern
-        kernels.
+        kernels. If a scalar, the same smoothness is used in each dimension.
 
     See Also
     --------
     Matern : Stationary Matern kernel.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from probnum.kernels import ProductMatern
+    >>> input_dim = 2
+    >>> lengthscales = np.array([0.1, 1.2])
+    >>> nus = np.array([0.5, 3.5])
+    >>> K = ProductMatern(input_dim=2, lengthscales=lenthscales, nus=nus)
+    >>> points = np.array([[0.0, 0.5], [1.0, 1.0], [0.5, 0.2]])
+    >>> K(points)
+    array([[1.00000000e+00, 4.03712525e-05, 6.45332482e-03],
+           [4.03712525e-05, 1.00000000e+00, 5.05119251e-03],
+           [6.45332482e-03, 5.05119251e-03, 1.00000000e+00]])
     """
 
     def __init__(

--- a/src/probnum/kernels/_product_matern.py
+++ b/src/probnum/kernels/_product_matern.py
@@ -1,0 +1,55 @@
+"""Product Matern kernel."""
+
+from typing import Optional
+
+import numpy as np
+
+import probnum.utils as _utils
+from probnum.type import IntArgType
+
+from ._kernel import Kernel
+from ._matern import Matern
+
+_InputType = np.ndarray
+
+
+class ProductMatern(Kernel[_InputType]):
+    """Product Matern kernel.
+
+    Covariance function defined as a product of one-dimensional Matern
+    kernels.
+    """
+
+    def __init__(
+        self, input_dim: IntArgType, lengthscales: np.ndarray, nus: np.ndarray
+    ):
+        # If only single lengthcsale or nu is given, use this in every dimension
+        if np.isscalar(lengthscales) or lengthscales.size == 1:
+            lengthscales = np.full((input_dim,), lengthscales)
+        if np.isscalar(nus) or nus.size == 1:
+            nus = np.full((input_dim,), nus)
+
+        one_d_materns = []
+        for dim in range(input_dim):
+            one_d_materns.append(
+                Matern(input_dim=1, lengthscale=lengthscales[dim], nu=nus[dim])
+            )
+        self.one_d_materns = one_d_materns
+
+        super().__init__(input_dim=input_dim, output_dim=1)
+
+    def __call__(self, x0: _InputType, x1: Optional[_InputType] = None) -> np.ndarray:
+
+        x0, x1, kernshape = self._check_and_reshape_inputs(x0, x1)
+        kernmat = np.ones(kernshape)
+
+        if x1 is None:
+            for dim in range(self.input_dim):
+                kernmat *= self.one_d_materns[dim](_utils.as_colvec(x0[:, dim]))
+        else:
+            for dim in range(self.input_dim):
+                kernmat *= self.one_d_materns[dim](
+                    _utils.as_colvec(x0[:, dim]), _utils.as_colvec(x1[:, dim])
+                )
+
+        return Kernel._reshape_kernelmatrix(kernmat, newshape=kernshape)

--- a/src/probnum/kernels/_product_matern.py
+++ b/src/probnum/kernels/_product_matern.py
@@ -17,8 +17,8 @@ class ProductMatern(Kernel[_InputType]):
     """Product Matern kernel.
 
     Covariance function defined as a product of one-dimensional Matern
-    kernels: :math:`k(x_0, x_1) = \prod_{i=1}^d k_i(x_{0,i}, x_{1,i}`,
-    where :math:`x_0 = (x_{0,i}, \ldots, x_{0,d})` and :math:`x_0 = (x_{0,i}, \ldots,
+    kernels: :math:`k(x_0, x_1) = \\prod_{i=1}^d k_i(x_{0,i}, x_{1,i}`,
+    where :math:`x_0 = (x_{0,i}, \\ldots, x_{0,d})` and :math:`x_0 = (x_{0,i}, \\ldots,
     x_{0,d})` and :math:`k_i` are one-dimensional Matern kernels.
 
     Parameters

--- a/src/probnum/quad/__init__.py
+++ b/src/probnum/quad/__init__.py
@@ -7,8 +7,10 @@ from .kernel_embeddings import (
     KernelEmbedding,
     _kernel_mean_expquad_gauss,
     _kernel_mean_expquad_lebesgue,
+    _kernel_mean_matern_lebesgue,
     _kernel_variance_expquad_gauss,
     _kernel_variance_expquad_lebesgue,
+    _kernel_variance_matern_lebesgue,
 )
 from .policies import sample_from_measure
 

--- a/src/probnum/quad/__init__.py
+++ b/src/probnum/quad/__init__.py
@@ -3,15 +3,7 @@
 from ._bayesquad import bayesquad
 from ._integration_measures import GaussianMeasure, IntegrationMeasure, LebesgueMeasure
 from .bq_methods import BayesianQuadrature
-from .kernel_embeddings import (
-    KernelEmbedding,
-    _kernel_mean_expquad_gauss,
-    _kernel_mean_expquad_lebesgue,
-    _kernel_mean_matern_lebesgue,
-    _kernel_variance_expquad_gauss,
-    _kernel_variance_expquad_lebesgue,
-    _kernel_variance_matern_lebesgue,
-)
+from .kernel_embeddings import KernelEmbedding
 from .policies import sample_from_measure
 
 # Public classes and functions. Order is reflected in documentation.

--- a/src/probnum/quad/kernel_embeddings/__init__.py
+++ b/src/probnum/quad/kernel_embeddings/__init__.py
@@ -4,4 +4,7 @@ from ._expquad_lebesgue import (
     _kernel_variance_expquad_lebesgue,
 )
 from ._kernel_embedding import KernelEmbedding
-from ._matern_lebesgue import _kernel_mean_matern_lebesgue
+from ._matern_lebesgue import (
+    _kernel_mean_matern_lebesgue,
+    _kernel_variance_matern_lebesgue,
+)

--- a/src/probnum/quad/kernel_embeddings/__init__.py
+++ b/src/probnum/quad/kernel_embeddings/__init__.py
@@ -1,10 +1,1 @@
-from ._expquad_gauss import _kernel_mean_expquad_gauss, _kernel_variance_expquad_gauss
-from ._expquad_lebesgue import (
-    _kernel_mean_expquad_lebesgue,
-    _kernel_variance_expquad_lebesgue,
-)
 from ._kernel_embedding import KernelEmbedding
-from ._matern_lebesgue import (
-    _kernel_mean_matern_lebesgue,
-    _kernel_variance_matern_lebesgue,
-)

--- a/src/probnum/quad/kernel_embeddings/__init__.py
+++ b/src/probnum/quad/kernel_embeddings/__init__.py
@@ -4,3 +4,4 @@ from ._expquad_lebesgue import (
     _kernel_variance_expquad_lebesgue,
 )
 from ._kernel_embedding import KernelEmbedding
+from ._matern_lebesgue import _kernel_mean_matern_lebesgue

--- a/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
+++ b/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
@@ -10,12 +10,14 @@ from probnum.quad._integration_measures import (
     IntegrationMeasure,
     LebesgueMeasure,
 )
-from probnum.quad.kernel_embeddings import (
-    _kernel_mean_expquad_gauss,
+
+from ._expquad_gauss import _kernel_mean_expquad_gauss, _kernel_variance_expquad_gauss
+from ._expquad_lebesgue import (
     _kernel_mean_expquad_lebesgue,
-    _kernel_mean_matern_lebesgue,
-    _kernel_variance_expquad_gauss,
     _kernel_variance_expquad_lebesgue,
+)
+from ._matern_lebesgue import (
+    _kernel_mean_matern_lebesgue,
     _kernel_variance_matern_lebesgue,
 )
 

--- a/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
+++ b/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
@@ -4,7 +4,7 @@ from typing import Callable, Tuple
 
 import numpy as np
 
-from probnum.kernels import ExpQuad, Kernel
+from probnum.kernels import ExpQuad, Kernel, Matern, ProductMatern
 from probnum.quad._integration_measures import (
     GaussianMeasure,
     IntegrationMeasure,
@@ -13,6 +13,7 @@ from probnum.quad._integration_measures import (
 from probnum.quad.kernel_embeddings import (
     _kernel_mean_expquad_gauss,
     _kernel_mean_expquad_lebesgue,
+    _kernel_mean_matern_lebesgue,
     _kernel_variance_expquad_gauss,
     _kernel_variance_expquad_lebesgue,
 )
@@ -97,6 +98,10 @@ def _get_kernel_embedding(
         elif isinstance(measure, LebesgueMeasure):
             return _kernel_mean_expquad_lebesgue, _kernel_variance_expquad_lebesgue
         raise NotImplementedError
+    # Matern
+    if isinstance(kernel, (Matern, ProductMatern)):
+        if isinstance(measure, LebesgueMeasure):
+            return _kernel_mean_matern_lebesgue, None
 
     # other kernels
     raise NotImplementedError

--- a/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
+++ b/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
@@ -16,6 +16,7 @@ from probnum.quad.kernel_embeddings import (
     _kernel_mean_matern_lebesgue,
     _kernel_variance_expquad_gauss,
     _kernel_variance_expquad_lebesgue,
+    _kernel_variance_matern_lebesgue,
 )
 
 
@@ -101,7 +102,7 @@ def _get_kernel_embedding(
     # Matern
     if isinstance(kernel, (Matern, ProductMatern)):
         if isinstance(measure, LebesgueMeasure):
-            return _kernel_mean_matern_lebesgue, None
+            return _kernel_mean_matern_lebesgue, _kernel_variance_matern_lebesgue
 
     # other kernels
     raise NotImplementedError

--- a/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
+++ b/src/probnum/quad/kernel_embeddings/_kernel_embedding.py
@@ -61,7 +61,8 @@ class KernelEmbedding:
         Returns
         -------
         k_mean :
-            *shape=(n_eval,)* -- The kernel integrated w.r.t. its first argument, evaluated at locations x.
+            *shape=(n_eval,)* -- The kernel integrated w.r.t. its first argument,
+                                 evaluated at locations x.
         """
         return self._kmean(x=x, kernel=self.kernel, measure=self.measure)
 

--- a/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
+++ b/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
@@ -38,7 +38,7 @@ def _kernel_mean_matern_lebesgue(
             domain=(measure.domain[0][dim], measure.domain[1][dim]),
         )
 
-    return kernel_mean
+    return measure.normalization_constant * kernel_mean
 
 
 def _kernel_mean_matern_1d_lebesgue(x: np.ndarray, kernel: Matern, domain: Tuple):

--- a/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
+++ b/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
@@ -13,7 +13,23 @@ from probnum.type import ScalarArgType
 def _kernel_mean_matern_lebesgue(
     x: np.ndarray, kernel: Union[Matern, ProductMatern], measure: LebesgueMeasure
 ) -> np.ndarray:
+    """Kernel mean of a ProductMatern or 1D Matern kernel w.r.t. its first argument
+    against a Lebesgue measure.
 
+    Parameters
+    ----------
+    x :
+        *shape (n_eval, dim)* -- n_eval locations where to evaluate the kernel mean.
+    kernel :
+        Instance of a ProductMatern or 1D Matern kernel.
+    measure :
+        Instance of a LebesgueMeasure.
+
+    Returns
+    -------
+    k_mean :
+        *shape=(n_eval,)* -- The kernel integrated w.r.t. its first argument, evaluated at locations x.
+    """
     kernel = _convert_to_product_matern(kernel)
 
     # Compute kernel mean via a product of one-dimensional kernel means
@@ -31,10 +47,25 @@ def _kernel_mean_matern_lebesgue(
 def _kernel_variance_matern_lebesgue(
     kernel: Union[Matern, ProductMatern], measure: LebesgueMeasure
 ) -> float:
+    """Kernel variance of a ProductMatern or 1D Matern kernel w.r.t. both arguments
+    against a Lebesgue measure.
+
+    Parameters
+    ----------
+    kernel :
+        Instance of a ProductMatern or 1D Matern kernel.
+    measure :
+        Instance of a LebesgueMeasure.
+
+    Returns
+    -------
+    k_var :
+        The kernel integrated w.r.t. both arguments.
+    """
 
     kernel = _convert_to_product_matern(kernel)
 
-    # Compute kernel mean via a product of one-dimensional kernel means
+    # Compute kernel mean via a product of one-dimensional kernel variances
     kernel_variance = 1.0
     for dim in range(kernel.input_dim):
         kernel_variance *= _kernel_variance_matern_1d_lebesgue(
@@ -46,6 +77,7 @@ def _kernel_variance_matern_lebesgue(
 
 
 def _convert_to_product_matern(kernel):
+    """Convert a 1D Matern kernel to a ProductMatern."""
     if isinstance(kernel, Matern):
         if kernel.input_dim > 1:
             raise NotImplementedError(
@@ -63,6 +95,10 @@ def _convert_to_product_matern(kernel):
 
 
 def _kernel_mean_matern_1d_lebesgue(x: np.ndarray, kernel: Matern, domain: Tuple):
+    """Kernel means for 1D Matern kernels.
+
+    Note that these are for unnormalized Lebesgue measure.
+    """
     (a, b) = domain
     ell = kernel.lengthscale
     if kernel.nu == 0.5:
@@ -122,6 +158,10 @@ def _kernel_mean_matern_1d_lebesgue(x: np.ndarray, kernel: Matern, domain: Tuple
 
 
 def _kernel_variance_matern_1d_lebesgue(kernel: Matern, domain: Tuple):
+    """Kernel variances for 1D Matern kernels.
+
+    Note that these are for unnormalized Lebesgue measure.
+    """
     (a, b) = domain
     r = b - a
     ell = kernel.lengthscale
@@ -157,7 +197,7 @@ def _kernel_variance_matern_1d_lebesgue(kernel: Matern, domain: Tuple):
             / (105.0 * ell)
             * (
                 2.0
-                * np.exp(-r / ell)
+                * np.exp(-c / ell)
                 * (
                     7.0 * np.sqrt(7.0) * (b ** 3 - a ** 3)
                     + 84.0 * b ** 2 * ell
@@ -172,7 +212,7 @@ def _kernel_variance_matern_1d_lebesgue(kernel: Matern, domain: Tuple):
                         + 19.0 * np.sqrt(7.0) * ell ** 2
                     )
                 )
-                - 6.0 * ell ** 2 * (16.0 * c + 35.0 * ell)
+                - 6.0 * ell ** 2 * (35.0 * ell - 16.0 * c)
             )
         )
     else:

--- a/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
+++ b/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
@@ -1,0 +1,50 @@
+"""Kernel embedding of Matern kernels with Lebesgue integration measure."""
+
+from typing import Tuple, Union
+
+import numpy as np
+
+import probnum.utils as _utils
+from probnum.kernels import Matern, ProductMatern
+from probnum.quad._integration_measures import LebesgueMeasure
+from probnum.type import ScalarArgType
+
+
+def _kernel_mean_matern_lebesgue(
+    x: np.ndarray, kernel: Union[Matern, ProductMatern], measure: LebesgueMeasure
+) -> np.ndarray:
+
+    # Convert ordinary Matern kernel to a product Matern kernel
+    if isinstance(kernel, Matern):
+        if kernel.input_dim > 1:
+            raise NotImplementedError(
+                "Kernel embeddings have been implemented only for "
+                "product Matern kernels in dimensions higher than "
+                "one."
+            )
+        else:
+            kernel = ProductMatern(
+                input_dim=kernel.input_dim,
+                lengthscales=kernel.lengthscale,
+                nus=kernel.nu,
+            )
+
+    # Compute kernel mean via a product of one-dimensional kernel means
+    kernel_mean = np.ones((x.shape[0],))
+    for dim in range(kernel.input_dim):
+        kernel_mean *= _kernel_mean_matern_1d_lebesgue(
+            x=x[:, dim],
+            kernel=kernel.one_d_materns[dim],
+            domain=(measure.domain[0][dim], measure.domain[1][dim]),
+        )
+
+    return kernel_mean
+
+
+def _kernel_mean_matern_1d_lebesgue(x: np.ndarray, kernel: Matern, domain: Tuple):
+    (a, b) = domain
+    ell = kernel.lengthscale
+    if kernel.nu == 0.5:
+        return ell * (2.0 - np.exp((a - x) / ell) - np.exp((x - b) / ell))
+    else:
+        raise NotImplementedError

--- a/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
+++ b/src/probnum/quad/kernel_embeddings/_matern_lebesgue.py
@@ -14,20 +14,7 @@ def _kernel_mean_matern_lebesgue(
     x: np.ndarray, kernel: Union[Matern, ProductMatern], measure: LebesgueMeasure
 ) -> np.ndarray:
 
-    # Convert ordinary Matern kernel to a product Matern kernel
-    if isinstance(kernel, Matern):
-        if kernel.input_dim > 1:
-            raise NotImplementedError(
-                "Kernel embeddings have been implemented only for "
-                "product Matern kernels in dimensions higher than "
-                "one."
-            )
-        else:
-            kernel = ProductMatern(
-                input_dim=kernel.input_dim,
-                lengthscales=kernel.lengthscale,
-                nus=kernel.nu,
-            )
+    kernel = _convert_to_product_matern(kernel)
 
     # Compute kernel mean via a product of one-dimensional kernel means
     kernel_mean = np.ones((x.shape[0],))
@@ -41,10 +28,152 @@ def _kernel_mean_matern_lebesgue(
     return measure.normalization_constant * kernel_mean
 
 
+def _kernel_variance_matern_lebesgue(
+    kernel: Union[Matern, ProductMatern], measure: LebesgueMeasure
+) -> float:
+
+    kernel = _convert_to_product_matern(kernel)
+
+    # Compute kernel mean via a product of one-dimensional kernel means
+    kernel_variance = 1.0
+    for dim in range(kernel.input_dim):
+        kernel_variance *= _kernel_variance_matern_1d_lebesgue(
+            kernel=kernel.one_d_materns[dim],
+            domain=(measure.domain[0][dim], measure.domain[1][dim]),
+        )
+
+    return measure.normalization_constant ** 2 * kernel_variance
+
+
+def _convert_to_product_matern(kernel):
+    if isinstance(kernel, Matern):
+        if kernel.input_dim > 1:
+            raise NotImplementedError(
+                "Kernel embeddings have been implemented only for "
+                "product Matern kernels in dimensions higher than "
+                "one."
+            )
+        else:
+            kernel = ProductMatern(
+                input_dim=kernel.input_dim,
+                lengthscales=kernel.lengthscale,
+                nus=kernel.nu,
+            )
+    return kernel
+
+
 def _kernel_mean_matern_1d_lebesgue(x: np.ndarray, kernel: Matern, domain: Tuple):
     (a, b) = domain
     ell = kernel.lengthscale
     if kernel.nu == 0.5:
         return ell * (2.0 - np.exp((a - x) / ell) - np.exp((x - b) / ell))
+    elif kernel.nu == 1.5:
+        return (
+            4.0 * ell / np.sqrt(3.0)
+            - np.exp(np.sqrt(3.0) * (x - b) / ell)
+            / 3.0
+            * (3.0 * b + 2.0 * np.sqrt(3.0) * ell - 3.0 * x)
+            - np.exp(np.sqrt(3.0) * (a - x) / ell)
+            / 3.0
+            * (3.0 * x + 2.0 * np.sqrt(3.0) * ell - 3.0 * a)
+        )
+    elif kernel.nu == 2.5:
+        return (
+            16.0 * ell / (3.0 * np.sqrt(5.0))
+            - np.exp(np.sqrt(5.0) * (x - b) / ell)
+            / (15.0 * ell)
+            * (
+                8.0 * np.sqrt(5.0) * ell ** 2
+                + 25.0 * ell * (b - x)
+                + 5.0 * np.sqrt(5.0) * (b - x) ** 2
+            )
+            - np.exp(np.sqrt(5.0) * (a - x) / ell)
+            / (15.0 * ell)
+            * (
+                8.0 * np.sqrt(5.0) * ell ** 2
+                + 25.0 * ell * (x - a)
+                + 5.0 * np.sqrt(5.0) * (a - x) ** 2
+            )
+        )
+    elif kernel.nu == 3.5:
+        return (
+            1.0
+            / (105.0 * ell ** 2)
+            * (
+                96.0 * np.sqrt(7.0) * ell ** 3
+                - np.exp(np.sqrt(7.0) * (x - b) / ell)
+                * (
+                    48.0 * np.sqrt(7.0) * ell ** 3
+                    - 231.0 * ell ** 2 * (x - b)
+                    + 63.0 * np.sqrt(7.0) * ell * (x - b) ** 2
+                    - 49.0 * (x - b) ** 3
+                )
+                - np.exp(np.sqrt(7.0) * (a - x) / ell)
+                * (
+                    48.0 * np.sqrt(7.0) * ell ** 3
+                    + 231.0 * ell ** 2 * (x - a)
+                    + 63.0 * np.sqrt(7.0) * ell * (x - a) ** 2
+                    + 49.0 * (x - a) ** 3
+                )
+            )
+        )
+    else:
+        raise NotImplementedError
+
+
+def _kernel_variance_matern_1d_lebesgue(kernel: Matern, domain: Tuple):
+    (a, b) = domain
+    r = b - a
+    ell = kernel.lengthscale
+    if kernel.nu == 0.5:
+        return 2.0 * ell * (r + ell * (np.exp(-r / ell) - 1.0))
+    elif kernel.nu == 1.5:
+        c = np.sqrt(3.0) * r
+        return (
+            2.0 * ell / 3.0 * (2.0 * c - 3.0 * ell + np.exp(-c / ell) * (c + 3.0 * ell))
+        )
+    elif kernel.nu == 2.5:
+        c = np.sqrt(5.0) * r
+        return (
+            1.0
+            / 15.0
+            * (
+                2.0 * ell * (8.0 * c - 15.0 * ell)
+                + 2.0
+                * np.exp(-c / ell)
+                * (
+                    5.0 * a ** 2
+                    - 10.0 * a * b
+                    + 5.0 * b ** 2
+                    + 7.0 * c * ell
+                    + 15.0 * ell ** 2
+                )
+            )
+        )
+    elif kernel.nu == 3.5:
+        c = np.sqrt(7.0) * r
+        return (
+            1.0
+            / (105.0 * ell)
+            * (
+                2.0
+                * np.exp(-r / ell)
+                * (
+                    7.0 * np.sqrt(7.0) * (b ** 3 - a ** 3)
+                    + 84.0 * b ** 2 * ell
+                    + 57.0 * np.sqrt(7.0) * b * ell ** 2
+                    + 105.0 * ell ** 3
+                    + 21.0 * a ** 2 * (np.sqrt(7.0) * b + 4.0 * ell)
+                    - 3.0
+                    * a
+                    * (
+                        7.0 * np.sqrt(7.0) * b ** 2
+                        + 56.0 * b * ell
+                        + 19.0 * np.sqrt(7.0) * ell ** 2
+                    )
+                )
+                - 6.0 * ell ** 2 * (16.0 * c + 35.0 * ell)
+            )
+        )
     else:
         raise NotImplementedError

--- a/tests/test_quad/conftest.py
+++ b/tests/test_quad/conftest.py
@@ -173,7 +173,10 @@ def fixture_f1d(request):
 
 # Matern kernels
 @pytest.fixture(
-    params=[pytest.param(matern_nu, id=f"nu={matern_nu}") for matern_nu in [0.5]],
+    params=[
+        pytest.param(matern_nu, id=f"nu={matern_nu}")
+        for matern_nu in [0.5, 1.5, 2.5, 3.5]
+    ],
     name="matern_nu",
 )
 def fixture_matern_nu(request) -> int:

--- a/tests/test_quad/conftest.py
+++ b/tests/test_quad/conftest.py
@@ -120,12 +120,22 @@ def fixture_measure(measure_params) -> measures.IntegrationMeasure:
     raise NotImplementedError
 
 
+# Kernel Embeddings
+@pytest.fixture(name="kernel_embedding")
+def fixture_kernel_embedding(
+    request, kernel: kernels.Kernel, measure: measures.IntegrationMeasure
+) -> KernelEmbedding:
+    """Set up kernel embedding."""
+    return KernelEmbedding(kernel, measure)
+
+
 # Kernels
 @pytest.fixture(
     params=[
         pytest.param(kerndef, id=kerndef[0].__name__)
         for kerndef in [
             (kernels.ExpQuad, {"lengthscale": 1.25}),
+            (kernels.ExpQuad, {"lengthscale": 0.9}),
         ]
     ],
     name="kernel",
@@ -159,3 +169,47 @@ def fixture_kernel_embedding(
 def fixture_f1d(request):
     """1D test function for BQ."""
     return request.param
+
+
+# New kernel stuff
+@pytest.fixture(
+    params=[pytest.param(name, id=name) for name in ["expquad", "matern"]],
+    name="kernel_name_tmp",
+)
+def fixture_kernel_names_tmp(request) -> str:
+    return request.param
+
+
+@pytest.fixture(name="kernel_tmp")
+def fixture_kernel_tmp(kernel_name_tmp, input_dim) -> kernels.Kernel:
+    if kernel_name_tmp == "matern":
+        lengthscales = 1.25
+        nus = 0.5
+        return kernels.ProductMatern(
+            input_dim=input_dim, nus=nus, lengthscales=lengthscales
+        )
+    if kernel_name_tmp == "expquad":
+        return "None"
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(kerndef, id=kerndef[0].__name__)
+        for kerndef in [
+            (kernels.ExpQuad, {"lengthscale": 1.25}),
+            (kernels.ExpQuad, {"lengthscale": 0.9}),
+        ]
+    ],
+    name="kernel",
+)
+def fixture_kernel(request, input_dim: int) -> kernels.Kernel:
+    """Kernel / covariance function."""
+    return request.param[0](**request.param[1], input_dim=input_dim)
+
+
+@pytest.fixture(name="kernel_embedding_tmp")
+def fixture_kernel_embedding_tmp(
+    request, kernel_tmp: kernels.Kernel, measure: measures.IntegrationMeasure
+) -> KernelEmbedding:
+    """Set up kernel embedding."""
+    return KernelEmbedding(kernel_tmp, measure)

--- a/tests/test_quad/conftest.py
+++ b/tests/test_quad/conftest.py
@@ -22,7 +22,7 @@ def fixture_random_state(request):
 
 
 @pytest.fixture(
-    params=[pytest.param(num_data, id=f"ndata{num_data}") for num_data in [1, 2, 20]],
+    params=[pytest.param(num_data, id=f"ndata={num_data}") for num_data in [1, 2, 20]],
     name="num_data",
 )
 def fixture_num_data(request) -> int:
@@ -32,7 +32,7 @@ def fixture_num_data(request) -> int:
 
 @pytest.fixture(
     params=[
-        pytest.param(input_dim, id=f"dim{input_dim}") for input_dim in [1, 2, 3, 5]
+        pytest.param(input_dim, id=f"dim={input_dim}") for input_dim in [1, 2, 3, 5]
     ],
     name="input_dim",
 )
@@ -171,45 +171,33 @@ def fixture_f1d(request):
     return request.param
 
 
-# New kernel stuff
+# Matern kernels
 @pytest.fixture(
-    params=[pytest.param(name, id=name) for name in ["expquad", "matern"]],
-    name="kernel_name_tmp",
+    params=[pytest.param(matern_nu, id=f"nu={matern_nu}") for matern_nu in [0.5]],
+    name="matern_nu",
 )
-def fixture_kernel_names_tmp(request) -> str:
+def fixture_matern_nu(request) -> int:
+    """Input dimension of the covariance function."""
     return request.param
-
-
-@pytest.fixture(name="kernel_tmp")
-def fixture_kernel_tmp(kernel_name_tmp, input_dim) -> kernels.Kernel:
-    if kernel_name_tmp == "matern":
-        lengthscales = 1.25
-        nus = 0.5
-        return kernels.ProductMatern(
-            input_dim=input_dim, nus=nus, lengthscales=lengthscales
-        )
-    if kernel_name_tmp == "expquad":
-        return "None"
 
 
 @pytest.fixture(
     params=[
-        pytest.param(kerndef, id=kerndef[0].__name__)
-        for kerndef in [
-            (kernels.ExpQuad, {"lengthscale": 1.25}),
-            (kernels.ExpQuad, {"lengthscale": 0.9}),
-        ]
+        pytest.param(matern_lengthscale, id=f"lengthscale={matern_lengthscale}")
+        for matern_lengthscale in [0.8, 1.0, 1.25]
     ],
-    name="kernel",
+    name="matern_lengthscale",
 )
-def fixture_kernel(request, input_dim: int) -> kernels.Kernel:
-    """Kernel / covariance function."""
-    return request.param[0](**request.param[1], input_dim=input_dim)
+def fixture_matern_lengthscale(request) -> int:
+    """Input dimension of the covariance function."""
+    return request.param
 
 
-@pytest.fixture(name="kernel_embedding_tmp")
-def fixture_kernel_embedding_tmp(
-    request, kernel_tmp: kernels.Kernel, measure: measures.IntegrationMeasure
-) -> KernelEmbedding:
-    """Set up kernel embedding."""
-    return KernelEmbedding(kernel_tmp, measure)
+@pytest.fixture(name="matern_kernel")
+def fixture_matern_kernel(
+    request, input_dim: int, matern_nu: float, matern_lengthscale: float
+) -> kernels.Kernel:
+    """Set up Matern kernel."""
+    return kernels.ProductMatern(
+        input_dim=input_dim, nus=matern_nu, lengthscales=matern_lengthscale
+    )

--- a/tests/test_quad/test_kernel_embeddings.py
+++ b/tests/test_quad/test_kernel_embeddings.py
@@ -184,3 +184,21 @@ def test_kernel_mean_matern_lebesgue_measure(matern_kernel, measure, num_data):
     np.testing.assert_allclose(
         true_kernel_means, num_kernel_means, rtol=1.0e-5, atol=1.0e-5
     )
+
+
+@pytest.mark.parametrize("input_dim", [1, 2, 3])
+@pytest.mark.parametrize("measure_name", ["lebesgue"])
+def test_kernel_variance_matern_lebesgue_measure(matern_kernel, measure):
+    kernel_embedding = KernelEmbedding(matern_kernel, measure)
+    n_gl = 20
+    x_gl, w_gl = gauss_legendre_tensor(
+        n_points=n_gl,
+        dim=kernel_embedding.dim,
+        domain=kernel_embedding.measure.domain,
+        normalized=kernel_embedding.measure.normalized,
+    )
+    num_kernel_variance = kernel_embedding.kernel_mean(x_gl) @ w_gl
+    true_kernel_variance = kernel_embedding.kernel_variance()
+    np.testing.assert_allclose(
+        true_kernel_variance, num_kernel_variance, rtol=1.0e-3, atol=1.0e-3
+    )

--- a/tests/test_quad/test_kernel_embeddings.py
+++ b/tests/test_quad/test_kernel_embeddings.py
@@ -4,9 +4,11 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 import pytest
+from scipy.integrate import quad
 from scipy.linalg import sqrtm
 from scipy.special import roots_legendre
 
+from probnum.quad import KernelEmbedding
 from probnum.type import FloatArgType, IntArgType
 
 
@@ -156,8 +158,29 @@ def test_kernel_var_expquad_lebesgue_measure(kernel_embedding):
 
 
 # Tests for Matern kernels and Lebesgue measure
-@pytest.mark.parametrize("input_dim", [1, 2, 3, 5])
+@pytest.mark.parametrize("input_dim", [1, 2, 3])
+@pytest.mark.parametrize("num_data", [1, 2, 5])
 @pytest.mark.parametrize("measure_name", ["lebesgue"])
-@pytest.mark.parametrize("kernel_name_tmp", ["matern"])
-def test_kernel_mean_matern_lebesgue_measure(kernel_embedding_tmp):
-    print(kernel_embedding_tmp.kernel.lengthscales)
+def test_kernel_mean_matern_lebesgue_measure(matern_kernel, measure, num_data):
+    kernel_embedding = KernelEmbedding(matern_kernel, measure)
+    points = kernel_embedding.measure.sample(num_data)
+    # Numerical integration using scipy's quad
+    num_kernel_means = np.zeros((num_data,))
+    a, b = kernel_embedding.measure.domain
+    for indx in range(num_data):
+        integral_current_dim = 1.0
+        for dim in range(kernel_embedding.measure.dim):
+
+            def fun(x):
+                return kernel_embedding.kernel.one_d_materns[dim](points[indx][dim], x)
+
+            integral_current_dim *= quad(fun, a[dim], b[dim])[0]
+        num_kernel_means[indx] = (
+            integral_current_dim * kernel_embedding.measure.normalization_constant
+        )
+    # True kernel means
+    true_kernel_means = kernel_embedding.kernel_mean(points)
+    # Compare
+    np.testing.assert_allclose(
+        true_kernel_means, num_kernel_means, rtol=1.0e-5, atol=1.0e-5
+    )

--- a/tests/test_quad/test_kernel_embeddings.py
+++ b/tests/test_quad/test_kernel_embeddings.py
@@ -75,10 +75,10 @@ def test_kernel_variance_float(kernel_embedding):
 # Tests for squared exponential kernel and Gaussian measure
 @pytest.mark.parametrize("input_dim", [1, 2, 3, 5])
 @pytest.mark.parametrize("measure_name", ["gauss"])
-def test_kernel_mean_gaussian_measure(kernel_embedding, num_data):
+def test_kernel_mean_expquad_gaussian_measure(kernel_embedding, num_data):
     """Test kernel means for the Gaussian measure against Gauss-Hermite tensor product
     rule."""
-    n_gh = 10
+    n_gh = 15
     x_gh, w_gh = gauss_hermite_tensor(
         n_points=n_gh,
         dim=kernel_embedding.dim,
@@ -96,7 +96,7 @@ def test_kernel_mean_gaussian_measure(kernel_embedding, num_data):
 
 @pytest.mark.parametrize("input_dim", [1, 2, 3, 5])
 @pytest.mark.parametrize("measure_name", ["gauss"])
-def test_kernel_var_gaussian_measure(kernel_embedding):
+def test_kernel_var_expquad_gaussian_measure(kernel_embedding):
     """Test kernel variance for the Gaussian measure against Gauss-Hermite tensor
     product rule."""
     n_gh = 20
@@ -117,7 +117,7 @@ def test_kernel_var_gaussian_measure(kernel_embedding):
 # Tests for squared exponential kernel and Lebesgue measure
 @pytest.mark.parametrize("input_dim", [1, 2, 3, 5])
 @pytest.mark.parametrize("measure_name", ["lebesgue"])
-def test_kernel_mean_lebesgue_measure(kernel_embedding, num_data):
+def test_kernel_mean_expquad_lebesgue_measure(kernel_embedding, num_data):
     """Test kernel means for the Lebesgue measure against Gauss-Legendre tensor product
     rule."""
     n_gl = 10
@@ -138,7 +138,7 @@ def test_kernel_mean_lebesgue_measure(kernel_embedding, num_data):
 
 @pytest.mark.parametrize("input_dim", [1, 2, 3, 5])
 @pytest.mark.parametrize("measure_name", ["lebesgue"])
-def test_kernel_var_lebesgue_measure(kernel_embedding):
+def test_kernel_var_expquad_lebesgue_measure(kernel_embedding):
     """Test kernel variance for the Lebesgue measure against Gauss-Legendre tensor
     product rule."""
     n_gl = 20
@@ -153,3 +153,11 @@ def test_kernel_var_lebesgue_measure(kernel_embedding):
     np.testing.assert_allclose(
         true_kernel_variance, num_kernel_variance, rtol=1.0e-3, atol=1.0e-3
     )
+
+
+# Tests for Matern kernels and Lebesgue measure
+@pytest.mark.parametrize("input_dim", [1, 2, 3, 5])
+@pytest.mark.parametrize("measure_name", ["lebesgue"])
+@pytest.mark.parametrize("kernel_name_tmp", ["matern"])
+def test_kernel_mean_matern_lebesgue_measure(kernel_embedding_tmp):
+    print(kernel_embedding_tmp.kernel.lengthscales)


### PR DESCRIPTION
This PR adds

1. Fast evaluation of the Matern 3.5 kernel via Horner's method.
2. `ProductMatern` class which implements kernels which are dimension-wise products of 1D Matern kernels.
3. Kernel means and variances for 1D `Matern` kernels and `ProductMatern` kernels w.r.t. the Lebesgue measure.