### PR TITLE
Correct links in footer of documentation

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -8,13 +8,13 @@
           <h4>Probabilistic Numerics</h4>
           <ul class="nav flex-column">
             <li class="nav-item">
-              <a class="nav-link" href="{{ pathto('research') }}#in-a-nutshell">In a Nutshell</a>
+              <a class="nav-link" href="https://www.probabilistic-numerics.org/">In a Nutshell</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{{ pathto('research/meetings/index') }}">Meetings and Events</a>
+              <a class="nav-link" href="https://www.probabilistic-numerics.org/meetings/">Meetings and Events</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{{ pathto('research/literature') }}">Literature</a>
+              <a class="nav-link" href="https://www.probabilistic-numerics.org/research/general/">Literature</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
# In a Nutshell
Links pointing to Probabilistic Numerics content in the footer of the documentation were dead.

# Detailed Description
Links now point to the corresponding sections of www.probabilistic-numerics.org.

# Related Issues
Closes #598 
