### PR TITLE
Pin MyST-Parser Version

### DIFF
--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -12,4 +12,4 @@ sphinx-gallery
 sphinxcontrib-bibtex
 
 # Markdown conversion
-myst-parser
+myst-parser<0.17.0


### PR DESCRIPTION
# In a Nutshell
The latest release 0.17.0 of [MyST-Parser](https://github.com/executablebooks/MyST-Parser) seems to have introduced a bug causing our readthedocs build to fail. Pinning the version alleviates such issues from coming up in the future.

# Detailed Description
On version 0.17.0 the following cross-reference of an anchor in `docs/source/development/pull_request.md` causes a warning:

```markdown
[continuous integration (CI)](#continuous-integration)
```
