### PR TITLE
Fixed pytest_cases to correct version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ full =
 test =
     pytest>=4.6
     pytest-cov
-    pytest-cases>=3.2.1
+    pytest-cases>=3.5
     # Optional dependencies of ProbNum
     GPy
     matplotlib


### PR DESCRIPTION
# In a Nutshell
#382 introduced test code which necessitates `pytest_cases>=3.5`. See also discussion in #398.