### PR TITLE
Scale the ODE filter error estimate with the current step size

### DIFF
--- a/src/probnum/diffeq/odefilter/_odefilter.py
+++ b/src/probnum/diffeq/odefilter/_odefilter.py
@@ -230,7 +230,7 @@ class ODEFilter(_odesolver.ODESolver):
         # Appending or not appending the diffusion (and because the computations below
         # are sufficiently costly such that skipping them here will have a positive impact).
         internal_norm = self.steprule.errorest_to_norm(
-            errorest=local_errors,
+            errorest=dt * local_errors,
             reference_state=reference_values,
         )
 


### PR DESCRIPTION
# In a Nutshell
To solve stiff ODEs, the local error estimate needs to be scaled with the step size.

# Detailed Description
I found that the current version of the EK1 was not able to solve the stiff Van-der-Pol problem as formulated here:
https://diffeq.sciml.ai/stable/types/ode_types/#DiffEqProblemLibrary.ODEProblemLibrary.prob_ode_vanstiff.
With this PR, solving this problem becomes possible.

Maybe I should add a test that makes sure that this capability is not lost in the future, e.g. solving VdP on a very small time span. But I first need to find such a setting that does not take too much time to solve, while also being a problem that did not work before, but does now. I'm open for suggestions and edits of this PR :) 