### PR TITLE
Pytest version pinned for Python 3.8.10 or older

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ full =
 # Dependencies needed to run the tests (semicolon/line-separated)
 test =
     pytest>=4.6
+    pytest>=4.6,<=6.2.3; python_version<="3.8.10"
     pytest-cov
     pytest-cases>=3.6.3
     # Optional dependencies of ProbNum

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,8 +72,8 @@ full =
 
 # Dependencies needed to run the tests (semicolon/line-separated)
 test =
-    pytest>=4.6
-    pytest>=4.6,<=6.2.3; python_version<="3.8.10"
+    pytest>=4.6; python_version>"3.8.10"
+    pytest>=4.6,<6.2; python_version<="3.8.10"
     pytest-cov
     pytest-cases>=3.6.3
     # Optional dependencies of ProbNum


### PR DESCRIPTION
# In a Nutshell
The test discovery fails on Python 3.8.10 or older with the most recent version of `pytest`.

# Detailed Description
Note that this bug was not caught by our CI since it tests with the most recent Python 3.8.x (currently x=12). 

The following error appears if using `pytest>6.1` with Python 3.8.10:

```bash
======================================== test session starts ========================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/j/Documents/Professional/research/code/probnum/.tox/py3/bin/python
cachedir: .tox/py3/.pytest_cache
rootdir: /home/j/Documents/Professional/research/code/probnum, configfile: pyproject.toml, testpaths: src, tests
plugins: cov-3.0.0, cases-3.6.4
collected 0 items / 1 error                                                                         

============================================== ERRORS ===============================================
___________________________________ ERROR collecting test session ___________________________________
/usr/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
.tox/py3/lib/python3.8/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
/home/j/Documents/research/probabilistic_numerics/code/probnum/tests/test_problems/test_zoo/test_linalg/conftest.py:54: in <module>
    ???
.tox/py3/lib/python3.8/site-packages/pytest_cases/fixture_core1_unions.py:327: in fixture_union
    union_fix = _fixture_union(caller_module, name,
.tox/py3/lib/python3.8/site-packages/pytest_cases/fixture_core1_unions.py:406: in _fixture_union
    setattr(fixtures_dest, name, new_union_fix)
E   AttributeError: 'NoneType' object has no attribute 'spd_mat'
====================================== short test summary info ======================================
ERROR  - AttributeError: 'NoneType' object has no attribute 'spd_mat'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========================================= 1 error in 0.68s ==========================================
ERROR: InvocationError for command /home/j/Documents/Professional/research/code/probnum/.tox/py3/bin/pytest --doctest-modules --cov=probnum --no-cov-on-fail --cov-report=xml --color=yes (exited with code 2)
______________________________________________ summary ______________________________________________
ERROR:   py3: commands failed

```
