### PR TITLE
Move `_RandomVariableList` under `probnum.randvars`

### DIFF
--- a/src/probnum/diffeq/_odesolution.py
+++ b/src/probnum/diffeq/_odesolution.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import numpy as np
 
-from probnum import _randomvariablelist, filtsmooth, randvars
+from probnum import filtsmooth, randvars
 from probnum.filtsmooth._timeseriesposterior import DenseOutputLocationArgType
 from probnum.typing import FloatArgType, IntArgType, ShapeArgType
 
@@ -31,12 +31,12 @@ class ODESolution(filtsmooth.TimeSeriesPosterior):
     def __init__(
         self,
         locations: np.ndarray,
-        states: _randomvariablelist._RandomVariableList,
-        derivatives: Optional[_randomvariablelist._RandomVariableList] = None,
+        states: randvars._RandomVariableList,
+        derivatives: Optional[randvars._RandomVariableList] = None,
     ):
         super().__init__(locations=locations, states=states)
         self.derivatives = (
-            _randomvariablelist._RandomVariableList(derivatives)
+            randvars._RandomVariableList(derivatives)
             if derivatives is not None
             else None
         )

--- a/src/probnum/diffeq/odefilter/_odefilter_solution.py
+++ b/src/probnum/diffeq/odefilter/_odefilter_solution.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 
-from probnum import _randomvariablelist, filtsmooth, randvars, utils
+from probnum import filtsmooth, randvars, utils
 from probnum.diffeq import _odesolution
 from probnum.filtsmooth._timeseriesposterior import DenseOutputLocationArgType
 from probnum.typing import FloatArgType, IntArgType, ShapeArgType
@@ -78,10 +78,10 @@ class ODEFilterSolution(_odesolution.ODESolution):
         self.proj_to_y = self.kalman_posterior.transition.proj2coord(coord=0)
         self.proj_to_dy = self.kalman_posterior.transition.proj2coord(coord=1)
 
-        states = _randomvariablelist._RandomVariableList(
+        states = randvars._RandomVariableList(
             [_project_rv(self.proj_to_y, rv) for rv in self.kalman_posterior.states]
         )
-        derivatives = _randomvariablelist._RandomVariableList(
+        derivatives = randvars._RandomVariableList(
             [_project_rv(self.proj_to_dy, rv) for rv in self.kalman_posterior.states]
         )
         super().__init__(

--- a/src/probnum/diffeq/perturbed/scipy_wrapper/_wrapped_scipy_odesolution.py
+++ b/src/probnum/diffeq/perturbed/scipy_wrapper/_wrapped_scipy_odesolution.py
@@ -2,7 +2,7 @@
 import numpy as np
 from scipy.integrate._ivp.common import OdeSolution
 
-from probnum import _randomvariablelist, randvars
+from probnum import randvars
 from probnum.diffeq import _odesolution
 from probnum.filtsmooth._timeseriesposterior import DenseOutputValueType
 from probnum.typing import DenseOutputLocationArgType
@@ -16,7 +16,7 @@ class WrappedScipyODESolution(_odesolution.ODESolution):
 
         # rvs is of the type `list` of `RandomVariable` and can therefore be
         # directly transformed into a _RandomVariableList
-        rv_states = _randomvariablelist._RandomVariableList(rvs)
+        rv_states = randvars._RandomVariableList(rvs)
         super().__init__(locations=scipy_solution.ts, states=rv_states)
 
     def __call__(self, t: DenseOutputLocationArgType) -> DenseOutputValueType:
@@ -29,7 +29,7 @@ class WrappedScipyODESolution(_odesolution.ODESolution):
 
         Returns
         -------
-        randvars.RandomVariable or _randomvariablelist._RandomVariableList
+        randvars.RandomVariable or randvars._RandomVariableList
             Estimate of the states at time ``t`` based on a fourth order polynomial.
         """
 
@@ -37,7 +37,7 @@ class WrappedScipyODESolution(_odesolution.ODESolution):
         if np.isscalar(t):
             solution_as_rv = randvars.Constant(states)
         else:
-            solution_as_rv = _randomvariablelist._RandomVariableList(
+            solution_as_rv = randvars._RandomVariableList(
                 [randvars.Constant(state) for state in states]
             )
         return solution_as_rv

--- a/src/probnum/diffeq/perturbed/step/_perturbedstepsolution.py
+++ b/src/probnum/diffeq/perturbed/step/_perturbedstepsolution.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import numpy as np
 from scipy.integrate._ivp import rk
 
-from probnum import _randomvariablelist, randvars
+from probnum import randvars
 from probnum.diffeq import _odesolution
 from probnum.typing import FloatArgType
 
@@ -17,7 +17,7 @@ class PerturbedStepSolution(_odesolution.ODESolution):
         self,
         scales: List[float],
         locations: np.ndarray,
-        states: _randomvariablelist._RandomVariableList,
+        states: randvars._RandomVariableList,
         interpolants: List[rk.DenseOutput],
     ):
         self.scales = scales

--- a/src/probnum/diffeq/perturbed/step/_perturbedstepsolver.py
+++ b/src/probnum/diffeq/perturbed/step/_perturbedstepsolver.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 import numpy as np
 
-from probnum import _randomvariablelist
+from probnum import randvars
 from probnum.diffeq import _odesolver, _odesolver_state
 from probnum.diffeq.perturbed import scipy_wrapper
 from probnum.diffeq.perturbed.step import (
@@ -134,9 +134,7 @@ class PerturbedStepSolver(_odesolver.ODESolver):
         """Call dense output after each step and store the interpolants."""
         return self.solver.method_callback(state)
 
-    def rvlist_to_odesol(
-        self, times: np.ndarray, rvs: _randomvariablelist._RandomVariableList
-    ):
+    def rvlist_to_odesol(self, times: np.ndarray, rvs: randvars._RandomVariableList):
         interpolants = self.solver.interpolants
         probnum_solution = _perturbedstepsolution.PerturbedStepSolution(
             self.scales, times, rvs, interpolants

--- a/src/probnum/filtsmooth/_timeseriesposterior.py
+++ b/src/probnum/filtsmooth/_timeseriesposterior.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional, Union
 
 import numpy as np
 
-from probnum import _randomvariablelist, randvars
+from probnum import randvars
 from probnum.typing import (
     ArrayLikeGetitemArgType,
     DenseOutputLocationArgType,
@@ -14,9 +14,7 @@ from probnum.typing import (
     ShapeArgType,
 )
 
-DenseOutputValueType = Union[
-    randvars.RandomVariable, _randomvariablelist._RandomVariableList
-]
+DenseOutputValueType = Union[randvars.RandomVariable, randvars._RandomVariableList]
 """Dense evaluation of a TimeSeriesPosterior returns a RandomVariable if evaluated at a single location,
 and a _RandomVariableList if evaluated at an array of locations."""
 
@@ -74,7 +72,7 @@ class TimeSeriesPosterior(abc.ABC):
 
     @property
     def states(self):
-        return _randomvariablelist._RandomVariableList(self._states)
+        return randvars._RandomVariableList(self._states)
 
     def __len__(self) -> int:
         """Length of the discrete-time solution.
@@ -103,7 +101,7 @@ class TimeSeriesPosterior(abc.ABC):
 
         Returns
         -------
-        randvars.RandomVariable or _randomvariablelist._RandomVariableList
+        randvars.RandomVariable or randvars._RandomVariableList
             Estimate of the states at time ``t``.
         """
         # The variable "squeeze_eventually" indicates whether
@@ -156,7 +154,7 @@ class TimeSeriesPosterior(abc.ABC):
 
         if t_has_been_promoted:
             return dense_output_values[0]
-        return _randomvariablelist._RandomVariableList(dense_output_values)
+        return randvars._RandomVariableList(dense_output_values)
 
     @abc.abstractmethod
     def interpolate(
@@ -169,7 +167,7 @@ class TimeSeriesPosterior(abc.ABC):
 
         Returns
         -------
-        randvars.RandomVariable or _randomvariablelist._RandomVariableList
+        randvars.RandomVariable or randvars._RandomVariableList
             Dense evaluation.
         """
         raise NotImplementedError

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -5,7 +5,7 @@ from typing import Callable, Generic, Optional, Type, TypeVar, Union
 
 import numpy as np
 
-from probnum import _randomvariablelist, randvars
+from probnum import randvars
 from probnum import utils as _utils
 from probnum.typing import DTypeArgType, IntArgType, ShapeArgType
 
@@ -100,7 +100,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         """Data type of (elements of) the random process evaluated at an input."""
         return self._dtype
 
-    def marginal(self, args: _InputType) -> _randomvariablelist._RandomVariableList:
+    def marginal(self, args: _InputType) -> randvars._RandomVariableList:
         """Batch of random variables defining the marginal distributions at the inputs.
 
         Parameters

--- a/src/probnum/randprocs/markov/_transition.py
+++ b/src/probnum/randprocs/markov/_transition.py
@@ -4,7 +4,7 @@ import abc
 
 import numpy as np
 
-from probnum import _randomvariablelist, randvars
+from probnum import randvars
 from probnum.typing import FloatArgType, IntArgType
 
 
@@ -254,7 +254,7 @@ class Transition(abc.ABC):
 
         Parameters
         ----------
-        rv_list : _randomvariablelist._RandomVariableList
+        rv_list : randvars._RandomVariableList
             List of random variables to be smoothed.
         locations :
             Locations :math:`t` of the random variables in the time-domain. Used for continuous-time transitions.
@@ -267,7 +267,7 @@ class Transition(abc.ABC):
 
         Returns
         -------
-        _randomvariablelist._RandomVariableList
+        randvars._RandomVariableList
             List of smoothed random variables.
         """
 
@@ -295,13 +295,13 @@ class Transition(abc.ABC):
             )
             out_rvs.append(curr_rv)
         out_rvs.reverse()
-        return _randomvariablelist._RandomVariableList(out_rvs)
+        return randvars._RandomVariableList(out_rvs)
 
     def jointly_transform_base_measure_realization_list_backward(
         self,
         base_measure_realizations: np.ndarray,
         t: FloatArgType,
-        rv_list: _randomvariablelist._RandomVariableList,
+        rv_list: randvars._RandomVariableList,
         _diffusion_list: np.ndarray,
         _previous_posterior=None,
     ) -> np.ndarray:

--- a/src/probnum/randvars/__init__.py
+++ b/src/probnum/randvars/__init__.py
@@ -1,10 +1,9 @@
 """Random Variables.
 
-Random variables generalize multi-dimensional arrays by encoding
-uncertainty about the (numerical) quantity in question. Despite their
-name, they do not necessarily represent stochastic objects. Random
-variables are also the primary in- and outputs of probabilistic
-numerical methods.
+Random variables generalize multi-dimensional arrays by encoding uncertainty about the
+(numerical) quantity in question. Despite their name, they do not necessarily represent
+stochastic objects. Random variables are also the primary in- and outputs of
+probabilistic numerical methods.
 """
 
 from ._categorical import Categorical
@@ -15,6 +14,7 @@ from ._random_variable import (
     DiscreteRandomVariable,
     RandomVariable,
 )
+from ._randomvariablelist import _RandomVariableList
 from ._scipy_stats import (
     WrappedSciPyContinuousRandomVariable,
     WrappedSciPyDiscreteRandomVariable,
@@ -34,6 +34,7 @@ __all__ = [
     "WrappedSciPyRandomVariable",
     "WrappedSciPyDiscreteRandomVariable",
     "WrappedSciPyContinuousRandomVariable",
+    "_RandomVariableList",
 ]
 
 # Set correct module paths. Corrects links and module paths in documentation.
@@ -48,5 +49,7 @@ WrappedSciPyContinuousRandomVariable.__module__ = "probnum.randvars"
 Constant.__module__ = "probnum.randvars"
 Normal.__module__ = "probnum.randvars"
 Categorical.__module__ = "probnum.randvars"
+
+_RandomVariableList.__module__ = "probnum.randvars"
 
 asrandvar.__module__ = "probnum.randvars"

--- a/src/probnum/randvars/_randomvariablelist.py
+++ b/src/probnum/randvars/_randomvariablelist.py
@@ -1,3 +1,5 @@
+"""List of random variables."""
+
 from typing import Union
 
 import numpy as np

--- a/tests/test_diffeq/test_odefilter/test_odefilter_solution.py
+++ b/tests/test_diffeq/test_odefilter/test_odefilter_solution.py
@@ -3,7 +3,6 @@ import pytest
 
 import probnum.problems.zoo.diffeq as diffeq_zoo
 from probnum import diffeq, randvars
-from probnum._randomvariablelist import _RandomVariableList
 
 
 @pytest.fixture
@@ -64,7 +63,7 @@ def test_getitem(posterior):
 def test_states(posterior):
     """RVs are stored correctly."""
 
-    assert isinstance(posterior.states, _RandomVariableList)
+    assert isinstance(posterior.states, randvars._RandomVariableList)
     assert len(posterior.states[0].shape) == 1
 
 

--- a/tests/test_diffeq/test_perturbed/test_scipy_wrapper/test_wrapped_scipy_odesolution.py
+++ b/tests/test_diffeq/test_perturbed/test_scipy_wrapper/test_wrapped_scipy_odesolution.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest_cases
 
-from probnum import _randomvariablelist, randvars
+from probnum import randvars
 
 
 @pytest_cases.fixture
@@ -28,7 +28,7 @@ def test_call_isscalar(solution_case):
     call_array = testsolution([0.1, 0.2, 0.3])
     assert np.isscalar(t)
     assert isinstance(call_scalar, randvars.Constant)
-    assert isinstance(call_array, _randomvariablelist._RandomVariableList)
+    assert isinstance(call_array, randvars._RandomVariableList)
 
 
 def test_states(solution_case):

--- a/tests/test_diffeq/test_perturbed/test_step/test_perturbedstepsolution.py
+++ b/tests/test_diffeq/test_perturbed/test_step/test_perturbedstepsolution.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.integrate._ivp import rk
 
 import probnum.problems.zoo.diffeq as diffeq_zoo
-from probnum import _randomvariablelist, diffeq
+from probnum import diffeq, randvars
 
 
 @pytest.fixture
@@ -29,16 +29,13 @@ def perturbed_solution(steprule):
 
 
 def test_states(perturbed_solution):
-    assert isinstance(
-        perturbed_solution.states, _randomvariablelist._RandomVariableList
-    )
+    assert isinstance(perturbed_solution.states, randvars._RandomVariableList)
 
 
 def test_call(perturbed_solution):
     """Test for continuity of the dense output.
 
-    Small changes of the locations should come with small changes of the
-    states.
+    Small changes of the locations should come with small changes of the states.
     """
     np.testing.assert_allclose(
         perturbed_solution(perturbed_solution.locations[0:]).mean,

--- a/tests/test_filtsmooth/test_gaussian/test_kalmanposterior.py
+++ b/tests/test_filtsmooth/test_gaussian/test_kalmanposterior.py
@@ -3,7 +3,6 @@ import pytest
 
 import probnum.problems.zoo.filtsmooth as filtsmooth_zoo
 from probnum import filtsmooth, problems, randprocs, randvars, utils
-from probnum._randomvariablelist import _RandomVariableList
 
 
 @pytest.fixture
@@ -94,7 +93,7 @@ def test_getitem(posterior):
 def test_states(posterior):
     """RVs are stored correctly."""
 
-    assert isinstance(posterior.states, _RandomVariableList)
+    assert isinstance(posterior.states, randvars._RandomVariableList)
     assert len(posterior.states[0].shape) == 1
 
 

--- a/tests/test_randvars/test_randomvariablelist.py
+++ b/tests/test_randvars/test_randomvariablelist.py
@@ -2,8 +2,7 @@ import unittest
 
 import numpy as np
 
-from probnum._randomvariablelist import _RandomVariableList
-from probnum.randvars import Constant
+from probnum.randvars import Constant, _RandomVariableList
 
 
 class TestRandomVariableList(unittest.TestCase):


### PR DESCRIPTION
# In a Nutshell
Moves the `_RandomVariableList` class under `randvars` where it belongs semantically.

# In Detail
Now that all random variables have been moved from top level into `probnum.randvars` also `_RandomVariableList` should live in that subpackage. This decoheres the package structure a little bit.