### PR TITLE
[Bugfix] Scalar arguments in `Kernel.__call__`

### DIFF
--- a/src/probnum/_function.py
+++ b/src/probnum/_function.py
@@ -132,7 +132,7 @@ class LambdaFunction(Function):
         self,
         fn: Callable[[np.ndarray], np.ndarray],
         input_shape: ShapeLike,
-        output_shape: ShapeLike,
+        output_shape: ShapeLike = (),
     ) -> None:
         self._fn = fn
 

--- a/src/probnum/randprocs/kernels/_exponentiated_quadratic.py
+++ b/src/probnum/randprocs/kernels/_exponentiated_quadratic.py
@@ -52,7 +52,10 @@ class ExpQuad(Kernel, IsotropicMixin):
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
         if x1 is None:
-            return np.ones_like(x0, shape=x0.shape[: x0.ndim - self._input_ndim])
+            return np.ones_like(  # pylint: disable=unexpected-keyword-arg
+                x0,
+                shape=x0.shape[: x0.ndim - self._input_ndim],
+            )
 
         return np.exp(
             -self._squared_euclidean_distances(x0, x1) / (2.0 * self.lengthscale**2)

--- a/src/probnum/randprocs/kernels/_exponentiated_quadratic.py
+++ b/src/probnum/randprocs/kernels/_exponentiated_quadratic.py
@@ -52,7 +52,7 @@ class ExpQuad(Kernel, IsotropicMixin):
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
         if x1 is None:
-            return np.ones_like(x0[..., 0])
+            return np.ones_like(x0, shape=x0.shape[: x0.ndim - self._input_ndim])
 
         return np.exp(
             -self._squared_euclidean_distances(x0, x1) / (2.0 * self.lengthscale**2)

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -339,7 +339,7 @@ class Kernel(abc.ABC):
         self,
         x0: ArrayLike,
         x1: Optional[ArrayLike],
-    ) -> Union[np.ndarray, np.float_]:
+    ) -> np.ndarray:
         """Implementation of the kernel evaluation which is called after input checking.
 
         When implementing a particular kernel, the subclass should implement the kernel

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -154,7 +154,7 @@ class Kernel(abc.ABC):
         self,
         x0: ArrayLike,
         x1: Optional[ArrayLike],
-    ) -> Union[np.ndarray, np.floating]:
+    ) -> np.ndarray:
         """Evaluate the (cross-)covariance function(s).
 
         The inputs are broadcast to a common shape following the "kernel broadcasting"
@@ -228,10 +228,10 @@ class Kernel(abc.ABC):
         See documentation of class :class:`Kernel`.
         """
 
-        x0 = np.atleast_1d(x0)
+        x0 = np.asarray(x0)
 
         if x1 is not None:
-            x1 = np.atleast_1d(x1)
+            x1 = np.asarray(x1)
 
         # Shape checking
         broadcast_input_shape = self._kernel_broadcast_shapes(x0, x1)
@@ -296,8 +296,8 @@ class Kernel(abc.ABC):
         See documentation of class :class:`Kernel`.
         """
 
-        x0 = np.array(x0)
-        x1 = x0 if x1 is None else np.array(x1)
+        x0 = np.asarray(x0)
+        x1 = x0 if x1 is None else np.asarray(x1)
 
         # Shape checking
         errmsg = (

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -1,7 +1,7 @@
 """Kernel / covariance function."""
 
 import abc
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -470,6 +470,9 @@ class Kernel(abc.ABC):
         if self.input_shape == ():
             return prods
 
+        if prods.shape == ():
+            return self._input_shape[0] * prods
+
         if prods.shape[-1] == 1:
             return self._input_shape[0] * prods[..., 0]
 
@@ -497,13 +500,18 @@ class IsotropicMixin(abc.ABC):  # pylint: disable=too-few-public-methods
         if x1 is None:
             return np.zeros_like(  # pylint: disable=unexpected-keyword-arg
                 x0,
-                shape=x0.shape[: -self._input_ndim],
+                shape=x0.shape[: x0.ndim - self._input_ndim],
             )
 
         sqdiffs = (x0 - x1) ** 2
 
         if self.input_shape == ():
             return sqdiffs
+
+        assert len(self.input_shape) == 1
+
+        if sqdiffs.shape == ():
+            return self._input_shape[0] * sqdiffs
 
         if sqdiffs.shape[-1] == 1:
             return self._input_shape[0] * sqdiffs[..., 0]

--- a/src/probnum/randprocs/kernels/_rational_quadratic.py
+++ b/src/probnum/randprocs/kernels/_rational_quadratic.py
@@ -70,7 +70,7 @@ class RatQuad(Kernel, IsotropicMixin):
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
         if x1 is None:
-            return np.ones_like(x0[..., 0])
+            return np.ones_like(x0, shape=x0.shape[: x0.ndim - self._input_ndim])
 
         return (
             1.0

--- a/src/probnum/randprocs/kernels/_rational_quadratic.py
+++ b/src/probnum/randprocs/kernels/_rational_quadratic.py
@@ -70,7 +70,10 @@ class RatQuad(Kernel, IsotropicMixin):
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
         if x1 is None:
-            return np.ones_like(x0, shape=x0.shape[: x0.ndim - self._input_ndim])
+            return np.ones_like(  # pylint: disable=unexpected-keyword-arg
+                x0,
+                shape=x0.shape[: x0.ndim - self._input_ndim],
+            )
 
         return (
             1.0

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands =
     pylint src/probnum/problems --disable="too-many-arguments,too-many-locals,unused-variable,unused-argument,else-if-used,consider-using-from-import,duplicate-code,line-too-long,missing-module-docstring,missing-function-docstring,missing-param-doc,missing-type-doc,missing-raises-doc" --jobs=0
     pylint src/probnum/quad --disable="too-many-arguments,missing-module-docstring" --jobs=0
     pylint src/probnum/randprocs --disable="arguments-differ,arguments-renamed,too-many-instance-attributes,too-many-arguments,too-many-locals,protected-access,unused-argument,no-else-return,duplicate-code,line-too-long,missing-module-docstring,missing-class-docstring,missing-function-docstring,missing-type-doc,missing-raises-doc,useless-param-doc,useless-type-doc,missing-return-type-doc" --jobs=0
-    pylint src/probnum/randprocs/kernels --jobs=0
+    pylint src/probnum/randprocs/kernels --disable="duplicate-code" --jobs=0
     pylint src/probnum/randvars --disable="too-many-arguments,too-many-locals,too-many-branches,too-few-public-methods,protected-access,unused-argument,no-else-return,duplicate-code,line-too-long,missing-function-docstring,missing-raises-doc" --jobs=0
     pylint src/probnum/utils --disable="no-else-return,else-if-used,line-too-long,missing-raises-doc,missing-return-type-doc" --jobs=0
     # Benchmark and Test Code Linting Pass


### PR DESCRIPTION
# In a Nutshell
Fixes a bug in `Kernel.__call__`, where scalar arguments produce incorrect outputs.

# Detailed Description
- `atleast_1d` -> `asarray` in `Kernel.__call__`
- Correct broadcasting behavior for scalar inputs and `Kernel`s with `input_shape=()`
- Make `output_shape` optional in `LambdaFunction.__init__`

# Related Issues
None
