### PR TITLE
Website Navigation Bar Update

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -8,7 +8,7 @@
           <h4>Probabilistic Numerics</h4>
           <ul class="nav flex-column">
             <li class="nav-item">
-              <a class="nav-link" href="{{ pathto('research') }}#probabilistic-numerics-in-a-nutshell">In a Nutshell</a>
+              <a class="nav-link" href="{{ pathto('research') }}#in-a-nutshell">In a Nutshell</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{{ pathto('research/meetings/index') }}">Meetings and Events</a>

--- a/docs/source/_templates/index.html
+++ b/docs/source/_templates/index.html
@@ -23,7 +23,6 @@
                     Get Started 🚀
                 </div>
             </a>
-
         </div>
     </div>
 </div>

--- a/docs/source/research.md
+++ b/docs/source/research.md
@@ -1,11 +1,11 @@
-# Research
+# Probabilistic Numerics
 
 Mathematical models used to explain and predict the behaviour of complex systems such as immune cells or the climate
 rely heavily on numerical methods. The exponential growth in available data and computing power has revolutionized the
 scale of such models. In practice given finite computational resources, this introduces *additional uncertainty* arising
 from not running numerical methods to convergence and from observations corrupted by noise.
 
-## Probabilistic Numerics in a Nutshell
+## In a Nutshell
 
 Probabilistic numerics (PN) [^Hennig2015] [^Oates2019] aims to quantify uncertainty arising from
 intractable or incomplete numerical computation and from stochastic input. This new paradigm which has emerged at the

--- a/docs/source/tutorials/pn_methods.ipynb
+++ b/docs/source/tutorials/pn_methods.ipynb
@@ -35907,7 +35907,7 @@
    "source": [
     "## Advantages of PN Methods\n",
     "\n",
-    "Probabilistic numerical methods have a number of advantages over classical methods, some of which we outline here. For a more exhaustive list, see the [values of the probabilistic approach](../research.md#probabilistic-numerics-in-a-nutshell).\n",
+    "Probabilistic numerical methods have a number of advantages over classical methods, some of which we outline here. For a more exhaustive list, see the [values of the probabilistic approach](../research.md#in-a-nutshell).\n",
     "\n",
     "As we have just seen, the probabilistic inference framework naturally handles stochastic observations of the problem to be solved. Also one can encode more prior knowledge beyond just a guess for the solution of the numerical problem by specifying the degree of certainty in this initial guess."
    ]


### PR DESCRIPTION
# In a Nutshell
Renames the navigation option on the landing page from "Research" to "Probabilistic Numerics".