### PR TITLE
Moving `quad` policies to separate modules

### DIFF
--- a/src/probnum/quad/solvers/policies/__init__.py
+++ b/src/probnum/quad/solvers/policies/__init__.py
@@ -1,1 +1,2 @@
-from ._policy import Policy, RandomPolicy
+from ._policy import Policy
+from ._random_policy import RandomPolicy

--- a/src/probnum/quad/solvers/policies/__init__.py
+++ b/src/probnum/quad/solvers/policies/__init__.py
@@ -1,4 +1,4 @@
-"""Policies functions for Bayesian quadrature."""
+"""Policies for Bayesian quadrature."""
 
 from ._policy import Policy
 from ._random_policy import RandomPolicy

--- a/src/probnum/quad/solvers/policies/__init__.py
+++ b/src/probnum/quad/solvers/policies/__init__.py
@@ -1,2 +1,4 @@
+"""Policies functions for Bayesian quadrature."""
+
 from ._policy import Policy
 from ._random_policy import RandomPolicy

--- a/src/probnum/quad/solvers/policies/_policy.py
+++ b/src/probnum/quad/solvers/policies/_policy.py
@@ -1,4 +1,4 @@
-"""Abstract base class for BQ acquisition policies."""
+"""Abstract base class for BQ policies."""
 
 import abc
 

--- a/src/probnum/quad/solvers/policies/_policy.py
+++ b/src/probnum/quad/solvers/policies/_policy.py
@@ -1,7 +1,6 @@
 """Abstract base class for BQ acquisition policies."""
 
 import abc
-from typing import Callable
 
 import numpy as np
 
@@ -12,7 +11,6 @@ from probnum.quad.solvers.bq_state import BQState
 
 class Policy(abc.ABC):
     """An abstract class for a policy that acquires nodes for Bayesian quadrature.
-
     Parameters
     ----------
     batch_size :
@@ -24,54 +22,13 @@ class Policy(abc.ABC):
 
     def __call__(self, bq_state: BQState) -> np.ndarray:
         """Find nodes according to the policy.
-
         Parameters
         ----------
         bq_state :
-            Current state of the BQ method.
-
+            State of the BQ belief.
         Returns
         -------
         nodes :
             *shape=(batch_size, input_dim)* -- Nodes found according to the policy.
         """
         raise NotImplementedError
-
-
-class RandomPolicy(Policy):
-    """Random sampling from an objective.
-
-    Parameters
-    ----------
-    sample_func :
-        The sample function. Needs to have the following interface:
-        `sample_func(batch_size: int, rng: np.random.Generator)` and return an array of
-        shape (batch_size, n_dim).
-    batch_size :
-        Size of batch of nodes when calling the policy once.
-    """
-
-    def __init__(
-        self,
-        sample_func: Callable,
-        batch_size: int,
-        rng: np.random.Generator = np.random.default_rng(),
-    ) -> None:
-        super().__init__(batch_size=batch_size)
-        self.sample_func = sample_func
-        self.rng = rng
-
-    def __call__(self, bq_state: BQState) -> np.ndarray:
-        """Find nodes according to the random policy.
-
-        Parameters
-        ----------
-        bq_state :
-            Current state of the BQ method.
-
-        Returns
-        -------
-        nodes :
-            *shape=(batch_size, input_dim)* -- Nodes found according to the policy.
-        """
-        return self.sample_func(self.batch_size, rng=self.rng)

--- a/src/probnum/quad/solvers/policies/_random_policy.py
+++ b/src/probnum/quad/solvers/policies/_random_policy.py
@@ -1,0 +1,37 @@
+"""Random policy for Bayesian Monte Carlo."""
+
+from typing import Callable
+
+import numpy as np
+
+from probnum.quad.solvers.bq_state import BQState
+
+from ._policy import Policy
+
+# pylint: disable=too-few-public-methods, fixme
+
+
+class RandomPolicy(Policy):
+    """Random sampling from an objective.
+    Parameters
+    ----------
+    sample_func :
+        The sample function. Needs to have the following interface:
+        `sample_func(batch_size: int, rng: np.random.Generator)` and return an array of
+        shape (batch_size, n_dim).
+    batch_size :
+        Size of batch of nodes when calling the policy once.
+    """
+
+    def __init__(
+        self,
+        sample_func: Callable,
+        batch_size: int,
+        rng: np.random.Generator = np.random.default_rng(),
+    ) -> None:
+        super().__init__(batch_size=batch_size)
+        self.sample_func = sample_func
+        self.rng = rng
+
+    def __call__(self, bq_state: BQState) -> np.ndarray:
+        return self.sample_func(self.batch_size, rng=self.rng)

--- a/src/probnum/quad/solvers/policies/_random_policy.py
+++ b/src/probnum/quad/solvers/policies/_random_policy.py
@@ -13,6 +13,7 @@ from ._policy import Policy
 
 class RandomPolicy(Policy):
     """Random sampling from an objective.
+
     Parameters
     ----------
     sample_func :


### PR DESCRIPTION
# In a Nutshell
This PR moves the existing `quad` policies to separate modules. No functional changes.

# Detailed Description
This is one of the changes proposed in #620 

# Related Issues
Closes #...
