### PR TITLE
Add `axes` argument to `LinearOperator.transpose`

### DIFF
--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -197,9 +197,7 @@ class LinearOperator:
 
     def __call__(self, x: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
         if axis is not None and (axis < -x.ndim or axis >= x.ndim):
-            raise ValueError(
-                f"Axis {axis} is out-of-bounds for operand of shape {np.shape(x)}."
-            )
+            raise np.AxisError(axis, ndim=x.ndim)
 
         if x.ndim == 1:
             return self @ x
@@ -209,6 +207,12 @@ class LinearOperator:
 
             if axis < 0:
                 axis += x.ndim
+
+            if x.shape[axis] != self.__shape[1]:
+                raise ValueError(
+                    f"Dimension mismatch. Expected array with {self.__shape[1]} "
+                    f"entries along axis {axis}, but got array with shape {x.shape}."
+                )
 
             if axis == (x.ndim - 1):
                 return (self @ x[..., np.newaxis])[..., 0]

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -474,7 +474,10 @@ class LinearOperator:
                 axes = axes[0]
 
             if len(axes) != 2:
-                raise ValueError("axes don't match array")
+                raise ValueError(
+                    f"The given axes {axes} don't match the linear operator with shape "
+                    f"{self.shape}."
+                )
 
             axes_int = []
 
@@ -493,10 +496,11 @@ class LinearOperator:
 
             if axes == (0, 1):
                 return self
-            elif axes == (1, 0):
+
+            if axes == (1, 0):
                 return self.T
-            else:
-                raise ValueError("repeated axis in transpose")
+
+            raise ValueError("Cannot transpose a linear operator along repeated axes.")
 
         return self.T
 

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -176,7 +176,7 @@ class LinearOperator:
 
     @property
     def size(self) -> int:
-        return np.prod(self.__shape)
+        return self.__shape[0] * self.__shape[1]
 
     @property
     def dtype(self) -> np.dtype:

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -28,6 +28,7 @@ def test_case_valid(linop: pn.linops.LinearOperator, matrix: np.ndarray):
 
     assert linop.ndim == matrix.ndim == 2
     assert linop.shape == matrix.shape
+    assert linop.size == matrix.size
     assert linop.dtype == matrix.dtype
 
 

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -293,14 +293,37 @@ def test_trace(linop: pn.linops.LinearOperator, matrix: np.ndarray):
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
 def test_transpose(linop: pn.linops.LinearOperator, matrix: np.ndarray):
-    linop_transpose = linop.T
-    matrix_transpose = matrix.T
+    matrix_transpose = matrix.transpose()
 
-    assert isinstance(linop_transpose, pn.linops.LinearOperator)
-    assert linop_transpose.shape == matrix_transpose.shape
-    assert linop_transpose.dtype == matrix_transpose.dtype
+    for linop_transpose in [
+        linop.transpose(),
+        linop.transpose(1, 0),
+        linop.transpose((1, 0)),
+        linop.transpose(1, -2),
+    ]:
+        linop_transpose = linop.transpose()
 
-    np.testing.assert_allclose(linop_transpose.todense(), matrix_transpose)
+        assert isinstance(linop_transpose, pn.linops.LinearOperator)
+        assert linop_transpose.shape == matrix_transpose.shape
+        assert linop_transpose.dtype == matrix_transpose.dtype
+
+        np.testing.assert_allclose(linop_transpose.todense(), matrix_transpose)
+
+    # Transpose with (0, 1) argument
+    for ax0 in [0, -2]:
+        for ax1 in [1, -1]:
+            assert linop.transpose(ax0, ax1) is linop
+            assert linop.transpose((ax0, ax1)) is linop
+
+    # Errors
+    for axes in [(0, 2), (-3, 1), ((0, 1), 1), (0, 1, 2), (0, 0), (1, 1)]:
+        try:
+            matrix.transpose(*axes)
+        except Exception as e:  # pylint: disable=broad-except
+            expected_exception = e
+
+        with pytest.raises(type(expected_exception)):
+            linop.transpose(*axes)
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)


### PR DESCRIPTION
# In a Nutshell
This PR adds a NumPy-style `axes` argument to `LinearOperator.transpose`.

# Detailed Description
- add `axes` argument to `LinearOperator.transpose`
- tests for `axes argument`
- better error checking for `LinearOperator.__call__`
- leaner implementation of `LinearOperator.size`

# Related Issues
None
