### PR TITLE
Update `apt` cache in Github action running notebooks

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          sudo apt-get update
           sudo apt-get install $(cat apt.txt)
           pip install -r docs/requirements.txt
           pip install .

--- a/docs/source/research/bibliography/related.bib
+++ b/docs/source/research/bibliography/related.bib
@@ -57,33 +57,6 @@
                   optimization in high-dimensional spaces.}
 }
 
-@article{HennigS2012,
-  title =	 {Entropy Search for Information-Efficient Global Optimization},
-  author =	 {Hennig, P. and Schuler, CJ.},
-  month =	 jun,
-  volume =	 13,
-  pages =	 {1809-1837},
-  abstract =	 {Contemporary global optimization algorithms are based on
-                  local measures of utility, rather than a probability measure
-                  over location and value of the optimum. They thus attempt to
-                  collect low function values, not to learn about the
-                  optimum. The reason for the absence of probabilistic global
-                  optimizers is that the corresponding inference problem is
-                  intractable in several ways. This paper develops desiderata
-                  for probabilistic optimization algorithms, then presents a
-                  concrete algorithm which addresses each of the computational
-                  intractabilities with a sequence of approximations and
-                  explicitly adresses the decision problem of maximizing
-                  information gain from each evaluation. },
-  journal =	 {Journal of Machine Learning Research},
-  year =	 2012,
-  file =
-                  {http://jmlr.csail.mit.edu/papers/volume13/hennig12a/hennig12a.pdf},
-  link =	 {http://jmlr.csail.mit.edu/papers/v13/hennig12a.html},
-  code = {http://probabilistic-optimization.org/Global.html}
-}
-
-
 @article{garrabrant,
       author =   {Scott Garrabrant and Tsvi Benson-Tilsen and Andrew Critch and Nate Soares and Jessica Taylor},
       title =  {Logical Induction},


### PR DESCRIPTION
# In a Nutshell
The Github Action running the notebooks kept failing. This bug is likely caused by an outdated `apt` cache. This PR adds `sudo apt-get update` to the action.

# Detailed Description
The Github Action running the notebooks displayed the following error:

```bash
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/ghostscript/libgs9-common_9.50~dfsg-5ubuntu4.2_all.deb  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/ghostscript/libgs9_9.50~dfsg-5ubuntu4.2_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/ghostscript/ghostscript_9.50~dfsg-5ubuntu4.2_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

The fix is based on this suggestion: https://askubuntu.com/questions/519539/failed-to-fetch-http-security-ubuntu-com-ubuntu-pool-main-e-eglibc-libc-bin-2