### PR TITLE
Auto-generate documentation for `probnum.config` options

### DIFF
--- a/docs/source/_ext/probnum-config-options.py
+++ b/docs/source/_ext/probnum-config-options.py
@@ -35,17 +35,15 @@ class ProbNumConfigOptions(SphinxDirective):
         tbody = nodes.tbody("")
         group.append(tbody)
 
-        for key, value in pn.config.__dict__.items():
+        for config_option in pn.config.__dict__.values():
             row = nodes.row("")
             tbody.append(row)
 
-            default_value = value
-            description = (  # TODO: Read this from the configuration registry
-                "A (typically small) value that is per default added to the diagonal "
-                "of covariance matrices in order to make inversion numerically stable."
-            )
+            name = config_option.name
+            default_value = config_option.default_value
+            description = config_option.description
 
-            row.append(nodes.entry("", nodes.literal(text=key)))
+            row.append(nodes.entry("", nodes.literal(text=name)))
             row.append(nodes.entry("", nodes.literal(text=repr(default_value))))
             row.append(nodes.entry("", self._parse_string(description)))
 

--- a/docs/source/_ext/probnum-config-options.py
+++ b/docs/source/_ext/probnum-config-options.py
@@ -10,11 +10,15 @@ class ProbNumConfigOptions(SphinxDirective):
 
     The ``name``s, ``default_value``s, and ``description``s of the pre-defined
     ProbNum configuration options are read and dynamically added to a table in the docs.
-    This plugin avoids maintaining the table in the config docstring manually.
+    This plugin [1]_ avoids maintaining the table in the config docstring manually.
 
     See Also
     --------
     probnum.config : Register and set configs to control specific ProbNum behavior.
+
+    References
+    ----------
+    .. [1] ``https://www.sphinx-doc.org/en/master/development/tutorials/helloworld.html``
     """
 
     def run(self):

--- a/docs/source/_ext/probnum-config-options.py
+++ b/docs/source/_ext/probnum-config-options.py
@@ -35,7 +35,7 @@ class ProbNumConfigOptions(SphinxDirective):
         tbody = nodes.tbody("")
         group.append(tbody)
 
-        for config_option in pn.config.__dict__.values():
+        for config_option in pn.config._options_registry.values():
             row = nodes.row("")
             tbody.append(row)
 

--- a/docs/source/_ext/probnum-config-options.py
+++ b/docs/source/_ext/probnum-config-options.py
@@ -6,6 +6,8 @@ import probnum as pn
 
 
 class ProbNumConfigOptions(SphinxDirective):
+    """Sphinx plugin that automatically generates the docs for ProbNum config options."""
+
     def run(self):
         table = nodes.table(
             "",

--- a/docs/source/_ext/probnum-config-options.py
+++ b/docs/source/_ext/probnum-config-options.py
@@ -11,6 +11,10 @@ class ProbNumConfigOptions(SphinxDirective):
     The ``name``s, ``default_value``s, and ``description``s of the pre-defined
     ProbNum configuration options are read and dynamically added to a table in the docs.
     This plugin avoids maintaining the table in the config docstring manually.
+
+    See Also
+    --------
+    probnum.config : Register and set configs to control specific ProbNum behavior.
     """
 
     def run(self):

--- a/docs/source/_ext/probnum-config-options.py
+++ b/docs/source/_ext/probnum-config-options.py
@@ -6,7 +6,12 @@ import probnum as pn
 
 
 class ProbNumConfigOptions(SphinxDirective):
-    """Sphinx plugin that automatically generates the docs for ProbNum config options."""
+    """Sphinx plugin that automatically generates the docs for ProbNum config options.
+
+    The ``name``s, ``default_value``s, and ``description``s of the pre-defined
+    ProbNum configuration options are read and dynamically added to a table in the docs.
+    This plugin avoids maintaining the table in the config docstring manually.
+    """
 
     def run(self):
         table = nodes.table(

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,8 @@ API Reference
     +-------------------------------------------------+--------------------------------------------------------------+
     | **Subpackage**                                  | **Description**                                              |
     +-------------------------------------------------+--------------------------------------------------------------+
+    | :class:`config <probnum._config.Configuration>` | Global configuration options.                                |
+    +-------------------------------------------------+--------------------------------------------------------------+
     | :mod:`~probnum.diffeq`                          | Probabilistic solvers for ordinary differential equations.   |
     +-------------------------------------------------+--------------------------------------------------------------+
     | :mod:`~probnum.filtsmooth`                      | Bayesian filtering and smoothing.                            |
@@ -29,8 +31,6 @@ API Reference
     +-------------------------------------------------+--------------------------------------------------------------+
     | :mod:`~probnum.utils`                           | Utility functions.                                           |
     +-------------------------------------------------+--------------------------------------------------------------+
-    | :class:`config <probnum._config.Configuration>` | Global configuration options.                                |
-    +-------------------------------------------------+--------------------------------------------------------------+
 
 .. toctree::
     :maxdepth: 2
@@ -38,6 +38,7 @@ API Reference
     :hidden:
 
     api/probnum
+    api/config
     api/diffeq
     api/filtsmooth
     api/kernels
@@ -49,4 +50,3 @@ API Reference
     api/randvars
     api/statespace
     api/utils
-    api/config

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("../src"))
+sys.path.append(os.path.abspath("./_ext"))
 
 # -- General configuration ------------------------------------------------
 
@@ -47,6 +48,7 @@ extensions = [
     "sphinx_gallery.load_style",
     "myst_parser",
     "nbsphinx",
+    "probnum-config-options",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/src/probnum/__init__.py
+++ b/src/probnum/__init__.py
@@ -9,8 +9,6 @@ resources and stochastic input.
 
 from pkg_resources import DistributionNotFound, get_distribution
 
-from . import _config
-
 # Global Configuration
 from ._config import _GLOBAL_CONFIG_SINGLETON as config
 

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -45,8 +45,11 @@ class Configuration:
     def __init__(self) -> None:
         object.__setattr__(self, "_options_registry", dict())
 
+    def __hasattr__(self, key: str) -> bool:
+        return key in self._options_registry
+
     def __getattr__(self, key):
-        if key not in self._options_registry:
+        if not self.__hasattr__(key):
             raise AttributeError(
                 f"getConfiguration entry {key} does not exist yet."
                 "Configuration entries must be `register`ed before they can be "
@@ -55,7 +58,7 @@ class Configuration:
         return self._options_registry[key].value
 
     def __setattr__(self, key: str, value: Any) -> None:
-        if key not in self._options_registry:
+        if not self.__hasattr__(key):
             raise AttributeError(
                 f"setConfiguration entry {key} does not exist yet."
                 "Configuration entries must be `register`ed before they can be "
@@ -69,24 +72,24 @@ class Configuration:
 
     @contextlib.contextmanager
     def __call__(self, **kwargs) -> None:
-        old_entries = dict()
+        old_options = dict()
 
         for key, value in kwargs.items():
-            if key not in self._options_registry:
+            if not self.__hasattr__(key):
                 raise AttributeError(
                     f"Configuration entry {key} does not exist yet."
                     "Configuration entries must be `register`ed before they can be "
                     "accessed."
                 )
 
-            old_entries[key] = getattr(self, key)
+            old_options[key] = getattr(self, key)
 
             setattr(self, key, value)
 
         try:
             yield
         finally:
-            for key, old_value in old_entries.items():
+            for key, old_value in old_options.items():
                 setattr(self, key, old_value)
 
     def register(self, key: str, default_value: Any, description: str) -> None:
@@ -102,7 +105,7 @@ class Configuration:
         description:
             A short description of the configuration option and what it controls.
         """
-        if key in self._options_registry:
+        if self.__hasattr__(key):
             raise KeyError(
                 f"Configuration entry {key} does already exist and "
                 "cannot be registered again."

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -4,19 +4,6 @@ import dataclasses
 from typing import Any
 
 
-@dataclasses.dataclass
-class Option:
-    name: str
-    default_value: Any
-    description: str
-    value: Any
-
-    def __repr__(self) -> str:
-        _r = "<Configuration.Option "
-        _r += f"name={self.name}, value={self.value}>"
-        return _r
-
-
 class Configuration:
     r"""
     Configuration over which some mechanics of ProbNum can be controlled dynamically.
@@ -42,25 +29,34 @@ class Configuration:
     0.01
     """
 
+    @dataclasses.dataclass
+    class Option:
+        name: str
+        default_value: Any
+        description: str
+        value: Any
+
+        def __repr__(self) -> str:
+            _r = "<Configuration.Option "
+            _r += f"name={self.name}, value={self.value}>"
+            return _r
+
     def __init__(self) -> None:
         object.__setattr__(self, "_options_registry", dict())
 
-    def __hasattr__(self, key: str) -> bool:
-        return key in self._options_registry
-
-    def __getattr__(self, key):
-        if not self.__hasattr__(key):
+    def __getattr__(self, key: str) -> Any:
+        if key not in self._options_registry:
             raise AttributeError(
-                f"getConfiguration entry {key} does not exist yet."
+                f"Configuration entry {key} does not exist yet."
                 "Configuration entries must be `register`ed before they can be "
                 "accessed."
             )
         return self._options_registry[key].value
 
     def __setattr__(self, key: str, value: Any) -> None:
-        if not self.__hasattr__(key):
+        if key not in self._options_registry:
             raise AttributeError(
-                f"setConfiguration entry {key} does not exist yet."
+                f"Configuration entry {key} does not exist yet."
                 "Configuration entries must be `register`ed before they can be "
                 "accessed."
             )
@@ -75,7 +71,7 @@ class Configuration:
         old_options = dict()
 
         for key, value in kwargs.items():
-            if not self.__hasattr__(key):
+            if key not in self._options_registry:
                 raise AttributeError(
                     f"Configuration entry {key} does not exist yet."
                     "Configuration entries must be `register`ed before they can be "
@@ -105,12 +101,12 @@ class Configuration:
         description:
             A short description of the configuration option and what it controls.
         """
-        if self.__hasattr__(key):
+        if key in self._options_registry:
             raise KeyError(
                 f"Configuration entry {key} does already exist and "
                 "cannot be registered again."
             )
-        new_config_option = Option(
+        new_config_option = Configuration.Option(
             name=key,
             default_value=default_value,
             description=description,

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -68,6 +68,7 @@ class Configuration:
 
     @contextlib.contextmanager
     def __call__(self, **kwargs) -> None:
+        """Context manager used to set values of registered config options."""
         old_options = dict()
 
         for key, value in kwargs.items():

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -28,6 +28,12 @@ class Configuration:
     0.01
     """
 
+    _NON_REGISTERED_KEY_ERR_MSG = (
+        'Configuration option "%s" does not exist yet. '
+        "Configuration options must be `register`ed before they can be "
+        "accessed."
+    )
+
     @dataclasses.dataclass
     class Option:
         name: str
@@ -45,20 +51,12 @@ class Configuration:
 
     def __getattr__(self, key: str) -> Any:
         if key not in self._options_registry:
-            raise AttributeError(
-                f"Configuration entry {key} does not exist yet."
-                "Configuration entries must be `register`ed before they can be "
-                "accessed."
-            )
+            raise AttributeError(f'Configuration option "{key}" does not exist.')
         return self._options_registry[key].value
 
     def __setattr__(self, key: str, value: Any) -> None:
         if key not in self._options_registry:
-            raise AttributeError(
-                f"Configuration entry {key} does not exist yet."
-                "Configuration entries must be `register`ed before they can be "
-                "accessed."
-            )
+            raise AttributeError(Configuration._NON_REGISTERED_KEY_ERR_MSG % key)
 
         self._options_registry[key].value = value
 
@@ -71,11 +69,7 @@ class Configuration:
 
         for key, value in kwargs.items():
             if key not in self._options_registry:
-                raise AttributeError(
-                    f"Configuration entry {key} does not exist yet."
-                    "Configuration entries must be `register`ed before they can be "
-                    "accessed."
-                )
+                raise AttributeError(Configuration._NON_REGISTERED_KEY_ERR_MSG % key)
 
             old_options[key] = getattr(self, key)
 
@@ -102,7 +96,7 @@ class Configuration:
         """
         if key in self._options_registry:
             raise KeyError(
-                f"Configuration entry {key} does already exist and "
+                f"Configuration option {key} does already exist and "
                 "cannot be registered again."
             )
         new_config_option = Configuration.Option(

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -71,15 +71,15 @@ class Configuration:
             if key not in self._options_registry:
                 raise AttributeError(Configuration._NON_REGISTERED_KEY_ERR_MSG % key)
 
-            old_options[key] = getattr(self, key)
+            old_options[key] = self._options_registry[key].value
 
-            setattr(self, key, value)
+            self._options_registry[key].value = value
 
         try:
             yield
         finally:
             for key, old_value in old_options.items():
-                setattr(self, key, old_value)
+                self._options_registry[key].value = old_value
 
     def register(self, key: str, default_value: Any, description: str) -> None:
         r"""Register a new configuration option.

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -12,16 +12,7 @@ class Configuration:
     :meth:`register`. Configuration entries can only be registered once and can only
     be used (accessed or overwritten) once they have been registered.
 
-    +----------------------------------+---------------+----------------------------------------------+
-    | Config entry                     | Default value | Description                                  |
-    +==================================+===============+==============================================+
-    | ``covariance_inversion_damping`` | ``1e-12``     | A (typically small) value that is per        |
-    |                                  |               | default added to the diagonal of covariance  |
-    |                                  |               | matrices in order to make inversion          |
-    |                                  |               | numerically stable.                          |
-    +----------------------------------+---------------+----------------------------------------------+
-    | ``...``                          | ``...``       | ...                                          |
-    +----------------------------------+---------------+----------------------------------------------+
+    .. probnum-config-options::
 
     Examples
     ========

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -1,5 +1,4 @@
 import contextlib
-import copy
 import dataclasses
 from typing import Any
 

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -47,6 +47,9 @@ class Configuration:
             return _r
 
     def __init__(self) -> None:
+        # This is the equivalent of `self._options_registry = dict()`.
+        # After rewriting the `__setattr__` method, we have to fall back on the
+        # `__setattr__` method of the super class.
         object.__setattr__(self, "_options_registry", dict())
 
     def __getattr__(self, key: str) -> Any:

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -1,9 +1,24 @@
 import contextlib
+import copy
+import dataclasses
 from typing import Any
 
 
+@dataclasses.dataclass
+class Option:
+    name: str
+    default_value: Any
+    description: str
+    value: Any
+
+    def __repr__(self) -> str:
+        _r = "<Configuration.Option "
+        _r += f"name={self.name}, value={self.value}>"
+        return _r
+
+
 class Configuration:
-    """
+    r"""
     Configuration over which some mechanics of ProbNum can be controlled dynamically.
 
     ProbNum provides some configurations together with default values. These
@@ -27,13 +42,38 @@ class Configuration:
     0.01
     """
 
+    def __init__(self) -> None:
+        object.__setattr__(self, "_options_registry", dict())
+
+    def __getattr__(self, key):
+        if key not in self._options_registry:
+            raise AttributeError(
+                f"getConfiguration entry {key} does not exist yet."
+                "Configuration entries must be `register`ed before they can be "
+                "accessed."
+            )
+        return self._options_registry[key].value
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key not in self._options_registry:
+            raise AttributeError(
+                f"setConfiguration entry {key} does not exist yet."
+                "Configuration entries must be `register`ed before they can be "
+                "accessed."
+            )
+
+        self._options_registry[key].value = value
+
+    def __repr__(self) -> str:
+        return repr(self._options_registry)
+
     @contextlib.contextmanager
     def __call__(self, **kwargs) -> None:
         old_entries = dict()
 
         for key, value in kwargs.items():
-            if not hasattr(self, key):
-                raise KeyError(
+            if key not in self._options_registry:
+                raise AttributeError(
                     f"Configuration entry {key} does not exist yet."
                     "Configuration entries must be `register`ed before they can be "
                     "accessed."
@@ -46,20 +86,11 @@ class Configuration:
         try:
             yield
         finally:
-            self.__dict__.update(old_entries)
+            for key, old_value in old_entries.items():
+                setattr(self, key, old_value)
 
-    def __setattr__(self, key: str, value: Any) -> None:
-        if not hasattr(self, key):
-            raise KeyError(
-                f"Configuration entry {key} does not exist yet."
-                "Configuration entries must be `register`ed before they can be "
-                "accessed."
-            )
-
-        self.__dict__[key] = value
-
-    def register(self, key: str, default_value: Any) -> None:
-        """Register new configuration option.
+    def register(self, key: str, default_value: Any, description: str) -> None:
+        r"""Register a new configuration option.
 
         Parameters
         ----------
@@ -68,13 +99,21 @@ class Configuration:
             ``with config(key=<some_value>): ...``.
         default_value:
             The default value of the configuration option.
+        description:
+            A short description of the configuration option and what it controls.
         """
-        if hasattr(self, key):
+        if key in self._options_registry:
             raise KeyError(
                 f"Configuration entry {key} does already exist and "
                 "cannot be registered again."
             )
-        self.__dict__[key] = default_value
+        new_config_option = Option(
+            name=key,
+            default_value=default_value,
+            description=description,
+            value=default_value,
+        )
+        self._options_registry[key] = new_config_option
 
 
 # Create a single, global configuration object,...
@@ -84,9 +123,16 @@ _GLOBAL_CONFIG_SINGLETON = Configuration()
 # (which have to be documented in the Configuration-class docstring!!), ...
 _DEFAULT_CONFIG_OPTIONS = [
     # list of tuples (config_key, default_value)
-    ("covariance_inversion_damping", 1e-12),
+    (
+        "covariance_inversion_damping",
+        1e-12,
+        (
+            "A (typically small) value that is per default added to the diagonal "
+            "of covariance matrices in order to make inversion numerically stable."
+        ),
+    ),
 ]
 
 # ... and register the default configuration options.
-for key, default_value in _DEFAULT_CONFIG_OPTIONS:
-    _GLOBAL_CONFIG_SINGLETON.register(key, default_value)
+for key, default_value, descr in _DEFAULT_CONFIG_OPTIONS:
+    _GLOBAL_CONFIG_SINGLETON.register(key, default_value, descr)

--- a/src/probnum/randvars/_normal.py
+++ b/src/probnum/randvars/_normal.py
@@ -248,8 +248,8 @@ class Normal(_random_variable.ContinuousRandomVariable[_ValueType]):
         damping_factor: Optional[FloatArgType] = None,
     ):
         """(P)recompute Cholesky factors (careful: in-place operation!)."""
-        if True:
-            damping_factor = 1e-12
+        if damping_factor is None:
+            damping_factor = config.covariance_inversion_damping
         if self.cov_cholesky_is_precomputed:
             raise Exception("A Cholesky factor is already available.")
         self._cov_cholesky = self._compute_cov_cholesky(damping_factor=damping_factor)
@@ -459,8 +459,8 @@ class Normal(_random_variable.ContinuousRandomVariable[_ValueType]):
     ) -> np.ndarray:
         """Compute the Cholesky factorization of the covariance from its dense
         representation."""
-        if True:
-            damping_factor = 1e-12
+        if damping_factor is None:
+            damping_factor = config.covariance_inversion_damping
         dense_cov = self.dense_cov
 
         return scipy.linalg.cholesky(

--- a/src/probnum/randvars/_normal.py
+++ b/src/probnum/randvars/_normal.py
@@ -248,8 +248,8 @@ class Normal(_random_variable.ContinuousRandomVariable[_ValueType]):
         damping_factor: Optional[FloatArgType] = None,
     ):
         """(P)recompute Cholesky factors (careful: in-place operation!)."""
-        if damping_factor is None:
-            damping_factor = config.covariance_inversion_damping
+        if True:
+            damping_factor = 1e-12
         if self.cov_cholesky_is_precomputed:
             raise Exception("A Cholesky factor is already available.")
         self._cov_cholesky = self._compute_cov_cholesky(damping_factor=damping_factor)
@@ -459,8 +459,8 @@ class Normal(_random_variable.ContinuousRandomVariable[_ValueType]):
     ) -> np.ndarray:
         """Compute the Cholesky factorization of the covariance from its dense
         representation."""
-        if damping_factor is None:
-            damping_factor = config.covariance_inversion_damping
+        if True:
+            damping_factor = 1e-12
         dense_cov = self.dense_cov
 
         return scipy.linalg.cholesky(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ def test_defaults():
 def test_register():
     # Check if registering a new config entry works
     probnum.config.register("some_config", 3.14, "Dummy description.")
+    assert hasattr(probnum.config, "some_config")
     assert probnum.config.some_config == 3.14
 
     # When registering a new entry with an already existing name, throw

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,9 +5,9 @@ from probnum._config import _DEFAULT_CONFIG_OPTIONS
 
 
 def test_defaults():
-    none_vals = {key: None for (key, _) in _DEFAULT_CONFIG_OPTIONS}
+    none_vals = {key: None for (key, _, _) in _DEFAULT_CONFIG_OPTIONS}
 
-    for key, default_val in _DEFAULT_CONFIG_OPTIONS:
+    for key, default_val, _ in _DEFAULT_CONFIG_OPTIONS:
         # Check if default is correct before context manager
         assert getattr(probnum.config, key) == default_val
         # Temporarily set all config values to None
@@ -21,12 +21,12 @@ def test_defaults():
 
 def test_register():
     # Check if registering a new config entry works
-    probnum.config.register("some_config", 3.14)
+    probnum.config.register("some_config", 3.14, "Dummy description.")
     assert probnum.config.some_config == 3.14
 
     # When registering a new entry with an already existing name, throw
     with pytest.raises(KeyError):
-        probnum.config.register("some_config", 4.2)
+        probnum.config.register("some_config", 4.2, "Dummy description.")
 
     # Check if temporarily setting the config entry to a different value (via
     # the context manager) works
@@ -43,10 +43,10 @@ def test_register():
 
     # Setting a config entry before registering it, does not work. Neither via
     # the context manager ...
-    with pytest.raises(KeyError):
+    with pytest.raises(AttributeError):
         with probnum.config(unknown_config=False):
             pass
 
     # ... nor by accessing the attribute directly.
-    with pytest.raises(KeyError):
+    with pytest.raises(AttributeError):
         probnum.config.unknown_config = False


### PR DESCRIPTION
# In a Nutshell
This PR implements a custom Sphinx extension which generates a table documenting the available configuration options automatically.

# Detailed Description
- [x] Sphinx extension generating configuration option documentation automatically
- [x] add per-option docstrings to `probnum.config` via a required (?) `docstring` argument in the `register` method
- [x] store configuration options as inner dataclasses `Configuration.Option` with fields `key`, `value`, `default_value`, and ~`docstring`~ `description`
- ~[ ] add iterator over registered `Configuration.Option`s~