### PR TITLE
Bugfix: Deploy to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,4 +27,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m build
-          twine upload dist/*-py3-none-any.whl
+          twine upload dist/*py3-none-any.whl


### PR DESCRIPTION
# In a Nutshell
This PR fixes a bug in the glob pattern used to upload ProbNum wheels to PyPI.

# Detailed Description
See above.

# Related Issues
None
