### PR TITLE
`codecov/codecov-action` instead of bash uploader

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -31,8 +31,8 @@ jobs:
         # Run tox using the version of Python in `PATH`
         run: tox -e py3
       - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v2
         if: startsWith(matrix.platform,'ubuntu') && matrix.python == '3.8'
-        run: bash <(curl -s https://codecov.io/bash)
 
   documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# In a Nutshell
The bash uploader has been deprecated by codecov. This PR refactors the CI to use the new preferred way to upload coverage reports.

# Detailed Description
- use `codecov/codecov-action` to upload coverage reports

# Related Issues
None
