### PR TITLE
Consistent types for `quad` domain.

### DIFF
--- a/src/probnum/quad/_bayesquad.py
+++ b/src/probnum/quad/_bayesquad.py
@@ -7,7 +7,7 @@ methods return a random variable, specifying the belief about the true value of 
 integral.
 """
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple
 import warnings
 
 import numpy as np
@@ -18,6 +18,7 @@ from probnum.randvars import Normal
 from probnum.typing import FloatLike, IntLike
 
 from ._integration_measures import GaussianMeasure, IntegrationMeasure, LebesgueMeasure
+from ._quad_typing import DomainLike
 from .solvers import BayesianQuadrature
 
 
@@ -25,9 +26,7 @@ def bayesquad(
     fun: Callable,
     input_dim: int,
     kernel: Optional[Kernel] = None,
-    domain: Optional[
-        Union[Tuple[FloatLike, FloatLike], Tuple[np.ndarray, np.ndarray]]
-    ] = None,
+    domain: Optional[DomainLike] = None,
     measure: Optional[IntegrationMeasure] = None,
     policy: Optional[str] = "bmc",
     max_evals: Optional[IntLike] = None,
@@ -162,9 +161,7 @@ def bayesquad_from_data(
     nodes: np.ndarray,
     fun_evals: np.ndarray,
     kernel: Optional[Kernel] = None,
-    domain: Optional[
-        Tuple[Union[np.ndarray, FloatLike], Union[np.ndarray, FloatLike]]
-    ] = None,
+    domain: Optional[DomainLike] = None,
     measure: Optional[IntegrationMeasure] = None,
 ) -> Tuple[Normal, BQInfo]:
     r"""Infer the value of an integral from a given set of nodes and function

--- a/src/probnum/quad/_quad_typing.py
+++ b/src/probnum/quad/_quad_typing.py
@@ -1,0 +1,8 @@
+from typing import Tuple, Union
+
+import numpy as np
+
+from probnum.typing import FloatLike
+
+_DomainType = Tuple[np.ndarray, np.ndarray]
+DomainLike = Union[Tuple[FloatLike, FloatLike], _DomainType]

--- a/src/probnum/quad/solvers/bayesian_quadrature.py
+++ b/src/probnum/quad/solvers/bayesian_quadrature.py
@@ -1,6 +1,6 @@
 """Probabilistic numerical methods for solving integrals."""
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 
@@ -16,6 +16,7 @@ from probnum.randvars import Normal
 from probnum.typing import FloatLike, IntLike
 
 from .._integration_measures import IntegrationMeasure, LebesgueMeasure
+from .._quad_typing import DomainLike
 from ..kernel_embeddings import KernelEmbedding
 from .belief_updates import BQBeliefUpdate, BQStandardBeliefUpdate
 from .bq_state import BQState
@@ -30,15 +31,15 @@ class BayesianQuadrature:
 
     Parameters
     ----------
-    kernel :
+    kernel
         The kernel used for the GP model.
-    measure :
+    measure
         The integration measure.
-    policy :
+    policy
         The policy choosing nodes at which to evaluate the integrand.
-    belief_update :
+    belief_update
         The inference method.
-    stopping_criterion :
+    stopping_criterion
         The criterion that determines convergence.
     """
     # pylint: disable=too-many-arguments
@@ -63,9 +64,7 @@ class BayesianQuadrature:
         input_dim: int,
         kernel: Optional[Kernel] = None,
         measure: Optional[IntegrationMeasure] = None,
-        domain: Optional[
-            Union[Tuple[FloatLike, FloatLike], Tuple[np.ndarray, np.ndarray]]
-        ] = None,
+        domain: Optional[DomainLike] = None,
         policy: str = "bmc",
         max_evals: Optional[IntLike] = None,
         var_tol: Optional[FloatLike] = None,
@@ -78,25 +77,25 @@ class BayesianQuadrature:
 
         Parameters
         ----------
-        input_dim :
+        input_dim
             Input dimension.
-        kernel :
+        kernel
             The kernel used for the GP model.
-        measure :
+        measure
             The integration measure.
-        domain :
+        domain
             The integration bounds.
-        policy :
+        policy
             The policy choosing nodes at which to evaluate the integrand.
-        max_evals :
+        max_evals
             Maximum number of evaluations as stopping criterion.
-        var_tol :
+        var_tol
             Variance tolerance as stopping criterion.
-        rel_tol :
+        rel_tol
             Relative tolerance as stopping criterion.
-        batch_size :
+        batch_size
             Batch size used in node acquisition.
-        rng :
+        rng
             The random number generator.
 
         Returns

--- a/tests/test_quad/test_bayesquad/test_bq.py
+++ b/tests/test_quad/test_bayesquad/test_bq.py
@@ -165,4 +165,3 @@ def test_domain_ignored_if_lebesgue(input_dim, measure):
         nodes=nodes, fun_evals=fun_evals, domain=domain, measure=measure
     )
     assert isinstance(bq_integral, Normal)
-

--- a/tests/test_quad/test_bayesquad/test_bq.py
+++ b/tests/test_quad/test_bayesquad/test_bq.py
@@ -5,7 +5,7 @@ import pytest
 from scipy.integrate import quad
 
 from probnum.quad import bayesquad, bayesquad_from_data
-from probnum.quad.kernel_embeddings._kernel_embedding import KernelEmbedding
+from probnum.quad.kernel_embeddings import KernelEmbedding
 from probnum.randvars import Normal
 
 from ..util import gauss_hermite_tensor, gauss_legendre_tensor
@@ -38,7 +38,10 @@ def test_integral_values_1d(f1d, kernel, measure, input_dim):
     bq_integral, _ = bayesquad(
         fun=f1d, input_dim=input_dim, kernel=kernel, measure=measure, max_evals=250
     )
-    num_integral, _ = quad(integrand, measure.domain[0], measure.domain[1])
+    domain = measure.domain
+    if domain is None:
+        domain = (-np.infty, np.infty)
+    num_integral, _ = quad(integrand, domain[0], domain[1])
     np.testing.assert_almost_equal(bq_integral.mean, num_integral, decimal=2)
 
 
@@ -56,7 +59,6 @@ def test_integral_values_x2_gaussian(kernel, measure, input_dim):
         n_points=n_gh, input_dim=input_dim, mean=measure.mean, cov=measure.cov
     )
     fun_evals = fun(nodes)
-    print(nodes.shape)
     bq_integral, _ = bayesquad_from_data(
         nodes=nodes, fun_evals=fun_evals, kernel=kernel, measure=measure
     )
@@ -132,7 +134,7 @@ def test_domain_and_gaussian_measure_raises_error(measure, input_dim):
 def test_no_domain_or_measure_raises_error(input_dim):
     """Test that errors are correctly raised when both domain and a Gaussian measure is
     given."""
-    fun = lambda x: x
+    fun = lambda x: np.ones(x.shape[0])
     nodes = np.linspace(0, 1, 3)
     fun_evals = fun(nodes)
 
@@ -147,7 +149,7 @@ def test_no_domain_or_measure_raises_error(input_dim):
 @pytest.mark.parametrize("measure_name", ["lebesgue"])
 def test_domain_ignored_if_lebesgue(input_dim, measure):
     domain = (0, 1)
-    fun = lambda x: x
+    fun = lambda x: np.reshape(x, (x.shape[0],))
 
     # standard BQ
     bq_integral, _ = bayesquad(
@@ -163,3 +165,4 @@ def test_domain_ignored_if_lebesgue(input_dim, measure):
         nodes=nodes, fun_evals=fun_evals, domain=domain, measure=measure
     )
     assert isinstance(bq_integral, Normal)
+

--- a/tests/test_quad/test_bq_utils.py
+++ b/tests/test_quad/test_bq_utils.py
@@ -1,0 +1,73 @@
+"""Basic tests for bq utils."""
+
+import numpy as np
+import pytest
+
+from probnum.quad import IntegrationMeasure
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "dom, in_dim",
+    [
+        ((0, 1), -2),  # negative dimension
+        ((np.zeros(2), np.ones(2)), 3),  # length of bounds does not match dimension
+        ((np.zeros(2), np.ones(3)), None),  # lower and upper bounds not equal lengths
+        ((np.array([0, 0]), np.array([1, 0])), None),  # integration domain is empty
+        ((np.zeros([2, 1]), np.ones([2, 1])), None),  # bounds have too many dimensions
+        ((np.zeros([2, 1]), np.ones([2, 1])), 2),  # bounds have too many dimensions
+    ]
+)
+def test_as_domain_wrong_input(dom, in_dim):
+    with pytest.raises(ValueError):
+        IntegrationMeasure.as_domain(dom, in_dim)
+
+
+@pytest.mark.parametrize(
+    "dom, in_dim",
+    [
+        ((0, 1), 1),  # convert bounds to 1D array
+        ((0, 1), 3),  # expand bounds to 3D array
+        ((np.zeros(3), np.ones(3)), 3)  # bounds already expanded
+    ]
+)
+def test_as_domain_returns_correct_shape(dom, in_dim):
+    as_domain, as_input_dim = IntegrationMeasure.as_domain(dom, in_dim)
+    assert len(as_domain) == 2
+    assert as_domain[0].ndim == 1 and as_domain[0].ndim == 1
+    assert as_domain[0].shape[0] == in_dim and as_domain[1].shape[0] == in_dim
+
+
+@pytest.mark.parametrize(
+    "dom, in_dim",
+    [
+        ((0, 1), None),  # convert to 1D array
+        ((0, 1), 1),  # expand to 1D array
+        ((0, 1), 3),  # expand to 3D array
+        ((np.zeros(3), np.ones(3)), None),  # already expanded
+        ((np.zeros(3), np.ones(3)), 3),  # already expanded
+    ]
+)
+def test_as_domain_returns_correct_type(dom, in_dim):
+    as_domain, as_input_dim = IntegrationMeasure.as_domain(dom, in_dim)
+    assert isinstance(as_input_dim, int) and isinstance(as_domain, tuple)
+    assert isinstance(as_domain[0], np.ndarray) and isinstance(as_domain[1], np.ndarray)
+
+
+def test_as_domain_returns_correct_none():
+    as_domain, as_input_dim = IntegrationMeasure.as_domain(None, None)
+    assert as_domain is None and as_input_dim is None
+
+    as_domain, as_input_dim = IntegrationMeasure.as_domain(None, float(1.0))
+    assert as_domain is None and isinstance(as_input_dim, int)
+
+
+def test_as_domain_correct_values():
+    in_dim, lb, ub = 3, 0.0, 1.5
+    as_domain, as_input_dim = IntegrationMeasure.as_domain((lb, ub), in_dim)
+
+    lb_expanded = lb * np.ones(in_dim)
+    ub_expanded = ub * np.ones(in_dim)
+    np.testing.assert_allclose(as_domain[0], lb_expanded, atol=0.0, rtol=1e-12)
+    np.testing.assert_allclose(as_domain[1], ub_expanded, atol=0.0, rtol=1e-12)
+# fmt: on


### PR DESCRIPTION
# In a Nutshell
This PR introduces `DomainLike` and `_DomainType` types for the `quad` package and a utility function `as_domain` to convert to the internal type. Tests added as well. Further some minor docstring corrections. This is part of #620 .

# Detailed Description
n/a

# Related Issues
Closes #...
