### PR TITLE
Cholesky decompositions of `LinearOperator`s

### DIFF
--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -1,4 +1,6 @@
 """Fallback-implementations of LinearOperator arithmetic."""
+from __future__ import annotations
+
 import functools
 import operator
 from typing import Tuple, Union
@@ -49,6 +51,12 @@ class ScaledLinearOperator(LinearOperator):
 
     def __repr__(self) -> str:
         return f"{self._scalar} * {self._linop}"
+
+    def _symmetrize(self) -> ScaledLinearOperator:
+        return ScaledLinearOperator(
+            linop=self._linop.symmetrize(),
+            scalar=self._scalar,
+        )
 
 
 class NegatedLinearOperator(ScaledLinearOperator):
@@ -115,6 +123,9 @@ class SumLinearOperator(LinearOperator):
                 expanded_summands.append(summand)
 
         return tuple(expanded_summands)
+
+    def _symmetrize(self) -> SumLinearOperator:
+        return SumLinearOperator(*[summand.symmetrize() for summand in self._summands])
 
 
 def _mul_fallback(

--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -43,6 +43,17 @@ class ScaledLinearOperator(LinearOperator):
             trace=lambda: self._scalar * self._linop.trace(),
         )
 
+        # Matrix properties
+        self.is_symmetric = self._linop.is_symmetric
+        self.is_lower_triangular = self._linop.is_lower_triangular
+        self.is_upper_triangular = self._linop.is_upper_triangular
+
+        if self.is_positive_definite:
+            if self._scalar > 0:
+                self.is_positive_definite = True
+            else:
+                self.is_positive_definite = False
+
     def _inv(self) -> "ScaledLinearOperator":
         if self._scalar == 0:
             raise np.linalg.LinAlgError("The operator is not invertible")
@@ -102,6 +113,19 @@ class SumLinearOperator(LinearOperator):
                 operator.add, (summand.trace() for summand in self._summands)
             ),
         )
+
+        # Matrix properties
+        if all(summand.is_symmetric for summand in self._summands):
+            self.is_symmetric = True
+
+        if all(summand.is_lower_triangular for summand in self._summands):
+            self.is_lower_triangular = True
+
+        if all(summand.is_upper_triangular for summand in self._summands):
+            self.is_upper_triangular = True
+
+        if all(summand.is_positive_definite for summand in self._summands):
+            self.is_positive_definite = True
 
     def __neg__(self):
         return SumLinearOperator(*(-summand for summand in self._summands))

--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -48,7 +48,7 @@ class ScaledLinearOperator(LinearOperator):
         self.is_lower_triangular = self._linop.is_lower_triangular
         self.is_upper_triangular = self._linop.is_upper_triangular
 
-        if self.is_positive_definite:
+        if self._linop.is_positive_definite:
             if self._scalar > 0:
                 self.is_positive_definite = True
             else:

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -216,6 +216,9 @@ class Kronecker(_linear_operator.LinearOperator):
         )
 
     def _symmetrize(self) -> _linear_operator.LinearOperator:
+        # This is only an approximation to the closest symmetric matrix in the
+        # Frobenius norm, which is however much more efficient than the exact
+        # solution to the optimization problem
         if self.A.is_square and self.B.is_square:
             return Kronecker(
                 A=self.A.symmetrize(),
@@ -483,6 +486,9 @@ class SymmetricKronecker(_linear_operator.LinearOperator):
         return super()._cholesky(lower)
 
     def _symmetrize(self) -> SymmetricKronecker:
+        # This is only an approximation to the closest symmetric matrix in the
+        # Frobenius norm, which is however much more efficient than the exact
+        # solution to the optimization problem
         if self._identical_factors:
             return SymmetricKronecker(A=self.A.symmetrize())
 
@@ -583,6 +589,8 @@ class IdentityKronecker(_linear_operator.LinearOperator):
         )
 
     def _symmetrize(self) -> IdentityKronecker:
+        # In contrast to the implementation for the generic Kronecker product, this is
+        # not only an approximation of the closes symmetric matrix in the Frobenius norm
         return IdentityKronecker(
             num_blocks=self.num_blocks,
             B=self.B.symmetrize(),

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -207,6 +207,12 @@ class Kronecker(_linear_operator.LinearOperator):
             B=self.B.cholesky(lower),
         )
 
+    def _symmetrize(self) -> Kronecker:
+        return Kronecker(
+            A=self.A.symmetrize(),
+            B=self.B.symmetrize(),
+        )
+
 
 def _kronecker_matmul(
     A: _linear_operator.LinearOperator,
@@ -464,6 +470,12 @@ class SymmetricKronecker(_linear_operator.LinearOperator):
             return SymmetricKronecker(A=self.A.cholesky(lower))
 
         return super()._cholesky(lower)
+
+    def _symmetrize(self) -> SymmetricKronecker:
+        if self._identical_factors:
+            return SymmetricKronecker(A=self.A.symmetrize())
+
+        return SymmetricKronecker(A=self.A.symmetrize(), B=self.B.symmetrize())
 
 
 class IdentityKronecker(_linear_operator.LinearOperator):

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -201,17 +201,23 @@ class Kronecker(_linear_operator.LinearOperator):
 
         return NotImplemented
 
-    def _cholesky(self, lower: bool = True) -> Kronecker:
-        return Kronecker(
-            A=self.A.cholesky(lower),
-            B=self.B.cholesky(lower),
-        )
+    def _cholesky(self, lower: bool = True) -> _linear_operator.LinearOperator:
+        if self.A.is_symmetric and self.B.is_symmetric:
+            return Kronecker(
+                A=self.A.cholesky(lower),
+                B=self.B.cholesky(lower),
+            )
 
-    def _symmetrize(self) -> Kronecker:
-        return Kronecker(
-            A=self.A.symmetrize(),
-            B=self.B.symmetrize(),
-        )
+        return super()._cholesky(lower)
+
+    def _symmetrize(self) -> _linear_operator.LinearOperator:
+        if self.A.is_square and self.B.is_square:
+            return Kronecker(
+                A=self.A.symmetrize(),
+                B=self.B.symmetrize(),
+            )
+
+        return super()._symmetrize()
 
 
 def _kronecker_matmul(

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -201,14 +201,15 @@ class Kronecker(_linear_operator.LinearOperator):
 
         return NotImplemented
 
-    def _cholesky(self, lower: bool = True) -> _linear_operator.LinearOperator:
-        if self.A.is_symmetric and self.B.is_symmetric:
-            return Kronecker(
-                A=self.A.cholesky(lower),
-                B=self.B.cholesky(lower),
-            )
+    def _cholesky(self, lower: bool = True) -> Kronecker:
+        # A Kronecker product is symmetric iff its factors are symmetric, since
+        # (A (x) B)^T = A^T (x) B^T
+        assert self.A.is_symmetric and self.B.is_symmetric
 
-        return super()._cholesky(lower)
+        return Kronecker(
+            A=self.A.cholesky(lower),
+            B=self.B.cholesky(lower),
+        )
 
     def _symmetrize(self) -> _linear_operator.LinearOperator:
         if self.A.is_square and self.B.is_square:

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -520,6 +520,9 @@ class IdentityKronecker(_linear_operator.LinearOperator):
             trace=trace,
         )
 
+        if self.B.is_symmetric:
+            self.is_symmetric = True
+
     @property
     def num_blocks(self):
         return self._num_blocks
@@ -561,3 +564,15 @@ class IdentityKronecker(_linear_operator.LinearOperator):
             return self.A.cond(p=p) * self.B.cond(p=p)
 
         return np.linalg.cond(self.todense(cache=False), p=p)
+
+    def _cholesky(self, lower: bool = True) -> IdentityKronecker:
+        return IdentityKronecker(
+            num_blocks=self.num_blocks,
+            B=self.B.cholesky(lower),
+        )
+
+    def _symmetrize(self) -> IdentityKronecker:
+        return IdentityKronecker(
+            num_blocks=self.num_blocks,
+            B=self.B.symmetrize(),
+        )

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -557,7 +557,7 @@ class LinearOperator:
 
         The Cholesky decomposition of a symmetric positive-definite matrix :math:`A \in
         \mathbb{R}^{n \times n}` is given by :math:`A = L L^T`, where the unique
-        Cholesky factor `L \in \mathbb{R}^{n \times n}` of :math:`A` is a lower
+        Cholesky factor :math:`L \in \mathbb{R}^{n \times n}` of :math:`A` is a lower
         triangular matrix with a positive diagonal.
 
         As a side-effect, this method will set the value of :attr:`is_positive_definite`
@@ -717,17 +717,23 @@ class LinearOperator:
         norm is given by
 
         .. math::
-            sym(A) = \\frac{1}{2} (A + A^T).
+            \\operatorname{sym}(A) := \\frac{1}{2} (A + A^T).
 
         However, for efficiency reasons, it is preferrable to approximate this operator
-        in some cases. For example, a Kronecker product :math:`K = A \\ocross B` is more
+        in some cases. For example, a Kronecker product :math:`K = A \\otimes B` is more
         efficiently symmetrized by means of
 
         .. math::
-            sym(A) \\ocross sym(B)
-            = sym(K) + \\frac{1}{2} \\left(
-                sym(K) - \frac{1}{2} \\left( A \\ocross B^T + A^T \\ocross B \\right)
-            \\right).
+            :nowrap:
+
+            \\begin{equation}
+                \\operatorname{sym}(A) \\otimes \\operatorname{sym}(B)
+                = \\operatorname{sym}(K) + \\frac{1}{2} \\left(
+                    \\frac{1}{2} \\left(
+                        A \\otimes B^T + A^T \\otimes B
+                    \\right) - \\operatorname{sym}(K)
+                \\right).
+            \\end{equation}
 
         Returns
         -------

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -546,12 +546,21 @@ class LinearOperator:
 
             self.is_positive_definite = True
 
-        if self.__cholesky_cache.is_lower_triangular == lower:
+        upper = not lower
+
+        if (lower and self.__cholesky_cache.is_lower_triangular) or (
+            upper and self.__cholesky_cache.is_upper_triangular
+        ):
             return self.__cholesky_cache
+
+        assert (
+            self.__cholesky_cache.is_lower_triangular
+            or self.__cholesky_cache.is_upper_triangular
+        )
 
         return self.__cholesky_cache.T
 
-    def _cholesky(self, lower: bool = True) -> LinearOperator:
+    def _cholesky(self, lower: bool) -> LinearOperator:
         return Matrix(
             scipy.linalg.cholesky(
                 self.todense(), lower=lower, overwrite_a=False, check_finite=True

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -544,6 +544,8 @@ class LinearOperator:
             else:
                 self.__cholesky_cache.is_upper_triangular = True
 
+            self.is_positive_definite = True
+
         if self.__cholesky_cache.is_lower_triangular == lower:
             return self.__cholesky_cache
 

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -168,6 +168,10 @@ class LinearOperator:
 
         self.__cholesky_cache = None
 
+        # Property inference
+        if not self.is_square:
+            self.is_symmetric = False
+
     @property
     def shape(self) -> Tuple[int, int]:
         """Shape of the linear operator.
@@ -622,6 +626,21 @@ class LinearOperator:
             return _InverseLinearOperator(self)
 
         return self.__inverse()
+
+    def symmetrize(self) -> LinearOperator:
+        if not self.is_square:
+            raise np.linalg.LinAlgError("A non-square operator can not be symmetrized.")
+
+        if self.is_symmetric:
+            return self
+
+        linop_sym = self._symmetrize()
+        linop_sym.is_symmetric = True
+
+        return linop_sym
+
+    def _symmetrize(self) -> LinearOperator:
+        return 0.5 * (self + self.T)
 
     ####################################################################################
     # Binary Arithmetic
@@ -1082,6 +1101,9 @@ class Matrix(LinearOperator):
 
     def __neg__(self) -> "Matrix":
         return Matrix(-self.A)
+
+    def _symmetrize(self) -> LinearOperator:
+        return Matrix(0.5 * (self.A + self.A.T))
 
 
 class Identity(LinearOperator):

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -530,8 +530,11 @@ class LinearOperator:
     def cholesky(self, lower: bool = True) -> LinearOperator:
         if self.is_symmetric is None or not self.is_symmetric:
             raise np.linalg.LinAlgError(
-                "The Cholesky decomposition is only defined for symmetric matrices"
+                "The Cholesky decomposition is only defined for symmetric matrices."
             )
+
+        if self.is_positive_definite is False:
+            raise np.linalg.LinAlgError("The linear operator is not positive definite.")
 
         if self.__cholesky_cache is None:
             self.__cholesky_cache = self._cholesky(lower)

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -198,11 +198,6 @@ class LinearOperator:
         """Data type of the linear operator."""
         return self.__dtype
 
-    @property
-    def is_square(self) -> bool:
-        """Whether input dimension matches output dimension."""
-        return self.shape[0] == self.shape[1]
-
     def __repr__(self) -> str:
         return (
             f"<{self.__class__.__name__} with "
@@ -316,15 +311,31 @@ class LinearOperator:
     ####################################################################################
 
     @property
+    def is_square(self) -> bool:
+        """Whether input dimension matches output dimension."""
+        return self.shape[0] == self.shape[1]
+
+    @property
     def is_symmetric(self) -> Optional[bool]:
+        """Whether the ``LinearOperator`` :math:`L` is symmetric, i.e. :math:`L = L^T`.
+
+        If this is ``None``, it is unknown whether the operator is symmetric or not.
+        Only square operators can be symmetric."""
         return self._is_symmetric
 
     @is_symmetric.setter
     def is_symmetric(self, value: Optional[bool]) -> None:
+        if value is True and not self.is_square:
+            raise ValueError("Only square operators can be symmetric.")
+
         self._set_property("symmetric", value)
 
     @property
     def is_lower_triangular(self) -> Optional[bool]:
+        """Whether the ``LinearOperator`` represents a lower triangular matrix.
+
+        If this is ``None``, it is unknown whether the matrix is lower triangular or
+        not."""
         return self._is_lower_triangular
 
     @is_lower_triangular.setter
@@ -333,6 +344,10 @@ class LinearOperator:
 
     @property
     def is_upper_triangular(self) -> Optional[bool]:
+        """Whether the ``LinearOperator`` represents an upper triangular matrix.
+
+        If this is ``None``, it is unknown whether the matrix is upper triangular or
+        not."""
         return self._is_upper_triangular
 
     @is_upper_triangular.setter
@@ -341,10 +356,20 @@ class LinearOperator:
 
     @property
     def is_positive_definite(self) -> Optional[bool]:
+        """Whether the ``LinearOperator`` :math:`L \\in \\mathbb{R}^{n \\times n}` is
+        (strictly) positive-definite, i.e. :math:`x^T L x > 0` for :math:`x \\in \
+        \\mathbb{R}^n`.
+
+        If this is ``None``, it is unknown whether the matrix is positive-definite or
+        not. Only symmetric operators can be positive-definite.
+        """
         return self._is_positive_definite
 
     @is_positive_definite.setter
     def is_positive_definite(self, value: Optional[bool]) -> None:
+        if value is True and not self.is_symmetric:
+            raise ValueError("Only symmetric operators can be positive-definite.")
+
         self._set_property("positive_definite", value)
 
     def _set_property(self, name: str, value: Optional[bool]):

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -1001,7 +1001,9 @@ class _InverseLinearOperator(LinearOperator):
         because for some reason, the SciPy implementation does not raise an exception
         if the matrix is singular.
         """
-        from scipy.linalg.lapack import get_lapack_funcs
+        from scipy.linalg.lapack import (  # pylint: disable=no-name-in-module,import-outside-toplevel
+            get_lapack_funcs,
+        )
 
         a = np.asarray_chkfinite(a)
         (getrf,) = get_lapack_funcs(("getrf",), (a,))

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -970,16 +970,20 @@ class _InverseLinearOperator(LinearOperator):
         return self.__factorization
 
     def _matmat(self, x: np.ndarray) -> np.ndarray:
-        if self._cho_solve:
-            return scipy.linalg.cho_solve(self.factorization, x, overwrite_b=False)
+        factorization = self.factorization  # Precompute, so that _cho_solve will be set
 
-        return scipy.linalg.lu_solve(self.factorization, x, trans=0, overwrite_b=False)
+        if self._cho_solve:
+            return scipy.linalg.cho_solve(factorization, x, overwrite_b=False)
+
+        return scipy.linalg.lu_solve(factorization, x, trans=0, overwrite_b=False)
 
     def _tmatmat(self, x: np.ndarray) -> np.ndarray:
-        if self._cho_solve:
-            return scipy.linalg.cho_solve(self.factorization, x.T, overwrite_b=False)
+        factorization = self.factorization  # Precompute, so that _cho_solve will be set
 
-        return scipy.linalg.lu_solve(self.factorization, x, trans=1, overwrite_b=False)
+        if self._cho_solve:
+            return scipy.linalg.cho_solve(factorization, x.T, overwrite_b=False)
+
+        return scipy.linalg.lu_solve(factorization, x, trans=1, overwrite_b=False)
 
 
 class _TypeCastLinearOperator(LinearOperator):

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -388,7 +388,7 @@ class LinearOperator:
         if curr_value is not None:
             assert isinstance(curr_value, bool)
 
-            raise ValueError(f"Can not change the value of the matrix property {name}")
+            raise ValueError(f"Can not change the value of the matrix property {name}.")
 
         if not isinstance(value, bool):
             raise TypeError(

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -320,7 +320,7 @@ class LinearOperator:
         return self._is_symmetric
 
     @is_symmetric.setter
-    def _(self, value: Optional[bool]) -> None:
+    def is_symmetric(self, value: Optional[bool]) -> None:
         self._set_property("symmetric", value)
 
     @property
@@ -328,7 +328,7 @@ class LinearOperator:
         return self._is_lower_triangular
 
     @is_lower_triangular.setter
-    def _(self, value: Optional[bool]) -> None:
+    def is_lower_triangular(self, value: Optional[bool]) -> None:
         self._set_property("lower_triangular", value)
 
     @property
@@ -336,7 +336,7 @@ class LinearOperator:
         return self._is_upper_triangular
 
     @is_upper_triangular.setter
-    def _(self, value: Optional[bool]) -> None:
+    def is_upper_triangular(self, value: Optional[bool]) -> None:
         self._set_property("upper_triangular", value)
 
     @property
@@ -344,7 +344,7 @@ class LinearOperator:
         return self._is_positive_definite
 
     @is_positive_definite.setter
-    def _(self, value: Optional[bool]) -> None:
+    def is_positive_definite(self, value: Optional[bool]) -> None:
         self._set_property("positive_definite", value)
 
     def _set_property(self, name: str, value: Optional[bool]):

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -944,6 +944,10 @@ class _InverseLinearOperator(LinearOperator):
             logabsdet=lambda: -self._linop.logabsdet(),
         )
 
+        # Matrix properties
+        self.is_symmetric = self._linop.is_symmetric
+        self.is_positive_definite = self._linop.is_positive_definite
+
     def __repr__(self) -> str:
         return f"Inverse of {self._linop}"
 

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -711,6 +711,36 @@ class LinearOperator:
         return self.__inverse()
 
     def symmetrize(self) -> LinearOperator:
+        """Compute or approximate the closest symmetric :class:`LinearOperator` in the
+        Frobenius norm.
+
+        The closest symmetric matrix to a given square matrix :math:`A` in the Frobenius
+        norm is given by
+
+        .. math::
+            A_s = \\frac{1}{2} (A + A^T).
+
+        However, for efficiency reasons, it is preferrable to approximate this operator
+        in some cases. For example, a Kronecker product :math:`K = A \\ocross B` is more
+        efficiently symmetrized by means of
+
+        .. math::
+            A_s \\ocross B_s
+            = K_s + \\frac{1}{2} \\left( A \\ocross B^T + A^T \\ocross B \\right).
+
+        Returns
+        -------
+        symmetrized_linop :
+            The closest symmetric :class:`LinearOperator` in the Frobenius norm, or an
+            approximation, which makes a reasonable trade-off between accuracy and
+            efficiency (see above). The resulting :class:`LinearOperator` will have its
+            :attr:`is_symmetric` property set to :obj:`True`.
+
+        Raises
+        ------
+        numpy.linalg.LinAlgError
+            If this method is called on a non-square :class:`LinearOperator`.
+        """
         if not self.is_square:
             raise np.linalg.LinAlgError("A non-square operator can not be symmetrized.")
 

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -7,7 +7,6 @@ from typing import Callable, Optional, Tuple, Union
 import numpy as np
 import scipy.linalg
 import scipy.sparse.linalg
-from pytest import raises
 
 import probnum.utils
 from probnum import config

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -717,15 +717,17 @@ class LinearOperator:
         norm is given by
 
         .. math::
-            A_s = \\frac{1}{2} (A + A^T).
+            sym(A) = \\frac{1}{2} (A + A^T).
 
         However, for efficiency reasons, it is preferrable to approximate this operator
         in some cases. For example, a Kronecker product :math:`K = A \\ocross B` is more
         efficiently symmetrized by means of
 
         .. math::
-            A_s \\ocross B_s
-            = K_s + \\frac{1}{2} \\left( A \\ocross B^T + A^T \\ocross B \\right).
+            sym(A) \\ocross sym(B)
+            = sym(K) + \\frac{1}{2} \\left(
+                sym(K) - \frac{1}{2} \\left( A \\ocross B^T + A^T \\ocross B \\right)
+            \\right).
 
         Returns
         -------

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -318,13 +318,13 @@ class Scaling(_linear_operator.LinearOperator):
         if self._scalar is not None:
             if self._scalar <= 0:
                 raise np.linalg.LinAlgError(
-                    "The linear operator is not positive definite"
+                    "The linear operator is not positive definite."
                 )
 
             return Scaling(np.sqrt(self._scalar), shape=self.shape)
 
         if np.any(self._factors <= 0):
-            raise np.linalg.LinAlgError("The linear operator is not positive definite")
+            raise np.linalg.LinAlgError("The linear operator is not positive definite.")
 
         return Scaling(np.sqrt(self._factors))
 

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -164,6 +164,11 @@ class Scaling(_linear_operator.LinearOperator):
             trace=trace,
         )
 
+        # Matrix properties
+        self.is_symmetric = True
+        self.is_lower_triangular = True
+        self.is_upper_triangular = True
+
     @property
     def factors(self) -> np.ndarray:
         """Scaling factors.
@@ -331,3 +336,10 @@ class Zero(_linear_operator.LinearOperator):
             det=det,
             trace=trace,
         )
+
+        # Matrix properties
+        self.is_symmetric = True
+        self.is_lower_triangular = True
+        self.is_upper_triangular = True
+
+        self.is_positive_definite = False

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -354,8 +354,9 @@ class Zero(_linear_operator.LinearOperator):
         )
 
         # Matrix properties
-        self.is_symmetric = True
-        self.is_lower_triangular = True
-        self.is_upper_triangular = True
+        if self.is_square:
+            self.is_symmetric = True
+            self.is_lower_triangular = True
+            self.is_upper_triangular = True
 
-        self.is_positive_definite = False
+            self.is_positive_definite = False

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -171,6 +171,9 @@ class Scaling(_linear_operator.LinearOperator):
         self.is_lower_triangular = True
         self.is_upper_triangular = True
 
+        if self._scalar is not None:
+            self.is_positive_definite = bool(self._scalar > 0.0)
+
     @property
     def factors(self) -> np.ndarray:
         """Scaling factors.

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -318,7 +318,7 @@ class Scaling(_linear_operator.LinearOperator):
                     "The linear operator is not positive definite"
                 )
 
-            return Scaling(np.sqrt(self._scalar), shape=self.shape, dtype=self.dtype)
+            return Scaling(np.sqrt(self._scalar), shape=self.shape)
 
         if np.any(self._factors <= 0):
             raise np.linalg.LinAlgError("The linear operator is not positive definite")

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -1,4 +1,6 @@
 """Scaling linear operator."""
+from __future__ import annotations
+
 from typing import Optional, Union
 
 import numpy as np
@@ -308,6 +310,20 @@ class Scaling(_linear_operator.LinearOperator):
             )
         else:
             return np.linalg.cond(self.todense(cache=False), p=p)
+
+    def _cholesky(self, lower: bool = True) -> Scaling:
+        if self._scalar is not None:
+            if self._scalar <= 0:
+                raise np.linalg.LinAlgError(
+                    "The linear operator is not positive definite"
+                )
+
+            return Scaling(np.sqrt(self._scalar), shape=self.shape, dtype=self.dtype)
+
+        if np.any(self._factors <= 0):
+            raise np.linalg.LinAlgError("The linear operator is not positive definite")
+
+        return Scaling(np.sqrt(self._factors))
 
 
 class Zero(_linear_operator.LinearOperator):

--- a/tests/test_linops/test_linop_decompositions.py
+++ b/tests/test_linops/test_linop_decompositions.py
@@ -123,4 +123,4 @@ def test_cholesky_not_positive_definite(
     with pytest.raises(type(expected_exception)):
         linop.cholesky(lower=lower)
 
-    assert linop.is_positive_definite
+    assert linop.is_positive_definite is False

--- a/tests/test_linops/test_linop_decompositions.py
+++ b/tests/test_linops/test_linop_decompositions.py
@@ -1,0 +1,124 @@
+import pathlib
+
+import numpy as np
+import pytest
+import pytest_cases
+import scipy.linalg
+from pytest_cases import filters
+
+import probnum as pn
+
+case_modules = [
+    ".test_linops_cases." + path.stem
+    for path in (pathlib.Path(__file__).parent / "test_linops_cases").glob("*_cases.py")
+]
+
+
+@pytest_cases.parametrize_with_cases(
+    "linop,matrix",
+    cases=case_modules,
+    has_tag=(
+        "symmetric",
+        "positive-definite",
+    ),
+)
+@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
+def test_cholesky(linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool):
+    """Tests whether the lower (upper) Cholesky factor of a ``LinearOperator`` is a
+    lower-triangular (upper-triangular) matrix square-root with positive diagonal."""
+
+    linop_cho = linop.cholesky(lower=lower)
+
+    np.testing.assert_allclose(
+        (linop_cho @ linop_cho.T if lower else linop_cho.T @ linop_cho).todense(),
+        matrix,
+        err_msg="Not a valid matrix square root",
+    )
+
+    np.testing.assert_array_equal(
+        np.diag(linop_cho.todense()) > 0,
+        True,
+        err_msg="Diagonal of the Cholesky factor is not positive.",
+    )
+
+    assert linop_cho.is_lower_triangular if lower else linop_cho.is_upper_triangular
+
+    np.testing.assert_array_equal(
+        (
+            np.triu(linop_cho.todense(), k=1)
+            if lower
+            else np.tril(linop_cho.todense(), k=-1)
+        ),
+        0.0,
+        err_msg=f"Cholesky factor is not {'lower' if lower else 'upper'} triangular",
+    )
+
+    # Test cacheing
+    assert linop.cholesky(lower=lower) is linop_cho
+
+    # Access transpose of the cached Cholesky factor
+    np.testing.assert_array_equal(
+        linop.cholesky(lower=not lower).T.todense(), linop_cho.todense()
+    )
+
+
+@pytest_cases.parametrize_with_cases(
+    "linop,matrix",
+    cases=case_modules,
+)
+@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
+def test_cholesky_is_symmetric_not_true(
+    linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
+):  # pylint: disable=unused-argument
+    """Tests whether computing the Cholesky decomposition of a ``LinearOperator``
+    whose ``is_symmetric`` property is not set to ``True`` results in an error."""
+
+    if linop.is_symmetric is not True:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.cholesky(lower=lower)
+
+
+@pytest_cases.parametrize_with_cases(
+    "linop,matrix",
+    cases=case_modules,
+)
+@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
+def test_cholesky_is_positive_definite_false(
+    linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
+):  # pylint: disable=unused-argument
+    """Tests whether computing the Cholesky decomposition of a ``LinearOperator``
+    whose ``is_symmetric`` property is not set to ``True`` results in an error."""
+
+    if linop.is_positive_definite is False:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.cholesky(lower=lower)
+
+
+@pytest_cases.parametrize_with_cases(
+    "linop,matrix",
+    cases=case_modules,
+    filter=(
+        filters.has_tag("symmetric")
+        & (
+            filters.has_tag("singular")
+            | filters.has_tag("negative-definite")
+            | filters.has_tag("indefinite")
+        )
+    ),
+)
+@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
+def test_cholesky_not_positive_definite(
+    linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
+):
+    """Tests whether computing the Cholesky decomposition of a symmetric, but not
+    positive definite matrix results in an error"""
+
+    expected_exception = None
+
+    try:
+        scipy.linalg.cholesky(matrix, lower=lower)
+    except Exception as e:  # pylint: disable=broad-except
+        expected_exception = e
+
+    with pytest.raises(type(expected_exception)):
+        linop.cholesky(lower=lower)

--- a/tests/test_linops/test_linop_decompositions.py
+++ b/tests/test_linops/test_linop_decompositions.py
@@ -122,3 +122,5 @@ def test_cholesky_not_positive_definite(
 
     with pytest.raises(type(expected_exception)):
         linop.cholesky(lower=lower)
+
+    assert linop.is_positive_definite

--- a/tests/test_linops/test_linop_properties.py
+++ b/tests/test_linops/test_linop_properties.py
@@ -1,0 +1,30 @@
+import pathlib
+
+import numpy as np
+import pytest
+import pytest_cases
+
+import probnum as pn
+
+case_modules = [
+    ".test_linops_cases." + path.stem
+    for path in (pathlib.Path(__file__).parent / "test_linops_cases").glob("*_cases.py")
+]
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_symmetric_linop_must_be_square(
+    linop: pn.linops.LinearOperator, matrix: np.ndarray
+):
+    if not linop.is_square:
+        with pytest.raises(ValueError):
+            linop.is_symmetric = True
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_positive_definite_linop_must_be_symmetric(
+    linop: pn.linops.LinearOperator, matrix: np.ndarray
+):
+    if not linop.is_symmetric:
+        with pytest.raises(ValueError):
+            linop.is_positive_definite = True

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -435,3 +435,16 @@ def test_cholesky_not_positive_definite(
 
     with pytest.raises(type(expected_exception)):
         linop.cholesky(lower=lower)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_symmetrize(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    if linop.is_square:
+        sym_linop = linop.symmetrize()
+
+        assert sym_linop.is_symmetric
+
+        np.testing.assert_array_equal(sym_linop.todense().T, sym_linop.todense())
+    else:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.symmetrize()

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -390,19 +390,43 @@ def test_cholesky(linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bo
         err_msg=f"Cholesky factor is not {'lower' if lower else 'upper'} triangular",
     )
 
+    # Test cacheing
+    assert linop.cholesky(lower=lower) is linop_cho
+
+    # Access transpose of the cached Cholesky factor
+    np.testing.assert_array_equal(
+        linop.cholesky(lower=not lower).T.todense(), linop_cho.todense()
+    )
+
 
 @pytest_cases.parametrize_with_cases(
     "linop,matrix",
     cases=case_modules,
 )
 @pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
-def test_cholesky_is_symmetric_not_set(
+def test_cholesky_is_symmetric_not_true(
     linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
 ):  # pylint: disable=unused-argument
     """Tests whether computing the Cholesky decomposition of a ``LinearOperator``
     whose ``is_symmetric`` property is not set to ``True`` results in an error."""
 
     if linop.is_symmetric is not True:
+        with pytest.raises(np.linalg.LinAlgError):
+            linop.cholesky(lower=lower)
+
+
+@pytest_cases.parametrize_with_cases(
+    "linop,matrix",
+    cases=case_modules,
+)
+@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
+def test_cholesky_is_positive_definite_false(
+    linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
+):  # pylint: disable=unused-argument
+    """Tests whether computing the Cholesky decomposition of a ``LinearOperator``
+    whose ``is_symmetric`` property is not set to ``True`` results in an error."""
+
+    if linop.is_positive_definite is False:
         with pytest.raises(np.linalg.LinAlgError):
             linop.cholesky(lower=lower)
 

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -347,3 +347,20 @@ def test_inv(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     else:
         with pytest.raises(np.linalg.LinAlgError):
             linop.inv()
+
+
+@pytest_cases.parametrize_with_cases(
+    "linop,matrix",
+    cases=case_modules,
+    has_tag=(
+        "symmetric",
+        "positive-definite",
+    ),
+)
+def test_cholesky(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    L = linop.cholesky(lower=True)
+
+    np.testing.assert_allclose(
+        (L @ L.T).todense(),
+        matrix,
+    )

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -4,8 +4,6 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import pytest
 import pytest_cases
-import scipy.linalg
-from pytest_cases import filters
 
 import probnum as pn
 
@@ -349,116 +347,6 @@ def test_inv(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     else:
         with pytest.raises(np.linalg.LinAlgError):
             linop.inv().todense()
-
-
-@pytest_cases.parametrize_with_cases(
-    "linop,matrix",
-    cases=case_modules,
-    has_tag=(
-        "symmetric",
-        "positive-definite",
-    ),
-)
-@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
-def test_cholesky(linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool):
-    """Tests whether the lower (upper) Cholesky factor of a ``LinearOperator`` is a
-    lower-triangular (upper-triangular) matrix square-root with positive diagonal."""
-
-    linop_cho = linop.cholesky(lower=lower)
-
-    np.testing.assert_allclose(
-        (linop_cho @ linop_cho.T if lower else linop_cho.T @ linop_cho).todense(),
-        matrix,
-        err_msg="Not a valid matrix square root",
-    )
-
-    np.testing.assert_array_equal(
-        np.diag(linop_cho.todense()) > 0,
-        True,
-        err_msg="Diagonal of the Cholesky factor is not positive.",
-    )
-
-    assert linop_cho.is_lower_triangular if lower else linop_cho.is_upper_triangular
-
-    np.testing.assert_array_equal(
-        (
-            np.triu(linop_cho.todense(), k=1)
-            if lower
-            else np.tril(linop_cho.todense(), k=-1)
-        ),
-        0.0,
-        err_msg=f"Cholesky factor is not {'lower' if lower else 'upper'} triangular",
-    )
-
-    # Test cacheing
-    assert linop.cholesky(lower=lower) is linop_cho
-
-    # Access transpose of the cached Cholesky factor
-    np.testing.assert_array_equal(
-        linop.cholesky(lower=not lower).T.todense(), linop_cho.todense()
-    )
-
-
-@pytest_cases.parametrize_with_cases(
-    "linop,matrix",
-    cases=case_modules,
-)
-@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
-def test_cholesky_is_symmetric_not_true(
-    linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
-):  # pylint: disable=unused-argument
-    """Tests whether computing the Cholesky decomposition of a ``LinearOperator``
-    whose ``is_symmetric`` property is not set to ``True`` results in an error."""
-
-    if linop.is_symmetric is not True:
-        with pytest.raises(np.linalg.LinAlgError):
-            linop.cholesky(lower=lower)
-
-
-@pytest_cases.parametrize_with_cases(
-    "linop,matrix",
-    cases=case_modules,
-)
-@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
-def test_cholesky_is_positive_definite_false(
-    linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
-):  # pylint: disable=unused-argument
-    """Tests whether computing the Cholesky decomposition of a ``LinearOperator``
-    whose ``is_symmetric`` property is not set to ``True`` results in an error."""
-
-    if linop.is_positive_definite is False:
-        with pytest.raises(np.linalg.LinAlgError):
-            linop.cholesky(lower=lower)
-
-
-@pytest_cases.parametrize_with_cases(
-    "linop,matrix",
-    cases=case_modules,
-    filter=(
-        filters.has_tag("symmetric")
-        & (
-            filters.has_tag("singular")
-            | filters.has_tag("negative-definite")
-            | filters.has_tag("indefinite")
-        )
-    ),
-)
-@pytest_cases.parametrize("lower", [True, False], ids=["lower", "upper"])
-def test_cholesky_not_positive_definite(
-    linop: pn.linops.LinearOperator, matrix: np.ndarray, lower: bool
-):
-    """Tests whether computing the Cholesky decomposition of a symmetric, but not
-    positive definite matrix results in an error"""
-
-    expected_exception = None
-
-    try:
-        scipy.linalg.cholesky(matrix, lower=lower)
-    except Exception as e:  # pylint: disable=broad-except
-        expected_exception = e
-
-    with pytest.raises(type(expected_exception)):
-        linop.cholesky(lower=lower)
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -345,10 +345,10 @@ def test_inv(linop: pn.linops.LinearOperator, matrix: np.ndarray):
             np.testing.assert_allclose(linop_inv.todense(), matrix_inv, atol=1e-12)
         else:
             with pytest.raises(type(expected_exception)):
-                linop.inv()
+                linop.inv().todense()
     else:
         with pytest.raises(np.linalg.LinAlgError):
-            linop.inv()
+            linop.inv().todense()
 
 
 @pytest_cases.parametrize_with_cases(

--- a/tests/test_linops/test_linops_cases/arithmetic_cases.py
+++ b/tests/test_linops/test_linops_cases/arithmetic_cases.py
@@ -1,0 +1,44 @@
+from typing import Tuple
+
+import numpy as np
+import pytest_cases
+
+import probnum as pn
+from probnum.linops._arithmetic_fallbacks import ScaledLinearOperator, SumLinearOperator
+from probnum.problems.zoo.linalg import random_spd_matrix
+
+spd_matrix_pairs = [
+    (
+        random_spd_matrix(np.random.default_rng(n + 9872), dim=n),
+        random_spd_matrix(np.random.default_rng(n + 1231), dim=n),
+    )
+    for n in [1, 2, 3, 5, 8]
+]
+
+
+@pytest_cases.case(tags=("square", "symmetric", "positive-definite"))
+@pytest_cases.parametrize("A", [A for A, _ in spd_matrix_pairs])
+@pytest_cases.parametrize("scalar", (4.2,))
+def case_scaled_linop_positive_definite(A: np.ndarray, scalar: float):
+    matrix = scalar * A
+
+    A = pn.linops.aslinop(A)
+    A.is_symmetric = True
+
+    return ScaledLinearOperator(A, scalar), matrix
+
+
+@pytest_cases.case(tags=("square", "symmetric", "positive-definite"))
+@pytest_cases.parametrize("A,B", spd_matrix_pairs)
+def case_sum_linop_positive_definite(
+    A: np.ndarray, B: np.ndarray
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    matrix = A + B
+
+    A = pn.linops.aslinop(A)
+    A.is_symmetric = True
+
+    B = pn.linops.aslinop(B)
+    B.is_symmetric = True
+
+    return SumLinearOperator(A, B), matrix

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -47,8 +47,8 @@ def case_kronecker(
     "A,B",
     [
         (
-            np.random.default_rng(78923 + m + n).standard_normal((m, n)),
-            np.random.default_rng(25789 + m + n).standard_normal((n, m)),
+            np.random.default_rng(78923 + m + n).uniform(0.9, 1.1, (m, n)),
+            np.random.default_rng(25789 + m + n).uniform(0.9, 1.1, (n, m)),
         )
         for m, n in ((3, 4), (1, 8), (2, 3))
     ],

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -56,6 +56,10 @@ def case_kronecker(
 def case_kronecker_square_non_square_factors(
     A: np.ndarray, B: np.ndarray
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    # Set last row to 0 to ensure singularity
+    # Without this, numerical instabilities in the `.inv()` tests lead to test failure
+    A[-1, :] = 0
+
     linop = pn.linops.Kronecker(A, B)
     matrix = np.kron(A, B)
 

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -48,7 +48,7 @@ def case_kronecker(
     [
         (
             np.random.default_rng(78923 + m + n).uniform(0.9, 1.1, (m, n)),
-            np.random.default_rng(25789 + m + n).uniform(0.9, 1.1, (n, m)),
+            np.full((n, m), np.random.default_rng(25789 + m + n).uniform(0.9, 1.1)),
         )
         for m, n in ((3, 4), (1, 8), (2, 3))
     ],
@@ -56,10 +56,6 @@ def case_kronecker(
 def case_kronecker_square_non_square_factors(
     A: np.ndarray, B: np.ndarray
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
-    # Set last row to 0 to ensure singularity
-    # Without this, numerical instabilities in the `.inv()` tests lead to test failure
-    A[-1, :] = 0
-
     linop = pn.linops.Kronecker(A, B)
     matrix = np.kron(A, B)
 

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -123,10 +123,22 @@ def case_symmetric_kronecker_identical_factors_positive_definite(
     return linop, matrix
 
 
+@pytest_cases.case(tags=["square"])
+@pytest_cases.parametrize("num_blocks", [1, 2, 3])
+@pytest_cases.parametrize("B", [np.array([[0.4, 2, 0.8], [-0.4, 0, -0.9], [1, 0, 2]])])
+def case_identity_kronecker_square(
+    num_blocks: int, B: Union[np.ndarray, pn.linops.LinearOperator]
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.IdentityKronecker(num_blocks, B)
+    matrix = np.kron(np.eye(num_blocks, dtype=linop.dtype), B)
+
+    return linop, matrix
+
+
 @pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
 @pytest_cases.parametrize("num_blocks", [1, 2, 3])
 @pytest_cases.parametrize("B", spd_matrices)
-def case_identity_kronecker(
+def case_identity_kronecker_positive_definite(
     num_blocks: int, B: Union[np.ndarray, pn.linops.LinearOperator]
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     B = pn.linops.aslinop(B)

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -11,8 +11,7 @@ from probnum.problems.zoo.linalg import random_spd_matrix
 spd_matrices = (
     pn.linops.Identity(shape=(1, 1)),
     np.array([[1.0, -2.0], [-2.0, 5.0]]),
-    random_spd_matrix(np.random.default_rng(597), dim=10),
-    random_spd_matrix(np.random.default_rng(597), dim=13),
+    random_spd_matrix(np.random.default_rng(597), dim=9),
 )
 
 

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -101,6 +101,35 @@ def case_symmetric_kronecker(
     return linop, matrix
 
 
+@pytest_cases.case(
+    tags=["symmetric_kronecker", "square", "symmetric", "positive-definite"]
+)
+@pytest_cases.parametrize(
+    "A,B",
+    [
+        (
+            random_spd_matrix(np.random.default_rng(234789 + n), dim=n),
+            random_spd_matrix(np.random.default_rng(347892 + n), dim=n),
+        )
+        for n in [1, 2, 3, 6]
+    ],
+)
+def case_symmetric_kronecker_positive_definite(
+    A: Union[np.ndarray, pn.linops.LinearOperator],
+    B: Union[np.ndarray, pn.linops.LinearOperator],
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    A = pn.linops.aslinop(A)
+    A.is_symmetric = True
+
+    B = pn.linops.aslinop(B)
+    B.is_symmetric = True
+
+    linop = pn.linops.SymmetricKronecker(A, B)
+    matrix = (np.kron(A.todense(), B.todense()) + np.kron(B.todense(), A.todense())) / 2
+
+    return linop, matrix
+
+
 @pytest.mark.parametrize(
     "A",
     [

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -121,3 +121,18 @@ def case_symmetric_kronecker_identical_factors_positive_definite(
     matrix = np.kron(A.todense(), A.todense())
 
     return linop, matrix
+
+
+@pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
+@pytest_cases.parametrize("num_blocks", [1, 2, 3])
+@pytest_cases.parametrize("B", spd_matrices)
+def case_identity_kronecker(
+    num_blocks: int, B: Union[np.ndarray, pn.linops.LinearOperator]
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    B = pn.linops.aslinop(B)
+    B.is_symmetric = True
+
+    linop = pn.linops.IdentityKronecker(num_blocks, B)
+    matrix = np.kron(np.eye(num_blocks, dtype=linop.dtype), B.todense())
+
+    return linop, matrix

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -42,6 +42,26 @@ def case_kronecker(
     return linop, matrix
 
 
+@pytest_cases.case(tags=["square", "singular"])
+@pytest_cases.parametrize(
+    "A,B",
+    [
+        (
+            np.random.default_rng(78923 + m + n).standard_normal((m, n)),
+            np.random.default_rng(25789 + m + n).standard_normal((n, m)),
+        )
+        for m, n in ((3, 4), (1, 8), (2, 3))
+    ],
+)
+def case_kronecker_square_non_square_factors(
+    A: np.ndarray, B: np.ndarray
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.Kronecker(A, B)
+    matrix = np.kron(A, B)
+
+    return linop, matrix
+
+
 @pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
 @pytest_cases.parametrize("A,B", itertools.product(spd_matrices, spd_matrices))
 def case_kronecker_positive_definite(

--- a/tests/test_linops/test_linops_cases/kronecker_cases.py
+++ b/tests/test_linops/test_linops_cases/kronecker_cases.py
@@ -1,10 +1,19 @@
-from typing import Tuple
+import itertools
+from typing import Tuple, Union
 
 import numpy as np
 import pytest
 import pytest_cases
 
 import probnum as pn
+from probnum.problems.zoo.linalg import random_spd_matrix
+
+spd_matrices = (
+    pn.linops.Identity(shape=(1, 1)),
+    np.array([[1.0, -2.0], [-2.0, 5.0]]),
+    random_spd_matrix(np.random.default_rng(597), dim=10),
+    random_spd_matrix(np.random.default_rng(597), dim=13),
+)
 
 
 @pytest.mark.parametrize(
@@ -30,6 +39,24 @@ def case_kronecker(
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     linop = pn.linops.Kronecker(A, B)
     matrix = np.kron(A, B)
+
+    return linop, matrix
+
+
+@pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
+@pytest_cases.parametrize("A,B", itertools.product(spd_matrices, spd_matrices))
+def case_kronecker_positive_definite(
+    A: Union[np.ndarray, pn.linops.LinearOperator],
+    B: Union[np.ndarray, pn.linops.LinearOperator],
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    A = pn.linops.aslinop(A)
+    A.is_symmetric = True
+
+    B = pn.linops.aslinop(B)
+    B.is_symmetric = True
+
+    linop = pn.linops.Kronecker(A, B)
+    matrix = np.kron(A.todense(), B.todense())
 
     return linop, matrix
 
@@ -72,5 +99,26 @@ def case_symmetric_kronecker_identical_factors(
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     linop = pn.linops.SymmetricKronecker(A)
     matrix = np.kron(A, A)
+
+    return linop, matrix
+
+
+@pytest_cases.case(
+    tags=[
+        "symmetric_kronecker",
+        "square",
+        "symmetric",
+        "positive-definite",
+    ]
+)
+@pytest_cases.parametrize("A", spd_matrices)
+def case_symmetric_kronecker_identical_factors_positive_definite(
+    A: Union[np.ndarray, pn.linops.LinearOperator],
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    A = pn.linops.aslinop(A)
+    A.is_symmetric = True
+
+    linop = pn.linops.SymmetricKronecker(A)
+    matrix = np.kron(A.todense(), A.todense())
 
     return linop, matrix

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -2,14 +2,21 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+import pytest_cases
 import scipy.sparse
 
 import probnum as pn
+from probnum.problems.zoo.linalg import random_spd_matrix
 
 matrices = [
     np.array([[-1.5, 3], [0, -230]]),
     np.array([[2, 0], [1, 3]]),
     np.array([[2, 0, -1.5], [1, 3, -230]]),
+]
+spd_matrices = [
+    np.array([[1.0]]),
+    np.array([[1.0, -2.0], [-2.0, 5.0]]),
+    random_spd_matrix(np.random.default_rng(597), dim=10),
 ]
 
 
@@ -26,11 +33,37 @@ def case_matvec(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.ndarra
     return linop, matrix
 
 
+@pytest_cases.case(tags=("square", "symmetric", "positive-definite"))
+@pytest_cases.parametrize("matrix", spd_matrices)
+def case_matvec_spd(matrix: np.ndarray):
+    @pn.linops.LinearOperator.broadcast_matvec
+    def _matmul(vec: np.ndarray):
+        return matrix @ vec
+
+    linop = pn.linops.LinearOperator(
+        shape=matrix.shape, dtype=matrix.dtype, matmul=_matmul
+    )
+
+    linop.is_symmetric = True
+
+    return linop, matrix
+
+
 @pytest.mark.parametrize("matrix", matrices)
 def case_matrix(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     return pn.linops.Matrix(matrix), matrix
 
 
+@pytest_cases.case(tags=("square", "symmetric", "positive-definite"))
+@pytest_cases.parametrize("matrix", spd_matrices)
+def case_matrix_spd(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.Matrix(matrix)
+    linop.is_symmetric = True
+
+    return linop, matrix
+
+
+@pytest_cases.case(tags=("square", "symmetric", "positive-definite"))
 @pytest.mark.parametrize("n", [3, 4, 8, 12, 15])
 def case_identity(n: int) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     return pn.linops.Identity(shape=n), np.eye(n)

--- a/tests/test_linops/test_linops_cases/scaling_cases.py
+++ b/tests/test_linops/test_linops_cases/scaling_cases.py
@@ -16,10 +16,7 @@ import probnum as pn
 def case_anisotropic_scaling(
     diagonal: np.ndarray,
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
-    linop = pn.linops.Scaling(diagonal)
-    linop.is_positive_definite = False
-
-    return linop, np.diag(diagonal)
+    return pn.linops.Scaling(diagonal), np.diag(diagonal)
 
 
 @pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
@@ -45,10 +42,7 @@ def case_positive_anisotropic_scaling(
 def case_singular_anisotropic_scaling(
     diagonal: np.ndarray,
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
-    linop = pn.linops.Scaling(diagonal)
-    linop.is_positive_definite = False
-
-    return linop, np.diag(diagonal)
+    return pn.linops.Scaling(diagonal), np.diag(diagonal)
 
 
 @pytest_cases.case(tags=["square", "symmetric", "positive-definite"])

--- a/tests/test_linops/test_linops_cases/scaling_cases.py
+++ b/tests/test_linops/test_linops_cases/scaling_cases.py
@@ -16,7 +16,10 @@ import probnum as pn
 def case_anisotropic_scaling(
     diagonal: np.ndarray,
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
-    return pn.linops.Scaling(diagonal), np.diag(diagonal)
+    linop = pn.linops.Scaling(diagonal)
+    linop.is_positive_definite = False
+
+    return linop, np.diag(diagonal)
 
 
 @pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
@@ -42,7 +45,10 @@ def case_positive_anisotropic_scaling(
 def case_singular_anisotropic_scaling(
     diagonal: np.ndarray,
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
-    return pn.linops.Scaling(diagonal), np.diag(diagonal)
+    linop = pn.linops.Scaling(diagonal)
+    linop.is_positive_definite = False
+
+    return linop, np.diag(diagonal)
 
 
 @pytest_cases.case(tags=["square", "symmetric", "positive-definite"])

--- a/tests/test_linops/test_linops_cases/scaling_cases.py
+++ b/tests/test_linops/test_linops_cases/scaling_cases.py
@@ -72,7 +72,7 @@ def case_positive_isotropic_scaling(
 )
 @pytest_cases.parametrize("n", [3, 4, 8, 12, 15])
 def case_singular_isotropic_scaling(n: int):
-    return pn.linops.Scaling(0.0, shape=n), np.zeros((n,), dtype=np.double)
+    return pn.linops.Scaling(0.0, shape=n), np.zeros((n, n), dtype=np.double)
 
 
 @pytest_cases.case(tags=["square", "symmetric", "negative-definite"])

--- a/tests/test_linops/test_linops_cases/scaling_cases.py
+++ b/tests/test_linops/test_linops_cases/scaling_cases.py
@@ -1,16 +1,16 @@
 from typing import Tuple
 
 import numpy as np
-import pytest
+import pytest_cases
 
 import probnum as pn
 
 
-@pytest.mark.parametrize(
+@pytest_cases.case(tags=["symmetric", "indefinite"])
+@pytest_cases.parametrize(
     "diagonal",
     [
         np.array([1.0, 2, -3]),
-        np.array([1.0, 2.0, 0.0, -1.0]),
     ],
 )
 def case_anisotropic_scaling(
@@ -19,17 +19,70 @@ def case_anisotropic_scaling(
     return pn.linops.Scaling(diagonal), np.diag(diagonal)
 
 
-@pytest.mark.parametrize("n", [3, 4, 8, 12, 15])
-@pytest.mark.parametrize(
+@pytest_cases.case(tags=["symmetric", "positive-definite"])
+@pytest_cases.parametrize(
+    "diagonal",
+    [
+        np.array([2.0, 5.0, 8.0]),
+    ],
+)
+def case_positive_anisotropic_scaling(
+    diagonal: np.ndarray,
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    return pn.linops.Scaling(diagonal), np.diag(diagonal)
+
+
+@pytest_cases.case(tags=["symmetric", "singular", "indefinite"])
+@pytest_cases.parametrize(
+    "diagonal",
+    [
+        np.array([1.0, 2.0, 0.0, -1.0]),
+    ],
+)
+def case_singular_anisotropic_scaling(
+    diagonal: np.ndarray,
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    return pn.linops.Scaling(diagonal), np.diag(diagonal)
+
+
+@pytest_cases.case(tags=["symmetric", "positive-definite"])
+@pytest_cases.parametrize("n", [3, 4, 8, 12, 15])
+@pytest_cases.parametrize(
     "scalar",
     [
-        0.0,  # Singular matrix
         1.0,  # Identity
+        2.8,  # double dtype
         5,  # Integer dtype
+    ],
+)
+def case_positive_isotropic_scaling(
+    n: int, scalar
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    return pn.linops.Scaling(scalar, shape=n), np.diag(np.full((n,), scalar))
+
+
+@pytest_cases.case(
+    tags=[
+        "symmetric",
+        "singular",
+        "positive-semidefinite",
+        "negative-semidefinite",
+    ]
+)
+@pytest_cases.parametrize("n", [3, 4, 8, 12, 15])
+def case_singular_isotropic_scaling(n: int):
+    return pn.linops.Scaling(0.0, shape=n), np.zeros((n,), dtype=np.double)
+
+
+@pytest_cases.case(tags=["symmetric", "negative-definite"])
+@pytest_cases.parametrize("n", [3, 4, 8, 12, 15])
+@pytest_cases.parametrize(
+    "scalar",
+    [
         -8.3,
     ],
 )
-def case_isotropic_scaling(
+def case_negative_isotropic_scaling(
     n: int, scalar
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     return pn.linops.Scaling(scalar, shape=n), np.diag(np.full((n,), scalar))

--- a/tests/test_linops/test_linops_cases/scaling_cases.py
+++ b/tests/test_linops/test_linops_cases/scaling_cases.py
@@ -6,7 +6,7 @@ import pytest_cases
 import probnum as pn
 
 
-@pytest_cases.case(tags=["symmetric", "indefinite"])
+@pytest_cases.case(tags=["square", "symmetric", "indefinite"])
 @pytest_cases.parametrize(
     "diagonal",
     [
@@ -19,7 +19,7 @@ def case_anisotropic_scaling(
     return pn.linops.Scaling(diagonal), np.diag(diagonal)
 
 
-@pytest_cases.case(tags=["symmetric", "positive-definite"])
+@pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
 @pytest_cases.parametrize(
     "diagonal",
     [
@@ -32,7 +32,7 @@ def case_positive_anisotropic_scaling(
     return pn.linops.Scaling(diagonal), np.diag(diagonal)
 
 
-@pytest_cases.case(tags=["symmetric", "singular", "indefinite"])
+@pytest_cases.case(tags=["square", "symmetric", "singular", "indefinite"])
 @pytest_cases.parametrize(
     "diagonal",
     [
@@ -45,7 +45,7 @@ def case_singular_anisotropic_scaling(
     return pn.linops.Scaling(diagonal), np.diag(diagonal)
 
 
-@pytest_cases.case(tags=["symmetric", "positive-definite"])
+@pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
 @pytest_cases.parametrize("n", [3, 4, 8, 12, 15])
 @pytest_cases.parametrize(
     "scalar",
@@ -63,6 +63,7 @@ def case_positive_isotropic_scaling(
 
 @pytest_cases.case(
     tags=[
+        "square",
         "symmetric",
         "singular",
         "positive-semidefinite",
@@ -74,7 +75,7 @@ def case_singular_isotropic_scaling(n: int):
     return pn.linops.Scaling(0.0, shape=n), np.zeros((n,), dtype=np.double)
 
 
-@pytest_cases.case(tags=["symmetric", "negative-definite"])
+@pytest_cases.case(tags=["square", "symmetric", "negative-definite"])
 @pytest_cases.parametrize("n", [3, 4, 8, 12, 15])
 @pytest_cases.parametrize(
     "scalar",


### PR DESCRIPTION
# In a Nutshell
This PR implements Cholesky decompositions for ProbNum's `linops` library.
To achieve this goal, I also had to implement symmetrization and parts of a matrix property system.

# Detailed Description
- `LinearOperator.cholesky(lower: bool) -> LinearOperator`
- `LinearOperator.symmetrize() -> LinearOperator` implementing "1/2 * (A + A^T)"
- Matrix properties
    - `is_symmetric`
    - `is_{upper,lower}_triangular`
    - `is_positive_definite`
- Fixed bugs in `Kronecker.{inv,cond}`
- `_InverseLinearOperator` uses Cholesky factorization for SPD matrices
- Fixed bug in `_InverseLinearOperator` of singular matrix
- Added new tests and test cases

# Related Issues
Implements parts of #569 and #571
