### PR TITLE
Consistent usage of "residual" in `probnum.linalg`

### DIFF
--- a/benchmarks/linearsolvers.py
+++ b/benchmarks/linearsolvers.py
@@ -71,7 +71,7 @@ class LinSolve:
         problinsolve(A=self.linsys.A, b=self.linsys.b)
 
     def track_residual_norm(self, linsys, dim):
-        return np.linalg.norm(self.linsys.A @ self.xhat.mean - self.linsys.b)
+        return np.linalg.norm(self.linsys.b - self.linsys.A @ self.xhat.mean)
 
     def track_error_2norm(self, linsys, dim):
         return np.linalg.norm(self.linsys.solution - self.xhat.mean)

--- a/src/probnum/linalg/_bayescg.py
+++ b/src/probnum/linalg/_bayescg.py
@@ -33,7 +33,7 @@ def bayescg(
         Maximum number of iterations. Defaults to :math:`10n`, where :math:`n` is the
         dimension of :math:`A`.
     atol
-        Absolute residual tolerance. If :math:`\lVert r_i \rVert = \lVert Ax_i - b
+        Absolute residual tolerance. If :math:`\lVert r_i \rVert = \lVert b - Ax_i
         \rVert < \text{atol}`, the iteration terminates.
     rtol
         Relative residual tolerance. If :math:`\lVert r_i \rVert  < \text{rtol}

--- a/src/probnum/linalg/solvers/_state.py
+++ b/src/probnum/linalg/solvers/_state.py
@@ -13,7 +13,10 @@ from probnum import problems
 class LinearSolverState:
     """State of a probabilistic linear solver.
 
-    The solver state separates the state of a probabilistic linear solver from the algorithm itself, making the solver stateless. The state contains the problem to be solved, the current belief over the quantities of interest and any miscellaneous quantities computed during an iteration of a probabilistic linear solver. The solver state is passed between the different components of the solver and may be used internally to cache quantities which are used more than once.
+    The solver state separates the state of a probabilistic linear solver from the algorithm itself, making the solver stateless.
+    The state contains the problem to be solved, the current belief over the quantities of interest and any miscellaneous quantities
+    computed during an iteration of a probabilistic linear solver. The solver state is passed between the different components of the
+    solver and may be used internally to cache quantities which are used more than once.
 
     Parameters
     ----------
@@ -42,7 +45,7 @@ class LinearSolverState:
         self._actions: List[np.ndarray] = [None]
         self._observations: List[Any] = [None]
         self._residuals: List[np.ndarray] = [
-            self.problem.A @ self.belief.x.mean - self.problem.b,
+            self.problem.b - self.problem.A @ self.belief.x.mean,
         ]
         self.cache: Dict[str, Any] = {}
 
@@ -107,16 +110,16 @@ class LinearSolverState:
 
     @property
     def residual(self) -> np.ndarray:
-        r"""Cached residual :math:`Ax_i-b` for the current solution estimate :math:`x_i`."""
+        r"""Cached residual :math:`b - Ax_i` for the current solution estimate :math:`x_i`."""
         if self._residuals[self.step] is None:
             self._residuals[self.step] = (
-                self.problem.A @ self.belief.x.mean - self.problem.b
+                self.problem.b - self.problem.A @ self.belief.x.mean
             )
         return self._residuals[self.step]
 
     @property
     def residuals(self) -> Tuple[np.ndarray, ...]:
-        r"""Residuals :math:`\{Ax_i - b\}_i`."""
+        r"""Residuals :math:`\{b - Ax_i\}_i`."""
         return tuple(self._residuals)
 
     def next_step(self) -> None:

--- a/src/probnum/linalg/solvers/information_ops/_projected_rhs.py
+++ b/src/probnum/linalg/solvers/information_ops/_projected_rhs.py
@@ -1,4 +1,4 @@
-"""Information operator returning a projection of the residual."""
+"""Information operator returning a projection of the right-hand-side."""
 import numpy as np
 
 import probnum  # pylint: disable="unused-import"

--- a/src/probnum/linalg/solvers/policies/_conjugate_gradient.py
+++ b/src/probnum/linalg/solvers/policies/_conjugate_gradient.py
@@ -13,16 +13,17 @@ from . import _linear_solver_policy
 class ConjugateGradientPolicy(_linear_solver_policy.LinearSolverPolicy):
     r"""Policy returning :math:`A`-conjugate actions.
 
-    Selects the negative gradient / residual as an initial action :math:`s_0 = b - A x_0` and then successively generates :math:`A`-conjugate actions, i.e. the actions satisfy :math:`s_i^\top A s_j = 0` iff :math:`i \neq j`.
+    Selects the negative gradient / residual as an initial action :math:`s_0 = b - A x_0` and then successively
+    generates :math:`A`-conjugate actions, i.e. the actions satisfy :math:`s_i^\top A s_j = 0` iff :math:`i \neq j`.
 
     Parameters
     ----------
     reorthogonalization_fn_residual
-        Reorthogonalization function, which takes a vector, an orthogonal basis and optionally an inner product and returns a reorthogonalized vector. If not `None`
-        the residuals are reorthogonalized before the action is computed.
+        Reorthogonalization function, which takes a vector, an orthogonal basis and optionally an inner product and
+        returns a reorthogonalized vector. If not `None` the residuals are reorthogonalized before the action is computed.
     reorthogonalization_fn_action
-        Reorthogonalization function, which takes a vector, an orthogonal basis and optionally an inner product and returns a reorthogonalized vector. If not `None`
-        the computed action is reorthogonalized.
+        Reorthogonalization function, which takes a vector, an orthogonal basis and optionally an inner product and
+        returns a reorthogonalized vector. If not `None` the computed action is reorthogonalized.
     """
 
     def __init__(
@@ -62,7 +63,7 @@ class ConjugateGradientPolicy(_linear_solver_policy.LinearSolverPolicy):
 
             # A-conjugacy correction (in exact arithmetic)
             beta = (np.linalg.norm(residual) / np.linalg.norm(prev_residual)) ** 2
-            action = -residual + beta * solver_state.actions[solver_state.step - 1]
+            action = residual + beta * solver_state.actions[solver_state.step - 1]
 
             # Reorthogonalization of the resulting action
             if self._reorthogonalization_fn_action is not None:
@@ -71,7 +72,7 @@ class ConjugateGradientPolicy(_linear_solver_policy.LinearSolverPolicy):
                 )
 
         else:
-            action = -residual
+            action = residual
 
         return action
 

--- a/src/probnum/linalg/solvers/stopping_criteria/_residual_norm.py
+++ b/src/probnum/linalg/solvers/stopping_criteria/_residual_norm.py
@@ -11,7 +11,7 @@ from ._linear_solver_stopping_criterion import LinearSolverStoppingCriterion
 class ResidualNormStoppingCriterion(LinearSolverStoppingCriterion):
     r"""Residual stopping criterion.
 
-    Terminate when the euclidean norm of the residual :math:`r_{i} = A x_{i} - b` is
+    Terminate when the euclidean norm of the residual :math:`r_{i} = b - A x_{i}` is
     sufficiently small, i.e. if it satisfies :math:`\lVert r_i \rVert_2 \leq \max(
     \text{atol}, \text{rtol} \lVert b \rVert_2)`.
 

--- a/tests/test_linalg/test_solvers/test_policies/test_conjugate_gradient.py
+++ b/tests/test_linalg/test_solvers/test_policies/test_conjugate_gradient.py
@@ -21,7 +21,7 @@ def test_initial_action_is_negative_gradient(
     assert state.step == 0
     state = copy.deepcopy(state)
     action = policy(state)
-    np.testing.assert_allclose(action, -state.residual)
+    np.testing.assert_allclose(action, state.residual)
 
 
 @parametrize_with_cases("policy", cases=cases_policies, glob="*conjugate_*")

--- a/tests/test_linalg/test_solvers/test_probabilistic_linear_solver/test_asymmetric.py
+++ b/tests/test_linalg/test_solvers/test_probabilistic_linear_solver/test_asymmetric.py
@@ -27,7 +27,7 @@ def test_small_residual(
         prior=prior, problem=problem, rng=np.random.default_rng(42)
     )
 
-    residual_norm = np.linalg.norm(problem.A @ belief.x.mean - problem.b, ord=2)
+    residual_norm = np.linalg.norm(problem.b - problem.A @ belief.x.mean, ord=2)
 
     assert residual_norm < 1e-5 or residual_norm < 1e-5 * np.linalg.norm(
         problem.b, ord=2

--- a/tests/test_linalg/test_solvers/test_probabilistic_linear_solver/test_symmetric.py
+++ b/tests/test_linalg/test_solvers/test_probabilistic_linear_solver/test_symmetric.py
@@ -26,7 +26,7 @@ def test_small_residual(
         prior=prior, problem=problem, rng=np.random.default_rng(42)
     )
 
-    residual_norm = np.linalg.norm(problem.A @ belief.x.mean - problem.b, ord=2)
+    residual_norm = np.linalg.norm(problem.b - problem.A @ belief.x.mean, ord=2)
 
     assert residual_norm < 1e-5 or residual_norm < 1e-5 * np.linalg.norm(
         problem.b, ord=2

--- a/tests/test_linalg/test_solvers/test_state.py
+++ b/tests/test_linalg/test_solvers/test_state.py
@@ -12,7 +12,7 @@ cases_states = "cases.states"
 def test_residual(state: LinearSolverState):
     """Test whether the state computes the residual correctly."""
     linsys = state.problem
-    residual = linsys.A @ state.belief.x.mean - linsys.b
+    residual = linsys.b - linsys.A @ state.belief.x.mean
     np.testing.assert_allclose(residual, state.residual)
 
 


### PR DESCRIPTION
# In a Nutshell
This PR introduces the more commonly used definition of residual as `residual = y - y_approx` into `probnum.linalg` instead of `residual = y_approx - y`.
