### PR TITLE
`__(r)matmul__` of `Matrix` linear operator outputs `np.matrix`

### DIFF
--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -909,8 +909,8 @@ class Matrix(LinearOperator):
             shape = self.A.shape
             dtype = self.A.dtype
 
-            matmul = lambda x: A @ x
-            rmatmul = lambda x: x @ A
+            matmul = lambda x: self.A @ x
+            rmatmul = lambda x: x @ self.A
             todense = lambda: self.A
             inverse = None
             trace = lambda: np.trace(self.A)

--- a/tests/test_linops/test_matrix.py
+++ b/tests/test_linops/test_matrix.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+import probnum as pn
+
+
+def test_matrix_linop_converts_numpy_matrix():
+    matrix = np.asmatrix(np.eye(10))
+    linop = pn.linops.Matrix(matrix)
+
+    assert not isinstance(linop.A, np.matrix)
+    assert not isinstance(linop @ np.eye(10), np.matrix)
+    assert not isinstance(np.eye(10) @ linop, np.matrix)


### PR DESCRIPTION
# In a Nutshell
This PR fixes a bug, where the `__(r)matmul__` operator of a `Matrix` linear operator constructed from a `np.matrix` returns a `np.matrix` when being called with a `np.ndarray` as argument.

# Detailed Description
- previously, the last two assertions in the test I added were failing

# Related Issues and PRs
None
