### PR TITLE
Fixed Python version for Github action running Jupyter notebooks

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# In a Nutshell
Sets the Python version with which the Jupyter notebooks are run to 3.9 in the Github action.

# Detailed Description
Builds in the CI recently started failing with the following error message:

<details>
  <summary>Show full error message.</summary>
  
```bash
Run for file in $(find -wholename "./docs/source/**/*.ipynb" -not -path "**/.ipynb_checkpoints/*")
[NbConvertApp] Converting notebook ./docs/source/tutorials/quickstart.ipynb to notebook
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.0/x64/bin/jupyter-nbconvert", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/jupyter_core/application.py", line 264, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/traitlets/config/application.py", line 846, in launch_instance
    app.start()
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/nbconvertapp.py", line 361, in start
    self.convert_notebooks()
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/nbconvertapp.py", line 533, in convert_notebooks
    self.convert_single_notebook(notebook_filename)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/nbconvertapp.py", line 498, in convert_single_notebook
    output, resources = self.export_single_notebook(notebook_filename, resources, input_buffer=input_buffer)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/nbconvertapp.py", line 427, in export_single_notebook
    output, resources = self.exporter.from_filename(notebook_filename, resources=resources)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/exporters/exporter.py", line 181, in from_filename
    return self.from_file(f, resources=resources, **kw)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/exporters/exporter.py", line 199, in from_file
    return self.from_notebook_node(nbformat.read(file_stream, as_version=4), resources=resources, **kw)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/exporters/notebook.py", line 32, in from_notebook_node
    nb_copy, resources = super().from_notebook_node(nb, resources, **kw)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/exporters/exporter.py", line 143, in from_notebook_node
    nb_copy, resources = self._preprocess(nb_copy, resources)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/exporters/exporter.py", line 318, in _preprocess
    nbc, resc = preprocessor(nbc, resc)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/preprocessors/base.py", line 47, in __call__
    return self.preprocess(nb, resources)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/preprocessors/execute.py", line 84, in preprocess
    self.preprocess_cell(cell, resources, index)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbconvert/preprocessors/execute.py", line 105, in preprocess_cell
    cell = self.execute_cell(cell, index, store_history=True)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbclient/util.py", line 78, in wrapped
    return just_run(coro(*args, **kwargs))
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbclient/util.py", line 57, in just_run
    return loop.run_until_complete(coro)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/asyncio/base_events.py", line 641, in run_until_complete
    return future.result()
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbclient/client.py", line 862, in async_execute_cell
    self._check_raise_for_error(cell, exec_reply)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/nbclient/client.py", line 765, in _check_raise_for_error
    raise CellExecutionError.from_cell_and_msg(cell, exec_reply_content)
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
------------------
import probnum as pn

# Solve for x using ProbNum
x_rv, _, _, _ = pn.linalg.problinsolve(A, b)
print(x_rv.mean)
------------------

---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
/tmp/ipykernel_12543/648192982.py in <module>
----> 1 import probnum as pn
      2 
      3 # Solve for x using ProbNum
      4 x_rv, _, _, _ = pn.linalg.problinsolve(A, b)
      5 print(x_rv.mean)

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/probnum/__init__.py in <module>
     18 # isort: on
     19 
---> 20 from . import (
     21     diffeq,
     22     filtsmooth,

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/probnum/diffeq/__init__.py in <module>
      9 #     solver = diffeq.perturbed.step.PerturbedStepSolver(...)
     10 # does not work.
---> 11 from . import perturbed
     12 from ._odesolution import ODESolution
     13 from ._odesolver import ODESolver

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/probnum/diffeq/perturbed/__init__.py in <module>
      1 """Perturbation-based solvers."""
      2 
----> 3 from . import step

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/probnum/diffeq/perturbed/step/__init__.py in <module>
      2 
      3 from ._perturbation_functions import perturb_lognormal, perturb_uniform
----> 4 from ._perturbedstepsolution import PerturbedStepSolution
      5 from ._perturbedstepsolver import PerturbedStepSolver
      6 

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/probnum/diffeq/perturbed/step/_perturbedstepsolution.py in <module>
      4 
      5 import numpy as np
----> 6 from scipy.integrate._ivp import rk
      7 
      8 from probnum import _randomvariablelist, randvars

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/integrate/__init__.py in <module>
     92 from .quadpack import *
     93 from ._ode import *
---> 94 from ._bvp import solve_bvp
     95 from ._ivp import (solve_ivp, OdeSolution, DenseOutput,
     96                    OdeSolver, RK23, RK45, DOP853, Radau, BDF, LSODA)

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/integrate/_bvp.py in <module>
      7 from scipy.sparse import coo_matrix, csc_matrix
      8 from scipy.sparse.linalg import splu
----> 9 from scipy.optimize import OptimizeResult
     10 
     11 

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/optimize/__init__.py in <module>
    419                            Bounds)
    420 from ._hessian_update_strategy import HessianUpdateStrategy, BFGS, SR1
--> 421 from ._shgo import shgo
    422 from ._dual_annealing import dual_annealing
    423 from ._qap import quadratic_assignment

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/optimize/_shgo.py in <module>
      7 import logging
      8 import warnings
----> 9 from scipy import spatial
     10 from scipy.optimize import OptimizeResult, minimize
     11 from scipy.optimize._shgo_lib import sobol_seq

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/spatial/__init__.py in <module>
    105 __all__ += ['distance', 'transform']
    106 
--> 107 from . import distance, transform
    108 
    109 from scipy._lib._testutils import PytestTester

/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/spatial/transform/__init__.py in <module>
     17    RotationSpline
     18 """
---> 19 from .rotation import Rotation, Slerp
     20 from ._rotation_spline import RotationSpline
     21 

ImportError: /opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/spatial/transform/rotation.cpython-310-x86_64-linux-gnu.so: undefined symbol: _PyGen_Send
ImportError: /opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/scipy/spatial/transform/rotation.cpython-310-x86_64-linux-gnu.so: undefined symbol: _PyGen_Send

Error: Process completed with exit code 1.
```
</details>

Github actions was running the notebooks with Python 3.10, however `scipy.spatial` makes use of Cython, which [does not yet support Python 3.10](https://github.com/cython/cython/issues/3876).

