### PR TITLE
Improved implementation of `random_sparse_spd_matrix`

### DIFF
--- a/src/probnum/problems/zoo/linalg/_random_spd_matrix.py
+++ b/src/probnum/problems/zoo/linalg/_random_spd_matrix.py
@@ -134,9 +134,9 @@ def random_sparse_spd_matrix(
     >>> sparsemat = random_sparse_spd_matrix(dim=5, density=0.1, random_state=42)
     >>> sparsemat.todense()
     matrix([[1.        , 0.        , 0.        , 0.        , 0.        ],
-            [0.        , 1.        , 0.        , 0.30424224, 0.        ],
+            [0.        , 1.        , 0.        , 0.37381802, 0.        ],
             [0.        , 0.        , 1.        , 0.        , 0.        ],
-            [0.        , 0.30424224, 0.        , 1.09256334, 0.        ],
+            [0.        , 0.37381802, 0.        , 1.13973991, 0.        ],
             [0.        , 0.        , 0.        , 0.        , 1.        ]])
     """
 

--- a/src/probnum/problems/zoo/linalg/_random_spd_matrix.py
+++ b/src/probnum/problems/zoo/linalg/_random_spd_matrix.py
@@ -104,7 +104,9 @@ def random_sparse_spd_matrix(
 
     Constructs a random sparse symmetric positive definite matrix for a given degree
     of sparsity. The matrix is constructed from its Cholesky factor :math:`L`. Its
-    diagonal is set to one and all other nonzero entries of the lower triangle are sampled from a uniform distribution with bounds :code:`[chol_entry_min, chol_entry_max]`. The resulting sparse matrix is then given by :math:`A=LL^\top`.
+    diagonal is set to one and all other nonzero entries of the lower triangle are
+    sampled from a uniform distribution with bounds :code:`[chol_entry_min,
+    chol_entry_max]`. The resulting sparse matrix is then given by :math:`A=LL^\top`.
 
     Parameters
     ----------

--- a/tests/test_problems/test_zoo/test_linalg/test_random_spd_matrix.py
+++ b/tests/test_problems/test_zoo/test_linalg/test_random_spd_matrix.py
@@ -4,7 +4,9 @@ from typing import Union
 
 import numpy as np
 import pytest
+import pytest_cases
 import scipy.sparse
+from scipy.sparse.csc import csc_matrix
 
 from probnum.problems.zoo.linalg import random_sparse_spd_matrix, random_spd_matrix
 
@@ -59,6 +61,28 @@ def test_is_spmatrix(rnd_sparse_spd_mat: scipy.sparse.spmatrix):
     """Test whether :meth:`random_sparse_spd_matrix` returns a
     `scipy.sparse.spmatrix`."""
     assert isinstance(rnd_sparse_spd_mat, scipy.sparse.spmatrix)
+
+
+@pytest_cases.parametrize(
+    "spformat,sparse_matrix_class",
+    [
+        ("bsr", scipy.sparse.bsr_matrix),
+        ("coo", scipy.sparse.coo_matrix),
+        ("csc", scipy.sparse.csc_matrix),
+        ("csr", scipy.sparse.csr_matrix),
+        ("dia", scipy.sparse.dia_matrix),
+        ("dok", scipy.sparse.dok_matrix),
+        ("lil", scipy.sparse.lil_matrix),
+    ],
+)
+def test_sparse_formats(
+    spformat: str, sparse_matrix_class: scipy.sparse.spmatrix, rng: np.random.Generator
+):
+    """Test whether sparse matrices in different formats can be created."""
+    sparse_mat = random_sparse_spd_matrix(
+        dim=1000, density=10 ** -3, format=spformat, random_state=rng
+    )
+    assert isinstance(sparse_mat, sparse_matrix_class)
 
 
 def test_large_sparse_matrix(rng: np.random.Generator):

--- a/tests/test_problems/test_zoo/test_linalg/test_random_spd_matrix.py
+++ b/tests/test_problems/test_zoo/test_linalg/test_random_spd_matrix.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 import pytest_cases
 import scipy.sparse
-from scipy.sparse.csc import csc_matrix
 
 from probnum.problems.zoo.linalg import random_sparse_spd_matrix, random_spd_matrix
 


### PR DESCRIPTION
# In a Nutshell
With the recent changes to `random_sparse_spd_matrix` in #455 , the function now returns a sparse matrix. However, the input arguments restricting the range of entries in the Cholesky factor was no longer considered and also the output sparsity format was not tested.
