### PR TITLE
Simplified TaylorMode implementation

### DIFF
--- a/src/probnum/diffeq/odefilter/init_routines/_autodiff.py
+++ b/src/probnum/diffeq/odefilter/init_routines/_autodiff.py
@@ -203,6 +203,11 @@ class TaylorMode(_AutoDiffBase):
         taylor_coefficients = self._taylor_approximation(
             f=f, y0=y0, order=num_derivatives
         )
+
+        # The `f` parameter is an autonomous ODE vector field that
+        # used to be a non-autonomous ODE vector field.
+        # Therefore, we eliminate the final column of the result,
+        # which would correspond to the `t`-part in f(t, y(t)).
         return taylor_coefficients[:, :-1]
 
     def _taylor_approximation(self, *, f, y0, order):

--- a/src/probnum/diffeq/odefilter/init_routines/_autodiff.py
+++ b/src/probnum/diffeq/odefilter/init_routines/_autodiff.py
@@ -214,9 +214,15 @@ class TaylorMode(_AutoDiffBase):
         """Compute an `n`th order Taylor approximation of f at y0."""
         taylor_coefficient_gen = self._taylor_coefficient_generator(f=f, y0=y0)
 
-        # get the nth entry of the coefficient-generator via itertools.islice
+        # Get the 'order'th entry of the coefficient-generator via itertools.islice
+        # The result is a tuple of length 'order+1', each entry of which
+        # corresponds to a derivative / Taylor coefficient.
         derivatives = next(itertools.islice(taylor_coefficient_gen, order, None))
 
+        # The shape of this array is (order+1, ode_dim+1).
+        # 'order+1' since a 0th order approximation has 1 coefficient (f(x0)),
+        # a 1st order approximation has 2 coefficients (f(x0), df(x0)), etc.
+        # 'ode_dim+1' since we tranformed the ODE into an autonomous ODE.
         derivatives_as_array = jnp.stack(derivatives, axis=0)
         return derivatives_as_array
 

--- a/src/probnum/diffeq/odefilter/init_routines/_autodiff.py
+++ b/src/probnum/diffeq/odefilter/init_routines/_autodiff.py
@@ -127,18 +127,12 @@ class TaylorMode(_AutoDiffBase):
 
     This requires JAX. For an explanation of what happens ``under the hood``, see [1]_.
 
-    The implementation is inspired by the implementation in
-    https://github.com/jacobjinkelly/easy-neural-ode/blob/master/latent_ode.py
-    See also [2]_.
-
     References
     ----------
     .. [1] Krämer, N. and Hennig, P.,
        Stable implementation of probabilistic ODE solvers,
        *arXiv:2012.10106*, 2020.
-    .. [2] Kelly, J. and Bettencourt, J. and Johnson, M. and Duvenaud, D.,
-        Learning differential equations that are easy to solve,
-        Neurips 2020.
+
 
     Examples
     --------

--- a/tests/test_diffeq/test_odefilter/test_init_routines/test_init_routines.py
+++ b/tests/test_diffeq/test_odefilter/test_init_routines/test_init_routines.py
@@ -19,7 +19,7 @@ only_if_jax_available = pytest.mark.skipif(not JAX_IS_AVAILABLE, reason="require
 
 
 @only_if_jax_available
-@pytest.mark.parametrize("num_derivatives", [2, 3, 5])
+@pytest.mark.parametrize("num_derivatives", [0, 1, 2, 3, 5])
 @pytest_cases.parametrize_with_cases("ivp, dy0_true", prefix="problem_", has_tag="jax")
 @pytest_cases.parametrize_with_cases(
     "routine", prefix="solver_", has_tag=("is_exact", "requires_jax")


### PR DESCRIPTION
# In a Nutshell
Rewrite the core implementation of `odefilter.init_routines.TaylorMode` into a more compact version and explain the background thoroughly.

No more early exits. No more confusing variable names. Transparent tuple/pytree usage. Let me know if something is not clear please!