### PR TITLE
Scipy intersphinx mapping update

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,7 +144,7 @@ nbsphinx_execute_arguments = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
     "matplotlib": ("https://matplotlib.org/", None),
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,7 +144,7 @@ nbsphinx_execute_arguments = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "matplotlib": ("https://matplotlib.org/", None),
 }
 


### PR DESCRIPTION
# In a Nutshell
Scipy apparently moved its intersphinx mapping (https://github.com/scipy/scipy/issues/14267). I am not sure why the doc-build still works, but it seems that the new address is https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/. 

This PR is split off from #626, to not interfere with merging the pytest version pin. If it should not be merged, then we can shoot down this one here instead of slowing the other one (no hard feelings in this case :)) . 
