### PR TITLE
[Bugfix] Missing `rng` argument in sample function of random variable `rv1 {+,-,*,/,//,@,%} rv2`

### DIFF
--- a/src/probnum/randvars/_arithmetic.py
+++ b/src/probnum/randvars/_arithmetic.py
@@ -125,13 +125,13 @@ def _default_rv_binary_op_factory(op_fn) -> _RandomVariableBinaryOperator:
 
 
 def _make_rv_binary_op_result_shape_dtype_sample_fn(op_fn, rv1, rv2):
-    rng = np.random.default_rng(1)
-    sample_fn = lambda size: op_fn(
-        rv1.sample(size=size, rng=rng), rv2.sample(size=size, rng=rng)
+    sample_fn = lambda rng, size: op_fn(
+        rv1.sample(rng, size=size),
+        rv2.sample(rng, size=size),
     )
 
     # Infer shape and dtype
-    infer_sample = sample_fn(())
+    infer_sample = sample_fn(np.random.default_rng(1), ())
 
     shape = infer_sample.shape
     dtype = infer_sample.dtype


### PR DESCRIPTION
# In a Nutshell
The `sample` function of `RandomVariable`s resulting from generically implemented binary operations is missing the `rng` argument.

# Detailed Description
See above.

# Related Issues
None
