### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.8", "3.9"]
+        python: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,13 @@ package_dir =
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
     numpy>=1.20
+    numpy>=1.21.3; python_version>="3.10"
     scipy>=1.4
+    scipy>=1.8.0; python_version>="3.10"
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.6
-python_requires = >=3.8
+python_requires = >=3.8,<3.11
 
 [options.packages.find]
 where = src
@@ -52,7 +54,7 @@ exclude =
 
 # Autodiff backends
 jax =
-    jax[minimum-jaxlib]<0.3.2; platform_system!="Windows"
+    jax[cpu]<0.3.2; platform_system!="Windows"
 
 # Problem zoo dependencies
 zoo =

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 zip_safe = False
@@ -65,7 +66,7 @@ zoo =
 # Calibration in the probabilistic linear solver
 pls_calib =
     GPy
-    # GPy can't be imported without matplolib.
+    # GPy can't be imported without matplotlib.
     # This is and should not be a ProbNum dependency.
     matplotlib
 


### PR DESCRIPTION
# In a Nutshell
This PR adds support for Python 3.10

# Detailed Description
- require Python >=3.8 but < 3.11
- Add conditional requirements on specific NumPy and SciPy versions, which introduced 3.10 support
- For some reason, `minimum-jaxlib` does not work under 3.10

# Related Issues
Closes #633
