### PR TITLE
Rename `lazy_linalg` config option `matrix_free`

### DIFF
--- a/benchmarks/randprocs.py
+++ b/benchmarks/randprocs.py
@@ -8,11 +8,11 @@ from probnum import config, linops, randprocs, randvars
 class MarkovProcessSampling:
     """Benchmark sampling from Markov processes."""
 
-    param_names = ["lazy_linalg", "len_trajectory", "num_derivatives", "dimension"]
+    param_names = ["matrix_free", "len_trajectory", "num_derivatives", "dimension"]
     params = [[True, False], [10], [5], [50, 100]]
 
-    def setup(self, lazy_linalg, len_trajectory, num_derivatives, dimension):
-        with config(lazy_linalg=lazy_linalg):
+    def setup(self, matrix_free, len_trajectory, num_derivatives, dimension):
+        with config(matrix_free=matrix_free):
 
             dynamics = randprocs.markov.integrator.IntegratedWienerTransition(
                 num_derivatives=num_derivatives,
@@ -39,8 +39,8 @@ class MarkovProcessSampling:
                 random_state=rng,
             )
 
-    def time_sample(self, lazy_linalg, len_trajectory, num_derivatives, dimension):
-        with config(lazy_linalg=lazy_linalg):
+    def time_sample(self, matrix_free, len_trajectory, num_derivatives, dimension):
+        with config(matrix_free=matrix_free):
             self.markov_process.transition.jointly_transform_base_measure_realization_list_forward(
                 base_measure_realizations=self.base_measure_realization,
                 t=self.time_grid,

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -127,12 +127,11 @@ _DEFAULT_CONFIG_OPTIONS = [
         ),
     ),
     (
-        "lazy_linalg",
+        "matrix_free",
         False,
         (
             "If True, wherever possible, LinearOperators are used instead "
-            "of Numpy arrays. LinearOperators provide lazy arithmetic and "
-            "thus memory- and runtime-efficient linear algebra operations."
+            "of arrays. LinearOperators define a matrix-vector product implicitly without instantiating the full matrix in memory. This makes them memory- and runtime-efficient for linear algebra operations."
         ),
     ),
 ]

--- a/src/probnum/randprocs/markov/discrete/_linear_gaussian.py
+++ b/src/probnum/randprocs/markov/discrete/_linear_gaussian.py
@@ -82,11 +82,11 @@ class LinearGaussian(_nonlinear_gaussian.NonlinearGaussian):
 
     def forward_rv(self, rv, t, compute_gain=False, _diffusion=1.0, **kwargs):
 
-        if config.lazy_linalg and not isinstance(rv.cov, linops.LinearOperator):
+        if config.matrix_free and not isinstance(rv.cov, linops.LinearOperator):
             warnings.warn(
                 (
                     "`forward_rv()` received np.ndarray as covariance, while "
-                    "`config.lazy_linalg` is set to `True`. This might lead "
+                    "`config.matrix_free` is set to `True`. This might lead "
                     "to unexpected behavior regarding data types."
                 ),
                 RuntimeWarning,
@@ -116,14 +116,14 @@ class LinearGaussian(_nonlinear_gaussian.NonlinearGaussian):
         **kwargs,
     ):
 
-        if config.lazy_linalg and not (
+        if config.matrix_free and not (
             isinstance(rv.cov, linops.LinearOperator)
             and isinstance(rv_obtained.cov, linops.LinearOperator)
         ):
             warnings.warn(
                 (
                     "`backward_rv()` received np.ndarray as covariance, while "
-                    "`config.lazy_linalg` is set to `True`. This might lead "
+                    "`config.matrix_free` is set to `True`. This might lead "
                     "to unexpected behavior regarding data types."
                 ),
                 RuntimeWarning,
@@ -172,7 +172,7 @@ class LinearGaussian(_nonlinear_gaussian.NonlinearGaussian):
         new_cov = H @ crosscov + _diffusion * R
         info = {"crosscov": crosscov}
         if compute_gain:
-            if config.lazy_linalg:
+            if config.matrix_free:
                 gain = (new_cov.T.inv() @ crosscov.T).T
             else:
                 gain = scipy.linalg.solve(new_cov.T, crosscov.T, assume_a="sym").T
@@ -183,7 +183,7 @@ class LinearGaussian(_nonlinear_gaussian.NonlinearGaussian):
         self, rv, t, compute_gain=False, _diffusion=1.0
     ) -> Tuple[randvars.RandomVariable, typing.Dict]:
 
-        if config.lazy_linalg:
+        if config.matrix_free:
             raise NotImplementedError(
                 "Sqrt-implementation does not work with linops for now."
             )
@@ -223,7 +223,7 @@ class LinearGaussian(_nonlinear_gaussian.NonlinearGaussian):
         """
         # forwarded_rv is ignored in square-root smoothing.
 
-        if config.lazy_linalg:
+        if config.matrix_free:
             raise NotImplementedError(
                 "Sqrt-implementation does not work with linops for now."
             )

--- a/src/probnum/randprocs/markov/integrator/_iwp.py
+++ b/src/probnum/randprocs/markov/integrator/_iwp.py
@@ -137,7 +137,7 @@ class IntegratedWienerTransition(_integrator.IntegratorTransition, continuous.LT
     @cached_property
     def _drift_matrix(self):
         drift_matrix_1d = np.diag(np.ones(self.num_derivatives), 1)
-        if config.lazy_linalg:
+        if config.matrix_free:
             return linops.Kronecker(
                 A=linops.Identity(self.wiener_process_dimension),
                 B=linops.Matrix(A=drift_matrix_1d),
@@ -153,7 +153,7 @@ class IntegratedWienerTransition(_integrator.IntegratorTransition, continuous.LT
         dispersion_matrix_1d = np.zeros(self.num_derivatives + 1)
         dispersion_matrix_1d[-1] = 1.0  # Unit diffusion
 
-        if config.lazy_linalg:
+        if config.matrix_free:
             return linops.Kronecker(
                 A=linops.Identity(self.wiener_process_dimension),
                 B=linops.Matrix(A=dispersion_matrix_1d.reshape(-1, 1)),
@@ -174,7 +174,7 @@ class IntegratedWienerTransition(_integrator.IntegratorTransition, continuous.LT
         state_transition_1d = np.flip(
             scipy.linalg.pascal(self.num_derivatives + 1, kind="lower", exact=False)
         )
-        if config.lazy_linalg:
+        if config.matrix_free:
             state_transition = linops.Kronecker(
                 A=linops.Identity(self.wiener_process_dimension),
                 B=linops.aslinop(state_transition_1d),
@@ -184,7 +184,7 @@ class IntegratedWienerTransition(_integrator.IntegratorTransition, continuous.LT
                 np.eye(self.wiener_process_dimension), state_transition_1d
             )
         process_noise_1d = np.flip(scipy.linalg.hilbert(self.num_derivatives + 1))
-        if config.lazy_linalg:
+        if config.matrix_free:
             process_noise = linops.Kronecker(
                 A=linops.Identity(self.wiener_process_dimension),
                 B=linops.aslinop(process_noise_1d),
@@ -198,7 +198,7 @@ class IntegratedWienerTransition(_integrator.IntegratorTransition, continuous.LT
         )
 
         process_noise_cholesky_1d = np.linalg.cholesky(process_noise_1d)
-        if config.lazy_linalg:
+        if config.matrix_free:
             process_noise_cholesky = linops.Kronecker(
                 A=linops.Identity(self.wiener_process_dimension),
                 B=linops.aslinop(process_noise_cholesky_1d),

--- a/src/probnum/randprocs/markov/integrator/_preconditioner.py
+++ b/src/probnum/randprocs/markov/integrator/_preconditioner.py
@@ -79,7 +79,7 @@ class NordsieckLikeCoordinates(Preconditioner):
 
     def __call__(self, step):
         scaling_vector = np.abs(step) ** self.powers / self.scales
-        if config.lazy_linalg:
+        if config.matrix_free:
             return linops.Kronecker(
                 A=linops.Identity(self.dimension),
                 B=linops.Scaling(factors=scaling_vector),

--- a/src/probnum/randvars/_constant.py
+++ b/src/probnum/randvars/_constant.py
@@ -73,7 +73,7 @@ class Constant(_random_variable.DiscreteRandomVariable[_ValueType]):
             np.promote_types(self._support.dtype, np.float_)
         )
 
-        if config.lazy_linalg:
+        if config.matrix_free:
             cov = lambda: (
                 linops.Scaling(
                     0.0,

--- a/tests/test_randprocs/test_markov/test_discrete/test_linear_gaussian.py
+++ b/tests/test_randprocs/test_markov/test_discrete/test_linear_gaussian.py
@@ -257,7 +257,7 @@ class TestLinearGaussianLinOps:
         spdmat1,
         spdmat2,
     ):
-        with config(lazy_linalg=True):
+        with config(matrix_free=True):
             self.G = lambda t: linops.aslinop(spdmat1)
             self.S = lambda t: linops.aslinop(spdmat2)
             self.v = lambda t: np.arange(test_ndim)
@@ -302,7 +302,7 @@ class TestLinearGaussianLinOps:
         linop_cov_rv = randvars.Normal(
             array_cov_rv.mean.copy(), linops.aslinop(array_cov_rv.cov)
         )
-        with config(lazy_linalg=True):
+        with config(matrix_free=True):
             with pytest.warns(RuntimeWarning):
                 self.transition.forward_rv(array_cov_rv, 0.0)
 
@@ -325,7 +325,7 @@ class TestLinearGaussianLinOps:
         linop_cov_rv2 = randvars.Normal(
             array_cov_rv2.mean.copy(), linops.aslinop(array_cov_rv2.cov)
         )
-        with config(lazy_linalg=True):
+        with config(matrix_free=True):
             with pytest.warns(RuntimeWarning):
                 self.transition.backward_rv(array_cov_rv1, array_cov_rv2)
             with pytest.warns(RuntimeWarning):
@@ -344,7 +344,7 @@ class TestLinearGaussianLinOps:
                 self.sqrt_transition.backward_rv(linop_cov_rv1, linop_cov_rv2)
 
     def test_backward_realization(self, some_normal_rv1, some_normal_rv2):
-        with config(lazy_linalg=True):
+        with config(matrix_free=True):
             array_cov_rv = some_normal_rv2
             linop_cov_rv = randvars.Normal(
                 array_cov_rv.mean.copy(), linops.aslinop(array_cov_rv.cov)

--- a/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
+++ b/tests/test_randprocs/test_markov/test_integrator/test_iwp.py
@@ -116,7 +116,7 @@ class TestIBMLinOps(test_lti_sde.TestLTISDE, test_integrator.TestIntegratorTrans
     ):
         self.some_num_derivatives = some_num_derivatives
         spatialdim = 1  # make tests compatible with some_normal_rv1, etc.
-        with config(lazy_linalg=True):
+        with config(matrix_free=True):
             self.transition = randprocs.markov.integrator.IntegratedWienerTransition(
                 num_derivatives=self.some_num_derivatives,
                 wiener_process_dimension=spatialdim,

--- a/tests/test_randvars/test_constant.py
+++ b/tests/test_randvars/test_constant.py
@@ -30,10 +30,10 @@ class TestConstant(unittest.TestCase):
         # Ignore scalar support, because in this case, LinOps make no sense.
         for supp in self.supports[1:]:
             with self.subTest():
-                with config(lazy_linalg=True):
+                with config(matrix_free=True):
                     rv_lo = randvars.Constant(support=supp)
                     assert isinstance(rv_lo.cov, linops.LinearOperator)
-                with config(lazy_linalg=False):
+                with config(matrix_free=False):
                     rv_de = randvars.Constant(support=supp)
                     assert isinstance(rv_de.cov, np.ndarray)
 

--- a/tests/test_randvars/test_normal.py
+++ b/tests/test_randvars/test_normal.py
@@ -419,9 +419,8 @@ class UnivariateNormalTestCase(unittest.TestCase, NumpyAssertions):
     def test_cov_cholesky_cov_cholesky_not_passed(self):
         """No cov_cholesky is passed in init.
 
-        In this case, the "is_precomputed" flag is False, a cov_cholesky
-        is computed on demand, but can also be computed manually with
-        any damping factor.
+        In this case, the "is_precomputed" flag is False, a cov_cholesky is computed on
+        demand, but can also be computed manually with any damping factor.
         """
         mean, cov = self.params
         rv = randvars.Normal(mean, cov)
@@ -471,9 +470,9 @@ class UnivariateNormalTestCase(unittest.TestCase, NumpyAssertions):
     def test_cov_cholesky_cov_cholesky_passed(self):
         """A value for cov_cholesky is passed in init.
 
-        In this case, the "is_precomputed" flag is True, the
-        cov_cholesky returns the argument that has been passed, but
-        (p)recomputing overwrites the argument with a new factor.
+        In this case, the "is_precomputed" flag is True, the cov_cholesky returns the
+        argument that has been passed, but (p)recomputing overwrites the argument with a
+        new factor.
         """
         mean, cov = self.params
 
@@ -551,9 +550,8 @@ class MultivariateNormalTestCase(unittest.TestCase, NumpyAssertions):
     def test_cov_cholesky_cov_cholesky_not_passed(self):
         """No cov_cholesky is passed in init.
 
-        In this case, the "is_precomputed" flag is False, a cov_cholesky
-        is computed on demand, but can also be computed manually with
-        any damping factor.
+        In this case, the "is_precomputed" flag is False, a cov_cholesky is computed on
+        demand, but can also be computed manually with any damping factor.
         """
         mean, cov = self.params
 
@@ -577,7 +575,7 @@ class MultivariateNormalTestCase(unittest.TestCase, NumpyAssertions):
             self.assertFalse(rv.cov_cholesky_is_precomputed)
 
         with self.subTest("Damping factor check"):
-            with config(lazy_linalg=False):
+            with config(matrix_free=False):
                 rv.precompute_cov_cholesky(damping_factor=10.0)
                 self.assertIsInstance(rv.cov_cholesky, np.ndarray)
                 self.assertAllClose(
@@ -596,7 +594,7 @@ class MultivariateNormalTestCase(unittest.TestCase, NumpyAssertions):
             self.assertFalse(rv.cov_cholesky_is_precomputed)
 
         with self.subTest("Damping factor check"):
-            with config(lazy_linalg=True):
+            with config(matrix_free=True):
                 rv.precompute_cov_cholesky(damping_factor=10.0)
                 self.assertIsInstance(rv.cov_cholesky, linops.LinearOperator)
                 self.assertAllClose(
@@ -610,9 +608,9 @@ class MultivariateNormalTestCase(unittest.TestCase, NumpyAssertions):
     def test_cov_cholesky_cov_cholesky_passed(self):
         """A value for cov_cholesky is passed in init.
 
-        In this case, the "is_precomputed" flag is True, the
-        cov_cholesky returns the argument that has been passed, but
-        (p)recomputing overwrites the argument with a new factor.
+        In this case, the "is_precomputed" flag is True, the cov_cholesky returns the
+        argument that has been passed, but (p)recomputing overwrites the argument with a
+        new factor.
         """
         mean, cov = self.params
 
@@ -714,9 +712,8 @@ class MatrixvariateNormalTestCase(unittest.TestCase, NumpyAssertions):
     def test_cov_cholesky_cov_cholesky_not_passed(self):
         """No cov_cholesky is passed in init.
 
-        In this case, the "is_precomputed" flag is False, a cov_cholesky
-        is computed on demand, but can also be computed manually with
-        any damping factor.
+        In this case, the "is_precomputed" flag is False, a cov_cholesky is computed on
+        demand, but can also be computed manually with any damping factor.
         """
         rv = randvars.Normal(
             mean=np.random.uniform(size=(2, 2)),
@@ -754,9 +751,9 @@ class MatrixvariateNormalTestCase(unittest.TestCase, NumpyAssertions):
     def test_cov_cholesky_cov_cholesky_passed(self):
         """A value for cov_cholesky is passed in init.
 
-        In this case, the "is_precomputed" flag is True, the
-        cov_cholesky returns the argument that has been passed, but
-        (p)recomputing overwrites the argument with a new factor.
+        In this case, the "is_precomputed" flag is True, the cov_cholesky returns the
+        argument that has been passed, but (p)recomputing overwrites the argument with a
+        new factor.
         """
         # This is purposely not the correct Cholesky factor for test reasons
         cov_cholesky = np.random.rand(4, 4)


### PR DESCRIPTION
# In a Nutshell
This PR gives a more descriptive name (`matrix_free`) to the configuration option which uses linear operators instead of full matrices.

# Detailed Description
The term `matrix_free` is a more complete description of what functionality `LinearOperator`s offer, namely that they
- only implicitly define the matrix-vector product
- generally do not instantiate a full matrix in memory
- are memory and time-efficient
- offer lazy arithmetic
