### PR TITLE
Remove support for complex dtypes from `LinearOperator`

### DIFF
--- a/src/probnum/linops/_arithmetic.py
+++ b/src/probnum/linops/_arithmetic.py
@@ -17,7 +17,6 @@ from ._arithmetic_fallbacks import (
 )
 from ._kronecker import IdentityKronecker, Kronecker, SymmetricKronecker, Symmetrize
 from ._linear_operator import (
-    AdjointLinearOperator,
     BinaryOperandType,
     Embedding,
     Identity,
@@ -25,7 +24,6 @@ from ._linear_operator import (
     Matrix,
     Selection,
     TransposedLinearOperator,
-    _ConjugateLinearOperator,
     _InverseLinearOperator,
     _TypeCastLinearOperator,
 )
@@ -36,14 +34,12 @@ _AnyLinOp = [
     ProductLinearOperator,
     ScaledLinearOperator,
     SumLinearOperator,
-    AdjointLinearOperator,
     Identity,
     IdentityKronecker,
     Matrix,
     TransposedLinearOperator,
     SymmetricKronecker,
     Symmetrize,
-    _ConjugateLinearOperator,
     _InverseLinearOperator,
     _TypeCastLinearOperator,
     Scaling,

--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -37,7 +37,6 @@ class ScaledLinearOperator(LinearOperator):
             rmatmul=lambda x: self._scalar * (x @ self._linop),
             todense=lambda: self._scalar * self._linop.todense(cache=False),
             transpose=lambda: self._scalar * self._linop.T,
-            adjoint=lambda: np.conj(self._scalar) * self._linop.H,
             inverse=self._inv,
             trace=lambda: self._scalar * self._linop.trace(),
         )
@@ -90,9 +89,6 @@ class SumLinearOperator(LinearOperator):
             ),
             transpose=lambda: SumLinearOperator(
                 *(summand.T for summand in self._summands)
-            ),
-            adjoint=lambda: SumLinearOperator(
-                *(summand.H for summand in self._summands)
             ),
             trace=lambda: functools.reduce(
                 operator.add, (summand.trace() for summand in self._summands)
@@ -166,9 +162,6 @@ class ProductLinearOperator(LinearOperator):
             ),
             transpose=lambda: ProductLinearOperator(
                 *(factor.T for factor in reversed(self._factors))
-            ),
-            adjoint=lambda: ProductLinearOperator(
-                *(factor.H for factor in reversed(self._factors))
             ),
             inverse=lambda: ProductLinearOperator(
                 *(factor.inv() for factor in reversed(self._factors))

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -130,11 +130,8 @@ class Kronecker(_linear_operator.LinearOperator):
             todense=lambda: np.kron(
                 self.A.todense(cache=False), self.B.todense(cache=False)
             ),
-            conjugate=lambda: Kronecker(A=self.A.conj(), B=self.B.conj()),
             # (A (x) B)^T = A^T (x) B^T
             transpose=lambda: Kronecker(A=self.A.T, B=self.B.T),
-            # (A (x) B)^H = A^H (x) B^H
-            adjoint=lambda: Kronecker(A=self.A.H, B=self.B.H),
             # (A (x) B)^-1 = A^-1 (x) B^-1
             inverse=lambda: Kronecker(A=self.A.inv(), B=self.B.inv()),
             rank=lambda: self.A.rank() * self.B.rank(),
@@ -308,11 +305,8 @@ class SymmetricKronecker(_linear_operator.LinearOperator):
             matmul = lambda x: _kronecker_matmul(self.A, self.A, x)
             rmatmul = lambda x: _kronecker_rmatmul(self.A, self.A, x)
             todense = self._todense_identical_factors
-            conjugate = lambda: SymmetricKronecker(A=self.A.conj())
             # (A (x)_s A)^T = A^T (x)_s A^T
             transpose = lambda: SymmetricKronecker(A=self.A.T)
-            # (A (x)_s A)^H = A^H (x)_s A^H
-            adjoint = lambda: SymmetricKronecker(A=self.A.H)
             # (A (x)_s A)^-1 = (A (x) A)^-1 = A^-1 (x) A^-1
             inverse = lambda: SymmetricKronecker(A=self.A.inv())
             rank = lambda: self.A.rank() ** 2
@@ -331,11 +325,8 @@ class SymmetricKronecker(_linear_operator.LinearOperator):
             matmul = self._matmul_different_factors
             rmatmul = self._rmatmul_different_factors
             todense = self._todense_different_factors
-            conjugate = lambda: SymmetricKronecker(A=self.A.conj(), B=self.B.conj())
             # (A (x)_s B)^T = A^T (x)_s B^T
             transpose = lambda: SymmetricKronecker(A=self.A.T, B=self.B.T)
-            # (A (x)_s B)^H = A^H (x)_s B^H
-            adjoint = lambda: SymmetricKronecker(A=self.A.H, B=self.B.H)
             inverse = None
             rank = None
             cond = None
@@ -348,9 +339,7 @@ class SymmetricKronecker(_linear_operator.LinearOperator):
             matmul=matmul,
             rmatmul=rmatmul,
             todense=todense,
-            conjugate=conjugate,
             transpose=transpose,
-            adjoint=adjoint,
             inverse=inverse,
             rank=rank,
             cond=cond,
@@ -488,11 +477,8 @@ class IdentityKronecker(_linear_operator.LinearOperator):
             todense=lambda: np.kron(
                 self.A.todense(cache=False), self.B.todense(cache=False)
             ),
-            conjugate=lambda: IdentityKronecker(self._num_blocks, B=self.B.conj()),
             # (A (x) B)^T = A (x) B^T
             transpose=lambda: IdentityKronecker(self._num_blocks, B=self.B.T),
-            # (A (x) B)^H = A^H (x) B^H
-            adjoint=lambda: IdentityKronecker(self._num_blocks, B=self.B.H),
             # (A (x) B)^-1 = A^-1 (x) B^-1
             inverse=lambda: IdentityKronecker(num_blocks, B=self.B.inv()),
             rank=lambda: self.A.rank() * self.B.rank(),

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -757,7 +757,6 @@ class _InverseLinearOperator(LinearOperator):
         self.__factorization = None
 
         tmatmul = LinearOperator.broadcast_matmat(self._tmatmat)
-        hmatmul = LinearOperator.broadcast_matmat(self._hmatmat)
 
         super().__init__(
             shape=self._linop.shape,
@@ -787,9 +786,6 @@ class _InverseLinearOperator(LinearOperator):
 
     def _tmatmat(self, x: np.ndarray) -> np.ndarray:
         return scipy.linalg.lu_solve(self.factorization, x, trans=1, overwrite_b=False)
-
-    def _hmatmat(self, x: np.ndarray) -> np.ndarray:
-        return scipy.linalg.lu_solve(self.factorization, x, trans=2, overwrite_b=False)
 
 
 class _TypeCastLinearOperator(LinearOperator):

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -134,14 +134,6 @@ class Scaling(_linear_operator.LinearOperator):
 
             todense = lambda: np.diag(self._factors)
 
-            conjugate = lambda: (
-                self
-                if (
-                    not np.issubdtype(dtype, np.complexfloating)
-                    or np.all(np.imag(self._factors) == 0)
-                )
-                else Scaling(np.conj(self._factors))
-            )
             inverse = self._inverse_anisotropic
 
             rank = lambda: np.count_nonzero(self.factors, axis=0)

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -83,7 +83,6 @@ class Scaling(_linear_operator.LinearOperator):
 
                 todense = lambda: np.identity(shape[0], dtype=dtype)
 
-                conjugate = lambda: self
                 inverse = lambda: self
 
                 rank = lambda: np.intp(shape[0])
@@ -101,11 +100,6 @@ class Scaling(_linear_operator.LinearOperator):
 
                 todense = self._todense_isotropic
 
-                conjugate = lambda: (
-                    self
-                    if np.imag(self._scalar) == 0
-                    else Scaling(np.conj(self._scalar), shape=shape)
-                )
                 inverse = self._inverse_isotropic
 
                 rank = lambda: np.intp(0 if self._scalar == 0 else shape[0])
@@ -168,9 +162,7 @@ class Scaling(_linear_operator.LinearOperator):
             rmatmul=rmatmul,
             apply=apply,
             todense=todense,
-            conjugate=conjugate,
             transpose=lambda: self,
-            adjoint=conjugate,
             inverse=inverse,
             rank=rank,
             eigvals=eigvals,

--- a/tests/test_linops/test_arithmetics.py
+++ b/tests/test_linops/test_arithmetics.py
@@ -21,13 +21,11 @@ from probnum.linops._kronecker import (
     Symmetrize,
 )
 from probnum.linops._linear_operator import (
-    AdjointLinearOperator,
     Embedding,
     Identity,
     Matrix,
     Selection,
     TransposedLinearOperator,
-    _ConjugateLinearOperator,
     _InverseLinearOperator,
     _TypeCastLinearOperator,
 )
@@ -91,10 +89,6 @@ def get_linop(linop_type):
         return SumLinearOperator(
             Matrix(np.random.rand(4, 4)), Matrix(np.random.rand(4, 4))
         )
-    elif linop_type is AdjointLinearOperator:
-        return AdjointLinearOperator(linop=Identity(4))
-    elif linop_type is _ConjugateLinearOperator:
-        return _ConjugateLinearOperator(linop=Identity(4, dtype=np.complex64))
     elif linop_type is SymmetricKronecker:
         return SymmetricKronecker(Identity(2), Identity(2))
     elif linop_type is Symmetrize:

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -292,18 +292,6 @@ def test_trace(linop: pn.linops.LinearOperator, matrix: np.ndarray):
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
-def test_conjugate(linop: pn.linops.LinearOperator, matrix: np.ndarray):
-    linop_conj = linop.conj()
-    matrix_conj = matrix.conj()
-
-    assert isinstance(linop_conj, pn.linops.LinearOperator)
-    assert linop_conj.shape == matrix_conj.shape
-    assert linop_conj.dtype == matrix_conj.dtype
-
-    np.testing.assert_allclose(linop_conj.todense(), matrix_conj)
-
-
-@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
 def test_transpose(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     linop_transpose = linop.T
     matrix_transpose = matrix.T
@@ -313,18 +301,6 @@ def test_transpose(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     assert linop_transpose.dtype == matrix_transpose.dtype
 
     np.testing.assert_allclose(linop_transpose.todense(), matrix_transpose)
-
-
-@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
-def test_adjoint(linop: pn.linops.LinearOperator, matrix: np.ndarray):
-    linop_adjoint = linop.H
-    matrix_adjoint = matrix.T.conj()
-
-    assert isinstance(linop_adjoint, pn.linops.LinearOperator)
-    assert linop_adjoint.shape == matrix_adjoint.shape
-    assert linop_adjoint.dtype == matrix_adjoint.dtype
-
-    np.testing.assert_allclose(linop_adjoint.todense(), matrix_adjoint)
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)


### PR DESCRIPTION
# In a Nutshell
This PR removes support for `np.complexfloating` dtypes from the `LinearOperator`.

# Detailed Description
At the moment, our linear operator has rudimentary support for complex numbers, but it is largely untested and makes the code more complex than it needs to be.
Since we don't use this feature right now and are unlikely to need it in the future, it is better to just remove the - possibly faulty - code alltogether.
If we do need the feature in the future, it is better to reintroduce the feature cleanly with tests and proper documentation.

# Related Issues
None
