### PR TITLE
fix rendering of formula in linsolver quickstart

### DIFF
--- a/docs/source/tutorials/linalg/linear_solvers_quickstart.ipynb
+++ b/docs/source/tutorials/linalg/linear_solvers_quickstart.ipynb
@@ -52,6 +52,7 @@
     "$$\n",
     "A \\mathbf{x} = \\mathbf{b}\n",
     "$$\n",
+    "\n",
     "where $A\\in\\mathbb{R}^{n\\times n}$ is a symmetric positive definite matrix, $\\mathbf{b}\\in\\mathbb{R}^n$ is a vector and $\\mathbf{x}\\in\\mathbb{R}^n$ is the unknown solution of the linear system. \n",
     "\n",
     "Solving such a linear system is arguably one of the most fundamental computations in statistics, machine learning and scientific computation. Many problems can be reduced to the solution of one or many (large-scale) linear systems. Some examples include least-squares regression, kernel methods, second-order optimization, quadratic programming, Kalman filtering, linear differential equations and all Gaussian (process) inference. Here, we will solve such a system using one of ProbNum' *probabilistic linear solvers*.\n"


### PR DESCRIPTION
# In a Nutshell
One formula does not render correctly it seems in the docs corresponding to notebook introduced in PR #511 . In the initial PR, the notebook looked OK when building the page locally, so no entirely sure if this PR will fix it (although I suspect it will). 

# Detailed Description
Added a blank line in the Markdown cell with the LaTeX formula.

# Related Issues
Closes #...
