### PR TITLE
Refactor `as_numpy_scalar` to produce scalar `np.ndarray`s

### DIFF
--- a/src/probnum/randvars/_random_variable.py
+++ b/src/probnum/randvars/_random_variable.py
@@ -958,7 +958,7 @@ class DiscreteRandomVariable(RandomVariable[_ValueType]):
     >>> x.sample(rng=rng, size=3)
     array([1, 0, 1])
     >>> x.pmf(2)
-    0.0
+    array(0.)
     >>> x.mean
     0.0
     """
@@ -1174,7 +1174,7 @@ class ContinuousRandomVariable(RandomVariable[_ValueType]):
     >>> u.sample(rng=rng, size=3)
     array([0.77395605, 0.43887844, 0.85859792])
     >>> u.pdf(0.5)
-    1.0
+    array(1.)
     >>> u.var
     0.08333333333333333
     """

--- a/src/probnum/typing.py
+++ b/src/probnum/typing.py
@@ -31,7 +31,7 @@ from numpy.typing import DTypeLike as _NumPyDTypeLike
 ShapeType = Tuple[int, ...]
 
 # Scalars, Arrays and Matrices
-ScalarType = np.number
+ScalarType = np.ndarray
 MatrixType = Union[np.ndarray, "probnum.linops.LinearOperator"]
 
 ########################################################################################

--- a/src/probnum/utils/argutils.py
+++ b/src/probnum/utils/argutils.py
@@ -42,8 +42,8 @@ def as_shape(x: ShapeLike, ndim: Optional[numbers.Integral] = None) -> ShapeType
     return shape
 
 
-def as_numpy_scalar(x: ScalarLike, dtype: DTypeLike = None) -> np.generic:
-    """Convert a scalar into a NumPy scalar.
+def as_numpy_scalar(x: ScalarLike, dtype: DTypeLike = None) -> np.ndarray:
+    """Convert a scalar into a scalar NumPy array.
 
     Parameters
     ----------
@@ -56,4 +56,4 @@ def as_numpy_scalar(x: ScalarLike, dtype: DTypeLike = None) -> np.generic:
     if np.ndim(x) != 0:
         raise ValueError("The given input is not a scalar.")
 
-    return np.asarray(x, dtype=dtype)[()]
+    return np.asarray(x, dtype=dtype)

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -226,7 +226,6 @@ def test_cond(
         linop_cond = linop.cond(p=p)
         matrix_cond = np.linalg.cond(matrix, p=p)
 
-        assert isinstance(linop_cond, np.inexact)
         assert linop_cond.shape == ()
         assert linop_cond.dtype == matrix_cond.dtype
 
@@ -250,7 +249,6 @@ def test_det(linop: pn.linops.LinearOperator, matrix: np.ndarray):
         linop_det = linop.det()
         matrix_det = np.linalg.det(matrix)
 
-        assert isinstance(linop_det, np.inexact)
         assert linop_det.shape == ()
         assert linop_det.dtype == matrix_det.dtype
 
@@ -266,7 +264,6 @@ def test_logabsdet(linop: pn.linops.LinearOperator, matrix: np.ndarray):
         linop_logabsdet = linop.logabsdet()
         _, matrix_logabsdet = np.linalg.slogdet(matrix)
 
-        assert isinstance(linop_logabsdet, np.inexact)
         assert linop_logabsdet.shape == ()
         assert linop_logabsdet.dtype == matrix_logabsdet.dtype
 
@@ -282,7 +279,6 @@ def test_trace(linop: pn.linops.LinearOperator, matrix: np.ndarray):
         linop_trace = linop.trace()
         matrix_trace = np.trace(matrix)
 
-        assert isinstance(linop_trace, np.number)
         assert linop_trace.shape == ()
         assert linop_trace.dtype == matrix_trace.dtype
 

--- a/tests/test_randvars/test_normal.py
+++ b/tests/test_randvars/test_normal.py
@@ -166,7 +166,7 @@ class NormalTestCase(unittest.TestCase, NumpyAssertions):
                 # TODO: check dimension of each realization in rv_sample
                 rv = randvars.Normal(mean=mean, cov=cov)
                 rv_sample = rv.sample(rng=self.rng, size=5)
-                if not np.isscalar(rv.mean):
+                if np.ndim(rv.mean) != 0:
                     self.assertEqual(
                         rv_sample.shape[-rv.ndim :],
                         mean.shape,

--- a/tests/test_utils/test_argutils.py
+++ b/tests/test_utils/test_argutils.py
@@ -7,7 +7,7 @@ import probnum.utils as pnut
 
 
 @pytest.mark.parametrize("scalar", [1, 1.0, 1.0 + 2.0j, np.array(1.0)])
-def test_as_numpy_scalar_scalar_is_good(scalar):
+def test_as_numpy_scalar_returns_scalar_array(scalar):
     """All sorts of scalars are transformed into a np.generic."""
     as_scalar = pnut.as_numpy_scalar(scalar)
     assert isinstance(as_scalar, np.ndarray) and as_scalar.shape == ()

--- a/tests/test_utils/test_argutils.py
+++ b/tests/test_utils/test_argutils.py
@@ -10,7 +10,7 @@ import probnum.utils as pnut
 def test_as_numpy_scalar_scalar_is_good(scalar):
     """All sorts of scalars are transformed into a np.generic."""
     as_scalar = pnut.as_numpy_scalar(scalar)
-    assert isinstance(as_scalar, np.generic)
+    assert isinstance(as_scalar, np.ndarray) and as_scalar.shape == ()
     np.testing.assert_allclose(as_scalar, scalar, atol=0.0, rtol=1e-12)
 
 


### PR DESCRIPTION
# In a Nutshell
This PR refactors the `probnum.utils.as_numpy_scalar` to return scalar `np.ndarray`s instead of `np.number`s. This is preparation for PR #581, since JAX and PyTorch don't have array scalars.
