### PR TITLE
`Kernel.output_shape` semantics and further `RandomProcess` refactoring

### DIFF
--- a/src/probnum/_function.py
+++ b/src/probnum/_function.py
@@ -56,6 +56,11 @@ class Function(abc.ABC):
         For scalar-valued function, this is an empty tuple."""
         return self._output_shape
 
+    @property
+    def output_ndim(self) -> int:
+        """Syntactic sugar for ``len(output_shape)``."""
+        return self._output_ndim
+
     def __call__(self, x: ArrayLike) -> np.ndarray:
         """Evaluate the function at a given input.
 

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -1,11 +1,10 @@
 """Gaussian processes."""
 
-from typing import Type, Union
+from typing import Union
 
 import numpy as np
 
 from probnum import randvars
-from probnum.typing import ShapeLike
 
 from . import _random_process, kernels
 from .. import _function
@@ -64,55 +63,16 @@ class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
         mean: _function.Function,
         cov: kernels.Kernel,
     ):
-        if not isinstance(mean, _function.Function):
-            raise TypeError("The mean function must have type `probnum.Function`.")
-
-        if not isinstance(cov, kernels.Kernel):
-            raise TypeError(
-                "The covariance functions must be implemented as a " "`Kernel`."
-            )
-
-        if mean.input_ndim > 1:
-            raise ValueError(
-                "The mean function must have input shape `()` or `(D_in,)`."
-            )
-
-        if mean.output_ndim > 1:
-            raise ValueError(
-                "The mean function must have output shape `()` or `(D_out,)`."
-            )
-
-        if mean.input_shape != cov.input_shape:
-            raise ValueError(
-                "The mean and covariance functions must have the same input shapes "
-                f"(`mean.input_shape` is {mean.input_shape} and `cov.input_shape` is "
-                f"{cov.input_shape})."
-            )
-
-        if 2 * mean.output_shape != cov.output_shape:
-            raise ValueError(
-                "The covariance `Kernel` must have shape "
-                "`mean.output_shape + mean.output_shape`."
-            )
-
-        self._mean = mean
-        self._cov = cov
-
         super().__init__(
             input_shape=mean.input_shape,
             output_shape=mean.output_shape,
             dtype=np.dtype(np.float_),
+            mean=mean,
+            cov=cov,
         )
 
     def __call__(self, args: _InputType) -> randvars.Normal:
         return randvars.Normal(
-            mean=np.array(self.mean(args), copy=False), cov=self.cov.matrix(args)
+            mean=np.array(self.mean(args), copy=False),
+            cov=self.cov.matrix(args),
         )
-
-    @property
-    def mean(self) -> _function.Function:
-        return self._mean
-
-    @property
-    def cov(self) -> kernels.Kernel:
-        return self._cov

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -117,15 +117,6 @@ class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
     def cov(self) -> kernels.Kernel:
         return self._cov
 
-    def _sample_at_input(
-        self,
-        rng: np.random.Generator,
-        args: _InputType,
-        size: ShapeLike = (),
-    ) -> _OutputType:
-        gaussian_rv = self.__call__(args)
-        return gaussian_rv.sample(rng=rng, size=size)
-
     def push_forward(
         self,
         args: _InputType,

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -58,6 +58,9 @@ class GaussianProcess(_random_process.RandomProcess[ArrayLike, np.ndarray]):
         mean: _function.Function,
         cov: kernels.Kernel,
     ):
+        if not isinstance(mean, _function.Function):
+            raise TypeError("The mean function must have type `probnum.Function`.")
+
         super().__init__(
             input_shape=mean.input_shape,
             output_shape=mean.output_shape,

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -73,6 +73,6 @@ class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
 
     def __call__(self, args: _InputType) -> randvars.Normal:
         return randvars.Normal(
-            mean=np.array(self.mean(args), copy=False),
+            mean=np.array(self.mean(args), copy=False),  # pylint: disable=not-callable
             cov=self.cov.matrix(args),
         )

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -1,19 +1,14 @@
 """Gaussian processes."""
-
-from typing import Union
-
 import numpy as np
 
 from probnum import randvars
 
 from . import _random_process, kernels
 from .. import _function
-
-_InputType = Union[np.floating, np.ndarray]
-_OutputType = Union[np.floating, np.ndarray]
+from ..typing import ArrayLike
 
 
-class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
+class GaussianProcess(_random_process.RandomProcess[ArrayLike, np.ndarray]):
     """Gaussian processes.
 
     A Gaussian process is a continuous stochastic process which if evaluated at a
@@ -71,7 +66,7 @@ class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
             cov=cov,
         )
 
-    def __call__(self, args: _InputType) -> randvars.Normal:
+    def __call__(self, args: ArrayLike) -> randvars.Normal:
         return randvars.Normal(
             mean=np.array(self.mean(args), copy=False),  # pylint: disable=not-callable
             cov=self.cov.matrix(args),

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -89,11 +89,10 @@ class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
                 f"{cov.input_shape})."
             )
 
-        if 2 * mean.output_shape != cov.shape:
+        if 2 * mean.output_shape != cov.output_shape:
             raise ValueError(
-                "The shape of the `Kernel` must be a tuple of the form "
-                "`(output_shape, output_shape)`, where `output_shape` is the output "
-                "shape of the mean function."
+                "The covariance `Kernel` must have shape "
+                "`mean.output_shape + mean.output_shape`."
             )
 
         self._mean = mean

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -72,12 +72,12 @@ class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
                 "The covariance functions must be implemented as a " "`Kernel`."
             )
 
-        if len(mean.input_shape) > 1:
+        if mean.input_ndim > 1:
             raise ValueError(
                 "The mean function must have input shape `()` or `(D_in,)`."
             )
 
-        if len(mean.output_shape) > 1:
+        if mean.output_ndim > 1:
             raise ValueError(
                 "The mean function must have output shape `()` or `(D_out,)`."
             )

--- a/src/probnum/randprocs/_gaussian_process.py
+++ b/src/probnum/randprocs/_gaussian_process.py
@@ -116,11 +116,3 @@ class GaussianProcess(_random_process.RandomProcess[_InputType, _OutputType]):
     @property
     def cov(self) -> kernels.Kernel:
         return self._cov
-
-    def push_forward(
-        self,
-        args: _InputType,
-        base_measure: Type[randvars.RandomVariable],
-        sample: np.ndarray,
-    ) -> np.ndarray:
-        raise NotImplementedError

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -149,7 +149,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         Parameters
         ----------
         args
-            *shape=* ``batch_shape + `` :attr:`input_shape` -- (Batch of) input(s) at
+            *shape=* ``batch_shape +`` :attr:`input_shape` -- (Batch of) input(s) at
             which to evaluate the random process. Currently, we require ``batch_shape``
             to have at most one dimension.
 
@@ -166,7 +166,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         Parameters
         ----------
         args
-            *shape=* ``batch_shape + `` :attr:`input_shape` -- (Batch of) input(s) at
+            *shape=* ``batch_shape +`` :attr:`input_shape` -- (Batch of) input(s) at
             which to evaluate the random process. Currently, we require ``batch_shape``
             to have at most one dimension.
         """
@@ -174,7 +174,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
 
     @property
     def mean(self) -> _function.Function:
-        r"""Mean function :math:`m(x) = \mathbb{E}[f(x)]` of the random process."""
+        r"""Mean function :math:`m(x) := \mathbb{E}[f(x)]` of the random process."""
         if self._mean is None:
             raise NotImplementedError
 
@@ -182,8 +182,18 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
 
     @property
     def cov(self) -> kernels.Kernel:
-        r"""Covariance function :math:`k(x_0, x_1) = \mathbb{E}[(f(x_0) - \mathbb{E}[
-        f(x_0)])(f(x_0) - \mathbb{E}[f(x_0)])^\top]` of the random process."""
+        r"""Covariance function :math:`k(x_0, x_1)` of the random process.
+
+        .. math::
+            :nowrap:
+
+            \begin{equation}
+                k(x_0, x_1) := \mathbb{E} \left[
+                    (f(x_0) - \mathbb{E}[f(x_0)])
+                    (f(x_1) - \mathbb{E}[f(x_1)])^\top
+                \right]
+            \end{equation}
+        """
         if self._cov is None:
             raise NotImplementedError
 
@@ -256,7 +266,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         base_measure
             Base measure. Given as a type of random variable.
         sample
-            *shape=* ``sample_shape + `` :attr:`input_shape` -- (Batch of) input(s) at
+            *shape=* ``sample_shape +`` :attr:`input_shape` -- (Batch of) input(s) at
             which to evaluate the random process. Currently, we require ``sample_shape``
             to have at most one dimension.
         """
@@ -279,7 +289,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         rng
             Random number generator.
         args
-            *shape=* ``size + `` :attr:`input_shape` -- (Batch of) input(s) at
+            *shape=* ``size +`` :attr:`input_shape` -- (Batch of) input(s) at
             which the sample paths will be evaluated. Currently, we require
             ``size`` to have at most one dimension. If ``None``, sample paths,
             i.e. callables are returned.
@@ -308,7 +318,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         rng
             Random number generator.
         args
-            *shape=* ``size + `` :attr:`input_shape` -- (Batch of) input(s) at
+            *shape=* ``size +`` :attr:`input_shape` -- (Batch of) input(s) at
             which the sample paths will be evaluated. Currently, we require
             ``size`` to have at most one dimension.
         size

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -269,4 +269,4 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         size
             Size of the sample.
         """
-        raise NotImplementedError
+        return self(args).sample(rng, size=size)

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -97,9 +97,19 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         return self._input_shape
 
     @property
+    def input_ndim(self) -> int:
+        """Syntactic sugar for ``len(input_shape)``."""
+        return self._input_ndim
+
+    @property
     def output_shape(self) -> ShapeType:
         """Shape of the random process evaluated at an input."""
         return self._output_shape
+
+    @property
+    def output_ndim(self) -> int:
+        """Syntactic sugar for ``len(output_shape)``."""
+        return self._output_ndim
 
     @property
     def dtype(self) -> np.dtype:

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -89,7 +89,6 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
             *shape=* ``batch_shape +`` :attr:`output_shape` -- Random process evaluated
             at the input(s).
         """
-        raise NotImplementedError
 
     @property
     def input_shape(self) -> ShapeType:
@@ -126,7 +125,6 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
             which to evaluate the random process. Currently, we require ``batch_shape``
             to have at most one dimension.
         """
-        # return self.__call__(args).marginal()
         raise NotImplementedError
 
     @property
@@ -149,9 +147,8 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         Parameters
         ----------
         args
-            *shape=* ``batch_shape + input_shape_bcastable`` -- (Batch of) input(s) at
-            which to evaluate the variance function. ``input_shape_bcastable`` must be a
-            shape that can be broadcast to :attr:`input_shape`.
+            *shape=* ``batch_shape +`` :attr:`input_shape` -- (Batch of) input(s) at
+            which to evaluate the variance function.
 
         Returns
         -------
@@ -179,9 +176,8 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         Parameters
         ----------
         args
-            *shape=* ``batch_shape + input_shape_bcastable`` -- (Batch of) input(s) at
-            which to evaluate the standard deviation function. ``input_shape_bcastable``
-            must be a shape that can be broadcast to :attr:`input_shape`.
+            *shape=* ``batch_shape +`` :attr:`input_shape` -- (Batch of) input(s) at
+            which to evaluate the standard deviation function.
 
         Returns
         -------
@@ -189,9 +185,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
             *shape=* ``batch_shape +`` :attr:`output_shape` -- Standard deviation of the
             process at ``args``.
         """
-            return np.sqrt(self.var(args=args))
-        except NotImplementedError as exc:
-            raise NotImplementedError from exc
+        return np.sqrt(self.var(args=args))
 
     def push_forward(
         self,

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -72,41 +72,43 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
         self._dtype = np.dtype(dtype)
 
         # Mean function
-        if not isinstance(mean, _function.Function):
-            raise TypeError("The mean function must have type `probnum.Function`.")
+        if mean is not None:
+            if not isinstance(mean, _function.Function):
+                raise TypeError("The mean function must have type `probnum.Function`.")
 
-        if mean.input_shape != self._input_shape:
-            raise ValueError(
-                f"The mean function must have the same `input_shape` as the random "
-                f"process (`{mean.input_shape}` != `{self._input_shape}`)."
-            )
+            if mean.input_shape != self._input_shape:
+                raise ValueError(
+                    f"The mean function must have the same `input_shape` as the random "
+                    f"process (`{mean.input_shape}` != `{self._input_shape}`)."
+                )
 
-        if mean.output_shape != self._output_shape:
-            raise ValueError(
-                f"The mean function must have the same `output_shape` as the random "
-                f"process (`{mean.output_shape}` != `{self._output_shape}`)."
-            )
+            if mean.output_shape != self._output_shape:
+                raise ValueError(
+                    f"The mean function must have the same `output_shape` as the "
+                    f"random process (`{mean.output_shape}` != `{self._output_shape}`)."
+                )
 
         self._mean = mean
 
         # Covariance function
-        if not isinstance(cov, kernels.Kernel):
-            raise TypeError(
-                "The covariance functions must be implemented as a " "`Kernel`."
-            )
+        if cov is not None:
+            if not isinstance(cov, kernels.Kernel):
+                raise TypeError(
+                    "The covariance functions must be implemented as a " "`Kernel`."
+                )
 
-        if cov.input_shape != self._input_shape:
-            raise ValueError(
-                f"The covariance function must have the same `input_shape` as the "
-                f"random process (`{cov.input_shape}` != `{self._input_shape}`)."
-            )
+            if cov.input_shape != self._input_shape:
+                raise ValueError(
+                    f"The covariance function must have the same `input_shape` as the "
+                    f"random process (`{cov.input_shape}` != `{self._input_shape}`)."
+                )
 
-        if cov.output_shape != 2 * self._output_shape:
-            raise ValueError(
-                f"The `output_shape` of the covariance function must be given by "
-                f"`2 * self.output_shape` (`{cov.output_shape}` != "
-                f"`{2 * self._output_shape}`)."
-            )
+            if cov.output_shape != 2 * self._output_shape:
+                raise ValueError(
+                    f"The `output_shape` of the covariance function must be given by "
+                    f"`2 * self.output_shape` (`{cov.output_shape}` != "
+                    f"`{2 * self._output_shape}`)."
+                )
 
         self._cov = cov
 

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -76,13 +76,13 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
             raise TypeError("The mean function must have type `probnum.Function`.")
 
         if mean.input_shape != self._input_shape:
-            raise TypeError(
+            raise ValueError(
                 f"The mean function must have the same `input_shape` as the random "
                 f"process (`{mean.input_shape}` != `{self._input_shape}`)."
             )
 
         if mean.output_shape != self._output_shape:
-            raise TypeError(
+            raise ValueError(
                 f"The mean function must have the same `output_shape` as the random "
                 f"process (`{mean.output_shape}` != `{self._output_shape}`)."
             )
@@ -96,7 +96,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
             )
 
         if cov.input_shape != self._input_shape:
-            raise TypeError(
+            raise ValueError(
                 f"The covariance function must have the same `input_shape` as the "
                 f"random process (`{cov.input_shape}` != `{self._input_shape}`)."
             )
@@ -105,7 +105,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
             raise ValueError(
                 f"The `output_shape` of the covariance function must be given by "
                 f"`2 * self.output_shape` (`{cov.output_shape}` != "
-                f"`{self._output_shape}`)."
+                f"`{2 * self._output_shape}`)."
             )
 
         self._cov = cov
@@ -138,7 +138,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
     def __repr__(self) -> str:
         return (
             f"<{self.__class__.__name__} with "
-            f"input_shape={self.input_shape}, output_shape={self.output_shape}, and "
+            f"input_shape={self.input_shape}, output_shape={self.output_shape}, "
             f"dtype={self.dtype}>"
         )
 

--- a/src/probnum/randprocs/_random_process.py
+++ b/src/probnum/randprocs/_random_process.py
@@ -217,7 +217,7 @@ class RandomProcess(Generic[_InputType, _OutputType], abc.ABC):
             *shape=* ``batch_shape +`` :attr:`output_shape` -- Variance of the process
             at ``args``.
         """
-        pointwise_covs = self.cov(args, None)
+        pointwise_covs = self.cov(args, None)  # pylint: disable=not-callable
 
         assert (
             pointwise_covs.shape

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -49,8 +49,8 @@ class Kernel(abc.ABC):
         \end{equation}
 
     of the vector-valued random process :math:`f`. To this end, we understand any
-    :class:`Kernel` with a non-empty :attr:`output_shape` as a tensor with the given
-    :attr:`output_shape`, which contains different (cross-)covariance functions as its entries.
+    :class:`Kernel` as a tensor whose shape is given by :attr:`output_shape`, which
+    contains different (cross-)covariance functions as its entries.
 
     Parameters
     ----------
@@ -58,6 +58,7 @@ class Kernel(abc.ABC):
         Shape of the :class:`Kernel`'s input.
     output_shape :
         Shape of the :class:`Kernel`'s output.
+
         If ``output_shape`` is set to ``()``, the :class:`Kernel` instance represents a
         single (cross-)covariance function. Otherwise, i.e. if ``output_shape`` is a
         non-empty tuple, the :class:`Kernel` instance represents a tensor of
@@ -408,7 +409,7 @@ class Kernel(abc.ABC):
     ) -> np.ndarray:
         """Implementation of the Euclidean inner product, which supports scalar inputs
         and an optional second argument."""
-        prods = x0 ** 2 if x1 is None else x0 * x1
+        prods = x0**2 if x1 is None else x0 * x1
 
         if self.input_ndim == 0:
             return prods

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -27,9 +27,9 @@ class Kernel(abc.ABC):
 
     is a function of two arguments :math:`x_0` and :math:`x_1`, which represents the
     covariance between two evaluations :math:`f(x_0)` and :math:`g(x_1)` of two
-    scalar-valued random processes :math:`f` and :math:`g` (or, equivalently, two
-    outputs :math:`h_i(x_0)` and :math:`h_j(x_1)` of a vector-valued random process
-    :math:`h`).
+    scalar-valued random processes :math:`f` and :math:`g` on a common probability space
+    (or, equivalently, two outputs :math:`h_i(x_0)` and :math:`h_j(x_1)` of a
+    vector-valued random process :math:`h`).
     If :math:`f = g`, then the cross-covariance function is also referred to as a
     covariance function, in which case it must be symmetric and positive
     (semi-)definite.
@@ -49,18 +49,19 @@ class Kernel(abc.ABC):
         \end{equation}
 
     of the vector-valued random process :math:`f`. To this end, we understand any
-    :class:`Kernel` with a non-empty :attr:`shape` as a tensor with the given
-    :attr:`shape`, which contains different (cross-)covariance functions as its entries.
+    :class:`Kernel` with a non-empty :attr:`output_shape` as a tensor with the given
+    :attr:`output_shape`, which contains different (cross-)covariance functions as its entries.
 
     Parameters
     ----------
     input_shape :
-        Shape of the kernel's input.
-    shape :
-        If ``shape`` is set to ``()``, the :class:`Kernel` instance represents a
-        single (cross-)covariance function. Otherwise, i.e. if ``shape`` is non-empty,
-        the :class:`Kernel` instance represents a tensor of (cross-)covariance
-        functions whose shape is given by ``shape``.
+        Shape of the :class:`Kernel`'s input.
+    output_shape :
+        Shape of the :class:`Kernel`'s output.
+        If ``output_shape`` is set to ``()``, the :class:`Kernel` instance represents a
+        single (cross-)covariance function. Otherwise, i.e. if ``output_shape`` is a
+        non-empty tuple, the :class:`Kernel` instance represents a tensor of
+        (cross-)covariance functions whose shape is given by ``output_shape``.
 
     Examples
     --------
@@ -69,6 +70,8 @@ class Kernel(abc.ABC):
     >>> k = pn.randprocs.kernels.Linear(input_shape=D)
     >>> k.input_shape
     (3,)
+    >>> k.output_shape
+    ()
 
     Generate some input data.
 
@@ -116,7 +119,7 @@ class Kernel(abc.ABC):
     def __init__(
         self,
         input_shape: ShapeLike,
-        shape: ShapeLike = (),
+        output_shape: ShapeLike = (),
     ):
         self._input_shape = _pn_utils.as_shape(input_shape)
         self._input_ndim = len(self._input_shape)
@@ -126,11 +129,12 @@ class Kernel(abc.ABC):
                 "Currently, we only support kernels with at most 1 input dimension."
             )
 
-        self._shape = _pn_utils.as_shape(shape)
+        self._output_shape = _pn_utils.as_shape(output_shape)
+        self._output_ndim = len(self._output_shape)
 
     @property
-    def input_shape(self) -> int:
-        """Dimension of single arguments of the covariance function."""
+    def input_shape(self) -> ShapeType:
+        """Shape of single, i.e. non-batched, arguments of the covariance function."""
         return self._input_shape
 
     @property
@@ -139,21 +143,27 @@ class Kernel(abc.ABC):
         return self._input_ndim
 
     @property
-    def shape(self) -> ShapeType:
-        """If :attr:`shape` is ``()``, the :class:`Kernel` instance represents a single
-        (cross-)covariance function.
+    def output_shape(self) -> ShapeType:
+        """Shape of single, i.e. non-batched, return values of the covariance function.
 
-        Otherwise, i.e. if :attr:`shape` is non-empty, the :class:`Kernel` instance
-        represents a tensor of (cross-)covariance functions whose shape is given by
-        ``shape``.
+        If :attr:`output_shape` is ``()``, the :class:`Kernel` instance represents
+        a single (cross-)covariance function.
+        Otherwise, i.e. if :attr:`output_shape` is non-empty, the :class:`Kernel`
+        instance represents a tensor of (cross-)covariance functions whose shape is
+        given by ``output_shape``.
         """
-        return self._shape
+        return self._output_shape
+
+    @property
+    def output_ndim(self) -> int:
+        """Syntactic sugar for ``len(output_shape)``."""
+        return self._output_ndim
 
     def __repr__(self) -> str:
         return (
             f"<{self.__class__.__name__} with"
             f" input_shape={self.input_shape} and"
-            f" shape={self.shape}>"
+            f" output_shape={self.output_shape}>"
         )
 
     def __call__(
@@ -180,21 +190,21 @@ class Kernel(abc.ABC):
         Returns
         -------
         k_x0_x1 :
-            *shape=* :attr:`shape` ``+ bcast_batch_shape`` -- The (cross-)covariance
-            function(s) evaluated at ``(x0, x1)``. Since the function is vectorized
-            over the batch shapes of the inputs, the output array contains the following
-            entries:
+            *shape=* ``bcast_batch_shape +`` :attr:`output_shape` -- The
+            (cross-)covariance function(s) evaluated at ``(x0, x1)``.
+            Since the function is vectorized over the batch shapes of the inputs, the
+            output array contains the following entries:
 
             .. code-block:: python
 
-                k_x0_x1[output_idx + batch_idx] = k[output_idx](
+                k_x0_x1[batch_idx + output_idx] = k[output_idx](
                     x0[batch_idx, ...],
                     x1[batch_idx, ...],
                 )
 
             where we assume that ``x0`` and ``x1`` have been broadcast to a common
             shape ``bcast_batch_shape +`` :attr:`input_shape`, and where ``output_idx``
-            and ``batch_idx`` are indices compatible with :attr:`shape` and
+            and ``batch_idx`` are indices compatible with :attr:`output_shape` and
             ``bcast_batch_shape``, respectively.
             By ``k[output_idx]`` we refer to the covariance function at index
             ``output_idx`` in the tensor of covariance functions represented by the
@@ -231,7 +241,7 @@ class Kernel(abc.ABC):
         # Evaluate the kernel
         k_x0_x1 = self._evaluate(x0, x1)
 
-        assert k_x0_x1.shape == self._shape + broadcast_batch_shape
+        assert k_x0_x1.shape == broadcast_batch_shape + self._output_shape
 
         return k_x0_x1
 
@@ -262,10 +272,11 @@ class Kernel(abc.ABC):
         Returns
         -------
         kernmat :
-            *shape=* :attr:`shape` ``+ batch_shape`` -- The matrix / stack of matrices
-            containing the pairwise evaluations of the (cross-)covariance function(s) on
-            ``x0`` and ``x1``. Depending on the shape of the inputs, ``batch_shape`` is
-            either ``(M, N)``, ``(M,)``, ``(N,)``, or ``()``.
+            *shape=* ``batch_shape +`` :attr:`output_shape` -- The matrix / stack of
+            matrices containing the pairwise evaluations of the (cross-)covariance
+            function(s) on ``x0`` and ``x1``.
+            Depending on the shape of the inputs, ``batch_shape`` is either ``(M, N)``,
+            ``(M,)``, ``(N,)``, or ``()``.
 
         Raises
         ------
@@ -397,7 +408,7 @@ class Kernel(abc.ABC):
     ) -> np.ndarray:
         """Implementation of the Euclidean inner product, which supports scalar inputs
         and an optional second argument."""
-        prods = x0**2 if x1 is None else x0 * x1
+        prods = x0 ** 2 if x1 is None else x0 * x1
 
         if self.input_ndim == 0:
             return prods

--- a/src/probnum/randprocs/kernels/_matern.py
+++ b/src/probnum/randprocs/kernels/_matern.py
@@ -84,7 +84,7 @@ class Matern(Kernel, IsotropicMixin):
             return np.exp(-1.0 / self.lengthscale * distances)
 
         if self.nu == 1.5:
-            scaled_distances = -np.sqrt(3) / self.lengthscale * distances
+            scaled_distances = np.sqrt(3) / self.lengthscale * distances
             return (1.0 + scaled_distances) * np.exp(-scaled_distances)
 
         if self.nu == 2.5:

--- a/src/probnum/randprocs/markov/_markov_process.py
+++ b/src/probnum/randprocs/markov/_markov_process.py
@@ -1,6 +1,6 @@
 """Markovian processes."""
 
-from typing import Optional, Type, Union
+from typing import Optional, Union
 
 import numpy as np
 import scipy.stats
@@ -48,26 +48,27 @@ class MarkovProcess(_random_process.RandomProcess):
         self.initrv = initrv
         self.transition = transition
 
+        input_shape = np.asarray(initarg).shape
+        output_shape = initrv.shape
+
         super().__init__(
-            input_shape=np.asarray(initarg).shape,
-            output_shape=initrv.shape,
+            input_shape=input_shape,
+            output_shape=output_shape,
             dtype=np.dtype(np.float_),
+            mean=_function.LambdaFunction(
+                lambda x: self.__call__(args=x).mean,
+                input_shape=input_shape,
+                output_shape=output_shape,
+            ),
+            cov=MarkovProcess.Kernel(
+                self.__call__,
+                input_shape=input_shape,
+                output_shape=output_shape,
+            ),
         )
 
     def __call__(self, args: _InputType) -> randvars.RandomVariable:
         raise NotImplementedError
-
-    @property
-    def mean(self) -> _function.Function:
-        return _function.LambdaFunction(
-            lambda x: self.__call__(args=x).mean,
-            input_shape=self.input_shape,
-            output_shape=self.output_shape,
-        )
-
-    @property
-    def cov(self) -> "MarkovProcess.Kernel":
-        return MarkovProcess.Kernel(self.__call__)
 
     def _sample_at_input(
         self,
@@ -108,18 +109,18 @@ class MarkovProcess(_random_process.RandomProcess):
         )
 
     class Kernel(kernels.Kernel):
-        def __init__(self, markov_proc: "MarkovProcess"):
-            self._randproc_call = markov_proc.__call__
+        def __init__(
+            self, markov_proc_call, input_shape: ShapeLike, output_shape: ShapeLike
+        ):
+            self._markov_proc_call = markov_proc_call
 
             super().__init__(
-                input_shape=markov_proc.input_shape,
-                shape=markov_proc.output_shape,
+                input_shape=input_shape,
+                output_shape=output_shape,
             )
 
-        def _evaluate(
-            self, x0: np.ndarray, x1: Optional[np.ndarray]
-        ) -> Union[np.ndarray, np.float_]:
+        def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray]) -> np.ndarray:
             if x1 is None:
-                return self._randproc_call(args=x0).cov
+                return self._markov_proc_call(args=x0).cov
 
             raise NotImplementedError

--- a/src/probnum/randprocs/markov/_markov_process.py
+++ b/src/probnum/randprocs/markov/_markov_process.py
@@ -107,14 +107,6 @@ class MarkovProcess(_random_process.RandomProcess):
             ]
         )
 
-    def push_forward(
-        self,
-        args: _InputType,
-        base_measure: Type[randvars.RandomVariable],
-        sample: np.ndarray,
-    ) -> np.ndarray:
-        raise NotImplementedError
-
     class Kernel(kernels.Kernel):
         def __init__(self, markov_proc: "MarkovProcess"):
             self._randproc_call = markov_proc.__call__

--- a/src/probnum/randprocs/markov/_markov_process.py
+++ b/src/probnum/randprocs/markov/_markov_process.py
@@ -63,7 +63,7 @@ class MarkovProcess(_random_process.RandomProcess):
             cov=MarkovProcess.Kernel(
                 self.__call__,
                 input_shape=input_shape,
-                output_shape=output_shape,
+                output_shape=2 * output_shape,
             ),
         )
 

--- a/tests/test_randprocs/test_random_process.py
+++ b/tests/test_randprocs/test_random_process.py
@@ -93,3 +93,77 @@ def test_rp_mean_cov_evaluated_matches_rv_mean_cov(
         err_msg=f"Covariance of evaluated {repr(random_process)} does not match the "
         f"random process mean function evaluated.",
     )
+
+
+class DummyRandomProcess(randprocs.RandomProcess):
+    def __call__(self, args):
+        raise NotImplementedError
+
+
+def test_invalid_mean_type_raises():
+    with pytest.raises(TypeError):
+        DummyRandomProcess(
+            input_shape=(),
+            output_shape=(),
+            dtype=np.double,
+            mean=np.zeros_like,
+        )
+
+
+def test_invalid_cov_type_raises():
+    with pytest.raises(TypeError):
+        DummyRandomProcess(
+            input_shape=(),
+            output_shape=(3,),
+            dtype=np.double,
+            cov=lambda x: np.zeros_like(  # pylint: disable=unexpected-keyword-arg
+                x,
+                shape=x.shape + (3, 3),
+            ),
+        )
+
+
+def test_inconsistent_mean_shape_errors():
+    with pytest.raises(ValueError):
+        DummyRandomProcess(
+            input_shape=(42,),
+            output_shape=(),
+            dtype=np.double,
+            mean=randprocs.mean_fns.Zero(
+                input_shape=(3,),
+                output_shape=(3,),
+            ),
+        )
+
+    with pytest.raises(ValueError):
+        DummyRandomProcess(
+            input_shape=(),
+            output_shape=(1,),
+            dtype=np.double,
+            mean=randprocs.mean_fns.Zero(
+                input_shape=(),
+                output_shape=(3,),
+            ),
+        )
+
+
+def test_inconsistent_cov_shape_errors():
+    with pytest.raises(ValueError):
+        DummyRandomProcess(
+            input_shape=(42,),
+            output_shape=(),
+            dtype=np.double,
+            cov=randprocs.kernels.ExpQuad(
+                input_shape=(3,),
+            ),
+        )
+
+    with pytest.raises(ValueError):
+        DummyRandomProcess(
+            input_shape=(),
+            output_shape=(1,),
+            dtype=np.double,
+            cov=randprocs.kernels.ExpQuad(
+                input_shape=(),
+            ),
+        )


### PR DESCRIPTION
# In a Nutshell
A few months ago, I redefined the shape of the outputs of `Kernel.__call__` to `cov.output_shape + batch_shape`.
However, this is very counterintuitive when in the context of random processes, since we would expect the outputs of the `mean`, `var`, and `std` functions to be `batch_shape + randproc.output_shape`, i.e. "the other way around".
My original change was made with multi-output GPs in mind, but even here it turns out that the `batch_shape + cov.output_shape`-order is easier to handle.

# Detailed 
- rename `Kernel.{shape => output_shape}`
- change output shapes of `Kernel.{__call__, matrix}` to `batch_shape + kernel.output_shape`
- adapt random processes to these changes
- fixed a bug in `Matern` 3/2 kernel
- refactor `RandomProcess`
  - add `input_ndim` and `output_ndim` as public arguments (also add these to `Function` and `Kernel`)
  - add default implementation of `_sample_at_input`
  - remove unnecessary overrides of `push_forward` in derived classes
  - add `mean` and `cov` arguments to the `RandomProcess` constructor and provide default implementations
  - improve the docstrings

# Related Issues
None
