### PR TITLE
small addition to dev guide

### DIFF
--- a/docs/source/development/pull_request.md
+++ b/docs/source/development/pull_request.md
@@ -237,6 +237,12 @@ Alternatively, you can run a single specific environment through `tox -e <env>`.
   $ tox -e docs
   ```
 
+- **Additional arguments passed to pytest via tox:** e.g., only run `doctests` in `linalg`.
+
+  ```shell
+  $ tox -e py39 -- src/probnum/linalg
+  ```
+
 Code coverage of the tests is reported via [codecov](https://codecov.io/github/probabilistic-numerics/probnum?branch=main).
 
 

--- a/docs/source/development/pull_request.md
+++ b/docs/source/development/pull_request.md
@@ -240,7 +240,7 @@ Alternatively, you can run a single specific environment through `tox -e <env>`.
 - **Additional arguments passed to pytest via tox:** e.g., only run `doctests` in `linalg`.
 
   ```shell
-  $ tox -e py39 -- src/probnum/linalg
+  $ tox -e py3 -- src/probnum/linalg
   ```
 
 Code coverage of the tests is reported via [codecov](https://codecov.io/github/probabilistic-numerics/probnum?branch=main).


### PR DESCRIPTION
# In a Nutshell

Added example of how to pass additional arguments to pytest via tox in dev guide. Reflects the changes made in #563 .

# Related Issues
Closes #...
