### PR TITLE
Invert semantics of `lazy_matrix_matrix_matmul` config option

### DIFF
--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -130,18 +130,23 @@ _DEFAULT_CONFIG_OPTIONS = [
         "matrix_free",
         False,
         (
-            "If ``True``, wherever possible, ``LinearOperator`` s are used instead "
-            "of arrays. ``LinearOperator`` s define a matrix-vector product implicitly without "
-            "instantiating the full matrix in memory. This makes them memory- and runtime-efficient "
-            "for linear algebra operations."
+            r"If :obj:`True`, wherever possible, :class:`~.linops.LinearOperator`\ s "
+            r"are used instead of arrays. :class:`~.linops.LinearOperator`\ s "
+            r"define a matrix-vector product implicitly without instantiating the full "
+            r"matrix in memory. This makes them memory- and runtime-efficient for "
+            r"linear algebra operations."
         ),
     ),
     (
         "lazy_matrix_matrix_matmul",
         False,
-        "If ``True``, the matmul operation applied to two ``Matrix``-``LinearOperator`` s will "
-        "again yield a ``Matrix``-``LinearOperator`` with the computed matrix-matrix product,"
-        " instead of a ``ProductLinearOperator``.",
+        (
+            r"If :obj:`True`, the matmul operation applied to two :class:`~probnum."
+            r"linops.LinearOperator`\ s of type :class:`~probnum.linops.Matrix` will "
+            r"again yield a :class:`~probnum.linops.Matrix` containing the computed "
+            r"matrix-matrix product, instead of a :class:`~probnum.linops."
+            r"_arithmetic_fallbacks.ProductLinearOperator`."
+        ),
     ),
 ]
 

--- a/src/probnum/_config.py
+++ b/src/probnum/_config.py
@@ -139,13 +139,18 @@ _DEFAULT_CONFIG_OPTIONS = [
     ),
     (
         "lazy_matrix_matrix_matmul",
-        False,
+        True,
         (
-            r"If :obj:`True`, the matmul operation applied to two :class:`~probnum."
-            r"linops.LinearOperator`\ s of type :class:`~probnum.linops.Matrix` will "
-            r"again yield a :class:`~probnum.linops.Matrix` containing the computed "
-            r"matrix-matrix product, instead of a :class:`~probnum.linops."
-            r"_arithmetic_fallbacks.ProductLinearOperator`."
+            r"If this is set to :obj:`False`, the matrix multiplication operator ``@`` "
+            r"applied to two :class:`~probnum.linops.LinearOperator`\ s of type "
+            r":class:`~probnum.linops.Matrix` multiplies the two matrices immediately "
+            r"and returns the product as a :class:`~probnum.linops.Matrix`. Otherwise, "
+            r"i.e. if this option is set to :obj:`True`, a :class:`~probnum.linops."
+            r"ProductLinearOperator`, representing the matrix product, is returned. "
+            r"Multiplying a vector with the :class:`~probnum.linops."
+            r"ProductLinearOperator` is often more efficient than computing the "
+            r"full matrix-matrix product first. This is why this option is set to "
+            r":obj:`True` by default."
         ),
     ),
 ]

--- a/src/probnum/linops/_arithmetic.py
+++ b/src/probnum/linops/_arithmetic.py
@@ -272,7 +272,7 @@ _sub_fns[(Matrix, Matrix)] = lambda mat1, mat2: Matrix(mat1.A - mat2.A)
 def _matmul_matrix_wrapped(
     mat: Matrix, wrapped: Union[_InverseLinearOperator, TransposedLinearOperator]
 ) -> Union[Matrix, NotImplementedType]:
-    if config.lazy_matrix_matrix_matmul:
+    if not config.lazy_matrix_matrix_matmul:
         return Matrix(mat.A @ wrapped)
     return NotImplemented
 
@@ -280,7 +280,7 @@ def _matmul_matrix_wrapped(
 def _matmul_wrapped_matrix(
     wrapped: Union[_InverseLinearOperator, TransposedLinearOperator], mat: Matrix
 ) -> Union[Matrix, NotImplementedType]:
-    if config.lazy_matrix_matrix_matmul:
+    if not config.lazy_matrix_matrix_matmul:
         return Matrix(wrapped @ mat.A)
     return NotImplemented
 

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -914,7 +914,7 @@ class Matrix(LinearOperator):
             raise np.linalg.LinAlgError(str(err)) from err
 
     def _matmul_matrix(self, other: "Matrix") -> "Matrix":
-        if config.lazy_matrix_matrix_matmul:
+        if not config.lazy_matrix_matrix_matmul:
             if not self.shape[1] == other.shape[0]:
                 raise ValueError(f"Matmul shape mismatch {self.shape} x {other.shape}")
 

--- a/tests/test_linops/test_arithmetics.py
+++ b/tests/test_linops/test_arithmetics.py
@@ -268,14 +268,14 @@ def test_lazy_matrix_matrix_matmul_option():
     inv = get_linop(_InverseLinearOperator)
     transposed = get_linop(TransposedLinearOperator)
 
-    with config(lazy_matrix_matrix_matmul=False):
+    with config(lazy_matrix_matrix_matmul=True):
         assert isinstance(mat1 @ mat2, ProductLinearOperator)
         assert isinstance(mat1 @ inv, ProductLinearOperator)
         assert isinstance(inv @ mat2, ProductLinearOperator)
         assert isinstance(mat1 @ transposed, ProductLinearOperator)
         assert isinstance(transposed @ mat2, ProductLinearOperator)
 
-    with config(lazy_matrix_matrix_matmul=True):
+    with config(lazy_matrix_matrix_matmul=False):
         assert isinstance(mat1 @ mat2, Matrix)
         assert isinstance(mat1 @ inv, Matrix)
         assert isinstance(inv @ mat2, Matrix)


### PR DESCRIPTION
# In a Nutshell
Currently, the `lazy_matrix_matrix_matmul` config option computes `Matrix` @ `Matrix` lazily if it is set to `False`, which is counterintuitive.
This PR inverts the semantics of the flag such that setting it to `True` enables lazy computation.

# Detailed Description
- inverted the semantivs of `lazy_matrix_matrix_matmul` config flag
- refactored the documentation of `matrix_free` and `lazy_matrix_matrix_matmul` to link `LinearOperator` and `Matrix` to the API docs

# Related Issues
None
