### PR TITLE
Kernel arithmetic

### DIFF
--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -82,12 +82,12 @@ class NegatedLinearOperator(ScaledLinearOperator):
 
 
 class SumLinearOperator(LinearOperator):
-    """Sum of two linear operators."""
+    """Sum of linear operators."""
 
     def __init__(self, *summands: LinearOperator):
 
         if not all(summand.shape == summands[0].shape for summand in summands):
-            raise ValueError("All summands must have the same shape")
+            raise ValueError("All summands must have the same shape.")
 
         self._summands = SumLinearOperator._expand_sum_ops(*summands)
 
@@ -167,7 +167,7 @@ def _mul_fallback(
 
 
 class ProductLinearOperator(LinearOperator):
-    """(Operator) Product of two linear operators."""
+    """(Operator) Product of linear operators."""
 
     def __init__(self, *factors: LinearOperator):
 

--- a/src/probnum/randprocs/kernels/__init__.py
+++ b/src/probnum/randprocs/kernels/__init__.py
@@ -3,6 +3,9 @@
 Kernels describe the spatial or temporal variation of a random process.
 If evaluated at two sets of points a kernel is defined as the covariance
 of the values of the random process at these locations.
+
+Kernels support basic algebraic operations, including scaling, addition
+and multiplication.
 """
 
 from ._exponentiated_quadratic import ExpQuad

--- a/src/probnum/randprocs/kernels/_arithmetic.py
+++ b/src/probnum/randprocs/kernels/_arithmetic.py
@@ -1,0 +1,3 @@
+"""Kernel arithmetic."""
+
+from ._arithmetic_fallbacks import ProductKernel, ScaledKernel, SumKernel

--- a/src/probnum/randprocs/kernels/_arithmetic.py
+++ b/src/probnum/randprocs/kernels/_arithmetic.py
@@ -1,3 +1,76 @@
 """Kernel arithmetic."""
 
-from ._arithmetic_fallbacks import ProductKernel, ScaledKernel, SumKernel
+from typing import Callable, Dict, Optional, Tuple, Union
+
+import numpy as np
+
+from probnum import utils
+from probnum.typing import NotImplementedType
+
+from ._arithmetic_fallbacks import SumKernel, _mul_fallback
+from ._kernel import BinaryOperandType, Kernel
+
+
+def add(op1: BinaryOperandType, op2: BinaryOperandType) -> Kernel:
+    return _apply(_add_fns, op1, op2, fallback_operator=SumKernel)
+
+
+def mul(op1: BinaryOperandType, op2: BinaryOperandType) -> Kernel:
+    return _apply(_mul_fns, op1, op2, fallback_operator=_mul_fallback)
+
+
+########################################################################################
+# Operator registry
+########################################################################################
+
+_BinaryOperatorType = Callable[[Kernel, Kernel], Union[Kernel, NotImplementedType]]
+_BinaryOperatorRegistryType = Dict[Tuple[type, type], _BinaryOperatorType]
+
+
+_add_fns: _BinaryOperatorRegistryType = {}
+_mul_fns: _BinaryOperatorRegistryType = {}
+
+########################################################################################
+# Fill Arithmetics Registries
+########################################################################################
+
+
+########################################################################################
+# Apply
+########################################################################################
+
+
+def _apply(
+    op_registry: _BinaryOperatorRegistryType,
+    op1: Kernel,
+    op2: Kernel,
+    fallback_operator: Optional[
+        Callable[
+            [Kernel, Kernel],
+            Union[Kernel, NotImplementedType],
+        ]
+    ] = None,
+) -> Union[Kernel, NotImplementedType]:
+    if np.ndim(op1) == 0:
+        key1 = np.number
+        op1 = utils.as_numpy_scalar(op1)
+    else:
+        key1 = type(op1)
+
+    if np.ndim(op2) == 0:
+        key2 = np.number
+        op2 = utils.as_numpy_scalar(op2)
+    else:
+        key2 = type(op2)
+
+    key = (key1, key2)
+
+    if key in op_registry:
+        res = op_registry[key](op1, op2)
+    else:
+        res = NotImplemented
+
+    if res is NotImplemented and fallback_operator is not None:
+        res = fallback_operator(op1, op2)
+
+    return res

--- a/src/probnum/randprocs/kernels/_arithmetic.py
+++ b/src/probnum/randprocs/kernels/_arithmetic.py
@@ -1,76 +1,11 @@
 """Kernel arithmetic."""
-
-from typing import Callable, Dict, Optional, Tuple, Union
-
-import numpy as np
-
-from probnum import utils
-from probnum.typing import NotImplementedType
-
 from ._arithmetic_fallbacks import SumKernel, _mul_fallback
 from ._kernel import BinaryOperandType, Kernel
 
 
 def add(op1: BinaryOperandType, op2: BinaryOperandType) -> Kernel:
-    return _apply(_add_fns, op1, op2, fallback_operator=SumKernel)
+    return SumKernel(op1, op2)
 
 
 def mul(op1: BinaryOperandType, op2: BinaryOperandType) -> Kernel:
-    return _apply(_mul_fns, op1, op2, fallback_operator=_mul_fallback)
-
-
-########################################################################################
-# Operator registry
-########################################################################################
-
-_BinaryOperatorType = Callable[[Kernel, Kernel], Union[Kernel, NotImplementedType]]
-_BinaryOperatorRegistryType = Dict[Tuple[type, type], _BinaryOperatorType]
-
-
-_add_fns: _BinaryOperatorRegistryType = {}
-_mul_fns: _BinaryOperatorRegistryType = {}
-
-########################################################################################
-# Fill Arithmetics Registries
-########################################################################################
-
-
-########################################################################################
-# Apply
-########################################################################################
-
-
-def _apply(
-    op_registry: _BinaryOperatorRegistryType,
-    op1: Kernel,
-    op2: Kernel,
-    fallback_operator: Optional[
-        Callable[
-            [Kernel, Kernel],
-            Union[Kernel, NotImplementedType],
-        ]
-    ] = None,
-) -> Union[Kernel, NotImplementedType]:
-    if np.ndim(op1) == 0:
-        key1 = np.number
-        op1 = utils.as_numpy_scalar(op1)
-    else:
-        key1 = type(op1)
-
-    if np.ndim(op2) == 0:
-        key2 = np.number
-        op2 = utils.as_numpy_scalar(op2)
-    else:
-        key2 = type(op2)
-
-    key = (key1, key2)
-
-    if key in op_registry:
-        res = op_registry[key](op1, op2)
-    else:
-        res = NotImplemented
-
-    if res is NotImplemented and fallback_operator is not None:
-        res = fallback_operator(op1, op2)
-
-    return res
+    return _mul_fallback(op1, op2)

--- a/src/probnum/randprocs/kernels/_arithmetic.py
+++ b/src/probnum/randprocs/kernels/_arithmetic.py
@@ -4,8 +4,10 @@ from ._kernel import BinaryOperandType, Kernel
 
 
 def add(op1: BinaryOperandType, op2: BinaryOperandType) -> Kernel:
+    """Kernel summation."""
     return SumKernel(op1, op2)
 
 
 def mul(op1: BinaryOperandType, op2: BinaryOperandType) -> Kernel:
+    """Kernel multiplication."""
     return _mul_fallback(op1, op2)

--- a/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
+++ b/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
@@ -74,7 +74,8 @@ class SumKernel(Kernel):
     Parameters
     ----------
     summands
-        Kernels to sum together. Must have the same ``input_shape`` and ``output_shape``.
+        Kernels to sum together. Must have the same ``input_shape`` and
+        ``output_shape``.
     """
 
     def __init__(self, *summands: Kernel):
@@ -109,7 +110,9 @@ class SumKernel(Kernel):
 
         for summand in summands:
             if isinstance(summand, SumKernel):
-                expanded_summands.extend(summand._summands)
+                expanded_summands.extend(
+                    summand._summands
+                )  # pylint: disable="protected-access"
             else:
                 expanded_summands.append(summand)
 
@@ -129,7 +132,8 @@ class ProductKernel(Kernel):
     Parameters
     ----------
     factors
-        Kernels to multiply together. Must have the same ``input_shape`` and ``output_shape``.
+        Kernels to multiply together. Must have the same ``input_shape`` and
+        ``output_shape``.
     """
 
     def __init__(self, *factors: Kernel):
@@ -164,7 +168,9 @@ class ProductKernel(Kernel):
 
         for factor in factors:
             if isinstance(factor, ProductKernel):
-                expanded_factors.extend(factor._factors)
+                expanded_factors.extend(
+                    factor._factors
+                )  # pylint: disable="protected-access"
             else:
                 expanded_factors.append(factor)
 

--- a/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
+++ b/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
@@ -1,0 +1,175 @@
+"""Fallback-implementations of Kernel arithmetic."""
+
+from __future__ import annotations
+
+import functools
+import operator
+from typing import Optional, Tuple
+
+import numpy as np
+
+from probnum import utils
+from probnum.typing import ScalarLike
+
+from ._kernel import Kernel
+
+########################################################################################
+# Generic Linear Operator Arithmetic (Fallbacks)
+########################################################################################
+
+
+class ScaledKernel(Kernel):
+    r"""Kernel scaled with a (positive) scalar.
+
+    Define a new kernel
+
+    .. math ::
+        k(x_0, x_1) = o k'(x_0, x_1)
+
+    by scaling with a positive scalar :math:`o \in (0, \infty)`.
+
+    Parameters
+    ----------
+    kernel
+        Kernel.
+    scalar
+        Scalar to multiply with.
+    """
+
+    def __init__(self, kernel: Kernel, scalar: ScalarLike):
+
+        if not isinstance(kernel, Kernel):
+            raise TypeError("`kernel` must be a `Kernel`")
+
+        if np.ndim(scalar) != 0:
+            raise TypeError("`scalar` must be a scalar.")
+
+        if not scalar > 0.0:
+            raise ValueError("'scalar' must be positive.")
+
+        self._kernel = kernel
+        self._scalar = utils.as_numpy_scalar(scalar)
+
+        super().__init__(kernel.input_shape, kernel.output_shape)
+
+    def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
+        return self._scalar * self._kernel(x0, x1)
+
+    def __repr__(self) -> str:
+        return f"{self._scalar} * {self._kernel}"
+
+
+class SumKernel(Kernel):
+    r"""Sum of kernels.
+
+    Define a new kernel
+
+    .. math ::
+        k(x_0, x_1) = \sum_{i=1}^m k_i(x_0, x_1)
+
+    from a set of kernels :math:`k_i` via summation.
+
+    Parameters
+    ----------
+    summands
+        Kernels to sum together. Must have the same ``input_shape`` and ``output_shape``.
+    """
+
+    def __init__(self, *summands: Kernel):
+
+        if not all(
+            (summand.input_shape == summands[0].input_shape)
+            and (summand.output_shape == summands[0].output_shape)
+            for summand in summands
+        ):
+            raise ValueError("All summands must have the same in- and output shape.")
+
+        self._summands = SumKernel._expand_sum_ops(*summands)
+
+        super().__init__(
+            input_shape=summands[0].input_shape, output_shape=summands[0].output_shape
+        )
+
+    def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
+        return (
+            lambda: functools.reduce(
+                operator.add,
+                (summand(x0, x1) for summand in self._summands),
+            ),
+        )
+
+    def __repr__(self):
+        res = "SumKernel [\n"
+        for s in self._summands:
+            res += f"\t{s}, \n"
+        return res + "]"
+
+    @staticmethod
+    def _expand_sum_kernels(*summands: Kernel) -> Tuple[Kernel, ...]:
+        expanded_summands = []
+
+        for summand in summands:
+            if isinstance(summand, SumKernel):
+                expanded_summands.extend(summand._summands)
+            else:
+                expanded_summands.append(summand)
+
+        return tuple(expanded_summands)
+
+
+class ProductKernel(Kernel):
+    """(Element-wise) Product of kernels.
+
+    Define a new kernel
+
+    .. math ::
+        k(x_0, x_1) = \prod_{i=1}^m k_i(x_0, x_1)
+
+    from a set of kernels :math:`k_i` via multiplication.
+
+    Parameters
+    ----------
+    factors
+        Kernels to multiply together. Must have the same ``input_shape`` and ``output_shape``.
+    """
+
+    def __init__(self, *factors: Kernel):
+
+        if not all(
+            (factor.input_shape == factors[0].input_shape)
+            and (factor.output_shape == factors[0].output_shape)
+            for factor in factors
+        ):
+            raise ValueError("All factors must have the same in- and output shape.")
+
+        self._factors = ProductKernel._expand_prod_ops(*factors)
+
+        super().__init__(
+            input_shape=factors[0].input_shape, output_shape=factors[0].output_shape
+        )
+
+    def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
+        return (
+            lambda: functools.reduce(
+                operator.mul,
+                (factor(x0, x1) for factor in self._factors),
+            ),
+        )
+
+    def __repr__(self):
+        res = "ProductKernel [\n"
+        for s in self._factors:
+            res += f"\t{s}, \n"
+        return res + "]"
+
+    @staticmethod
+    def _expand_prod_kernels(*factors: Kernel) -> Tuple[Kernel, ...]:
+        expanded_factors = []
+
+        for factor in factors:
+            if isinstance(factor, ProductKernel):
+                expanded_factors.extend(factor._factors)
+            else:
+                expanded_factors.append(factor)
+
+        return tuple(expanded_factors)

--- a/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
+++ b/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
@@ -50,7 +50,9 @@ class ScaledKernel(Kernel):
         self._kernel = kernel
         self._scalar = utils.as_numpy_scalar(scalar)
 
-        super().__init__(kernel.input_shape, kernel.output_shape)
+        super().__init__(
+            input_shape=kernel.input_shape, output_shape=kernel.output_shape
+        )
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
         return self._scalar * self._kernel(x0, x1)
@@ -115,7 +117,7 @@ class SumKernel(Kernel):
 
 
 class ProductKernel(Kernel):
-    """(Element-wise) Product of kernels.
+    r"""(Element-wise) Product of kernels.
 
     Define a new kernel
 
@@ -175,7 +177,9 @@ def _mul_fallback(
     res = NotImplemented
 
     if isinstance(op1, Kernel):
-        if np.ndim(op2) == 0:
+        if isinstance(op2, Kernel):
+            res = ProductKernel(op1, op2)
+        elif np.ndim(op2) == 0:
             res = ScaledKernel(kernel=op1, scalar=op2)
     elif isinstance(op2, Kernel):
         if np.ndim(op1) == 0:

--- a/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
+++ b/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
@@ -110,9 +110,8 @@ class SumKernel(Kernel):
 
         for summand in summands:
             if isinstance(summand, SumKernel):
-                expanded_summands.extend(
-                    summand._summands
-                )  # pylint: disable="protected-access"
+                # pylint: disable="protected-access"
+                expanded_summands.extend(summand._summands)
             else:
                 expanded_summands.append(summand)
 
@@ -168,9 +167,8 @@ class ProductKernel(Kernel):
 
         for factor in factors:
             if isinstance(factor, ProductKernel):
-                expanded_factors.extend(
-                    factor._factors
-                )  # pylint: disable="protected-access"
+                # pylint: disable="protected-access"
+                expanded_factors.extend(factor._factors)
             else:
                 expanded_factors.append(factor)
 

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -428,10 +428,8 @@ class Kernel(abc.ABC):
 
     __array_ufunc__ = None
     """
-    This prevents numpy from calling elementwise arithmetic operations allowing
-    expressions like `y = np.array([1, 1]) + linop` to call the arithmetic operations
-    defined by `LinearOperator` instead of elementwise. Thus no array of
-    `LinearOperator`s but a `LinearOperator` with the correct shape is returned.
+    This prevents numpy from calling elementwise arithmetic operations instead of
+    the arithmetic operations defined by `Kernel`.
     """
 
     def __add__(self, other: BinaryOperandType) -> Kernel:

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -126,7 +126,7 @@ class Kernel(abc.ABC):
 
     >>> from probnum.randprocs.kernels import WhiteNoise
     >>> k_noise = k + 0.1 * WhiteNoise(input_shape=D)
-    >>> k.matrix(xs)
+    >>> k_noise.matrix(xs)
     array([[0.14132231, 0.11570248, 0.19008264, 0.26446281],
            [0.11570248, 0.51322314, 0.7107438 , 1.00826446],
            [0.19008264, 0.7107438 , 1.33140496, 1.75206612],

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -71,8 +71,9 @@ class Kernel(abc.ABC):
     Examples
     --------
 
+    >>> from probnum.randprocs.kernels import Linear
     >>> D = 3
-    >>> k = pn.randprocs.kernels.Linear(input_shape=D)
+    >>> k = Linear(input_shape=D)
     >>> k.input_shape
     (3,)
     >>> k.output_shape
@@ -119,6 +120,17 @@ class Kernel(abc.ABC):
 
     >>> k(xs[:-1, :], xs[1:, :])
     array([0.11570248, 0.7107438 , 1.75206612])
+
+    Kernels support basic arithmetic operations. For example we can add noise to the
+    kernel in the following fashion.
+
+    >>> from probnum.randprocs.kernels import WhiteNoise
+    >>> k_noise = k + 0.1 * WhiteNoise(input_shape=D)
+    >>> k.matrix(xs)
+    array([[0.14132231, 0.11570248, 0.19008264, 0.26446281],
+           [0.11570248, 0.51322314, 0.7107438 , 1.00826446],
+           [0.19008264, 0.7107438 , 1.33140496, 1.75206612],
+           [0.26446281, 1.00826446, 1.75206612, 2.59586777]])
     """
 
     def __init__(

--- a/src/probnum/randprocs/kernels/_white_noise.py
+++ b/src/probnum/randprocs/kernels/_white_noise.py
@@ -22,24 +22,28 @@ class WhiteNoise(Kernel):
     ----------
     input_shape :
         Shape of the kernel's input.
-    sigma :
-        Noise level :math:`\sigma`.
+    sigma_sq :
+        Noise level :math:`\sigma^2 \geq 0`.
     """
 
-    def __init__(self, input_shape: ShapeLike, sigma: ScalarLike = 1.0):
-        self.sigma = _utils.as_numpy_scalar(sigma)
-        self._sigma_sq = self.sigma**2
+    def __init__(self, input_shape: ShapeLike, sigma_sq: ScalarLike = 1.0):
+
+        if sigma_sq < 0:
+            raise ValueError(f"Noise level sigma_sq={sigma_sq} must be non-negative.")
+
+        self.sigma_sq = _utils.as_numpy_scalar(sigma_sq)
+
         super().__init__(input_shape=input_shape)
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray]) -> np.ndarray:
         if x1 is None:
             return np.full_like(  # pylint: disable=unexpected-keyword-arg
                 x0,
-                self._sigma_sq,
+                self.sigma_sq,
                 shape=x0.shape[: x0.ndim - self.input_ndim],
             )
 
         if self.input_shape == ():
-            return self._sigma_sq * (x0 == x1)
+            return self.sigma_sq * (x0 == x1)
 
-        return self._sigma_sq * np.all(x0 == x1, axis=-1)
+        return self.sigma_sq * np.all(x0 == x1, axis=-1)

--- a/tests/test_randprocs/test_kernels/conftest.py
+++ b/tests/test_randprocs/test_kernels/conftest.py
@@ -36,7 +36,7 @@ def fixture_input_shape(request) -> ShapeType:
         pytest.param(kerndef, id=kerndef[0].__name__)
         for kerndef in [
             (pn.randprocs.kernels.Linear, {"constant": 1.0}),
-            (pn.randprocs.kernels.WhiteNoise, {"sigma": -1.0}),
+            (pn.randprocs.kernels.WhiteNoise, {"sigma_sq": 1.0}),
             (pn.randprocs.kernels.Polynomial, {"constant": 1.0, "exponent": 3}),
             (pn.randprocs.kernels.ExpQuad, {"lengthscale": 1.5}),
             (pn.randprocs.kernels.RatQuad, {"lengthscale": 0.5, "alpha": 2.0}),
@@ -60,7 +60,9 @@ def fixture_kernel_call_naive(
 ) -> Callable[[np.ndarray, Optional[np.ndarray]], np.ndarray]:
     """Naive implementation of kernel broadcasting which applies the kernel function to
     scalar arguments while looping over the first dimensions of the inputs explicitly.
-    Can be used as a reference implementation of `Kernel.__call__` vectorization."""
+
+    Can be used as a reference implementation of `Kernel.__call__` vectorization.
+    """
 
     if kernel.input_ndim == 0:
         kernel_vectorized = np.vectorize(kernel, signature="(),()->()")

--- a/tests/test_randprocs/test_kernels/test_arithmetic.py
+++ b/tests/test_randprocs/test_kernels/test_arithmetic.py
@@ -1,1 +1,35 @@
 """Tests for kernel arithmetic."""
+from probnum.randprocs import kernels
+from probnum.randprocs.kernels._arithmetic_fallbacks import (
+    ProductKernel,
+    ScaledKernel,
+    SumKernel,
+)
+
+
+def test_scalar_mul(kernel: kernels.Kernel):
+    scalar = 3.14
+    kernel_mul = kernel * scalar
+    kernel_rmul = scalar * kernel
+    assert isinstance(kernel_mul, ScaledKernel)
+    assert isinstance(kernel_rmul, ScaledKernel)
+    assert kernel_mul.input_shape == kernel.input_shape
+    assert kernel_rmul.input_shape == kernel.input_shape
+    assert kernel_mul.output_shape == kernel.output_shape
+    assert kernel_rmul.output_shape == kernel.output_shape
+
+
+def test_add(kernel: kernels.Kernel):
+    k_whitenoise = kernels.WhiteNoise(input_shape=kernel.input_shape)
+    kernel_sum = kernel + k_whitenoise
+    assert isinstance(kernel_sum, SumKernel)
+    assert kernel_sum.input_shape == kernel.input_shape
+    assert kernel_sum.output_shape == kernel.output_shape
+
+
+def test_mul(kernel: kernels.Kernel):
+    k_poly = kernels.Polynomial(input_shape=kernel.input_shape)
+    kernel_prod = kernel * k_poly
+    assert isinstance(kernel_prod, ProductKernel)
+    assert kernel_prod.input_shape == kernel.input_shape
+    assert kernel_prod.output_shape == kernel.output_shape

--- a/tests/test_randprocs/test_kernels/test_arithmetic.py
+++ b/tests/test_randprocs/test_kernels/test_arithmetic.py
@@ -1,0 +1,1 @@
+"""Tests for kernel arithmetic."""

--- a/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
+++ b/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
@@ -54,6 +54,13 @@ def test_sum_kernel_shape_mismatch_raises_error():
         )
 
 
+def test_sum_kernel_contracts():
+    input_shape = ()
+    k = kernels.ExpQuad(input_shape=input_shape)
+    k_sum = SumKernel(k, SumKernel(k, k))
+    assert all(not isinstance(summand, SumKernel) for summand in k_sum._summands)
+
+
 def test_product_kernel_evaluation(kernel: kernels.Kernel, x0: np.ndarray):
     k_poly = kernels.Polynomial(input_shape=kernel.input_shape)
     k_sum = ProductKernel(kernel, k_poly)
@@ -65,3 +72,10 @@ def test_product_kernel_shape_mismatch_raises_error():
         ProductKernel(
             kernels.WhiteNoise(input_shape=()), kernels.WhiteNoise(input_shape=(1,))
         )
+
+
+def test_product_kernel_contracts():
+    input_shape = ()
+    k = kernels.ExpQuad(input_shape=input_shape)
+    k_prod = ProductKernel(k, ProductKernel(k, k))
+    assert all(not isinstance(factor, ProductKernel) for factor in k_prod._factors)

--- a/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
+++ b/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
@@ -1,0 +1,1 @@
+"""Tests for fall-back implementations of kernel arithmetic."""

--- a/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
+++ b/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
@@ -1,1 +1,67 @@
 """Tests for fall-back implementations of kernel arithmetic."""
+
+import numpy as np
+import pytest
+from pytest_cases import parametrize
+
+from probnum.randprocs import kernels
+from probnum.randprocs.kernels._arithmetic_fallbacks import (
+    ProductKernel,
+    ScaledKernel,
+    SumKernel,
+)
+from probnum.typing import ScalarType
+
+
+@parametrize("scalar", [1.0, 3, 1000.0])
+def test_scaled_kernel_evaluation(
+    kernel: kernels.Kernel, scalar: ScalarType, x0: np.ndarray
+):
+    k_scaled = ScaledKernel(kernel=kernel, scalar=scalar)
+    np.testing.assert_allclose(k_scaled.matrix(x0), scalar * kernel.matrix(x0))
+
+
+def test_non_positive_scalar_raises_error():
+    with pytest.raises(ValueError):
+        ScaledKernel(kernel=kernels.WhiteNoise(input_shape=()), scalar=0.0)
+
+    with pytest.raises(ValueError):
+        ScaledKernel(kernel=kernels.WhiteNoise(input_shape=()), scalar=-1.0)
+
+
+def test_non_scalar_raises_error():
+    with pytest.raises(TypeError):
+        ScaledKernel(kernel=kernels.WhiteNoise(input_shape=()), scalar=np.array([0, 1]))
+
+
+def test_non_kernel_raises_error():
+    with pytest.raises(TypeError):
+        ScaledKernel(kernel=np.eye(5), scalar=1.0)
+
+
+def test_sum_kernel_evaluation(kernel: kernels.Kernel, x0: np.ndarray):
+    k_whitenoise = kernels.WhiteNoise(input_shape=kernel.input_shape)
+    k_sum = SumKernel(kernel, k_whitenoise)
+    np.testing.assert_allclose(
+        k_sum.matrix(x0), kernel.matrix(x0) + k_whitenoise.matrix(x0)
+    )
+
+
+def test_sum_kernel_shape_mismatch_raises_error():
+    with pytest.raises(ValueError):
+        SumKernel(
+            kernels.WhiteNoise(input_shape=()), kernels.WhiteNoise(input_shape=(1,))
+        )
+
+
+def test_product_kernel_evaluation(kernel: kernels.Kernel, x0: np.ndarray):
+    k_poly = kernels.Polynomial(input_shape=kernel.input_shape)
+    k_sum = ProductKernel(kernel, k_poly)
+    np.testing.assert_allclose(k_sum.matrix(x0), kernel.matrix(x0) * k_poly.matrix(x0))
+
+
+def test_product_kernel_shape_mismatch_raises_error():
+    with pytest.raises(ValueError):
+        ProductKernel(
+            kernels.WhiteNoise(input_shape=()), kernels.WhiteNoise(input_shape=(1,))
+        )


### PR DESCRIPTION
# In a Nutshell
This PR adds basic arithmetic for `Kernel`s. Kernel arithmetic allows user-friendly definition of custom kernels from existing ones.

# Detailed Description
This PR adds a `SumKernel`, `ScaledKernel` and `ProductKernel` as well as addition and multiplication of kernels. This allows the definition of kernels in the following fashion

```python
import numpy as np
from probnum.randprocs.kernels import ExpQuad, WhiteNoise

# Data
x = np.linspace(-1, 1, 5)

# Kernel via arithmetic
k = ExpQuad(input_shape=()) + 0.01 * WhiteNoise(input_shape=())

# Kernel matrix
k.matrix(x)
"""
array([[1.01      , 0.8824969 , 0.60653066, 0.32465247, 0.13533528],
       [0.8824969 , 1.01      , 0.8824969 , 0.60653066, 0.32465247],
       [0.60653066, 0.8824969 , 1.01      , 0.8824969 , 0.60653066],
       [0.32465247, 0.60653066, 0.8824969 , 1.01      , 0.8824969 ],
       [0.13533528, 0.32465247, 0.60653066, 0.8824969 , 1.01      ]])
"""
```

# Other
This PR deliberately does not introduce an operator registry analogously to the one for `LinearOperator`s yet. Algebraic reductions as for `LinearOperator`s are most likely way less common for kernels.