### PR TITLE
Remove restriction for negative scalars in `ScaledKernel`

### DIFF
--- a/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
+++ b/src/probnum/randprocs/kernels/_arithmetic_fallbacks.py
@@ -44,9 +44,6 @@ class ScaledKernel(Kernel):
         if np.ndim(scalar) != 0:
             raise TypeError("`scalar` must be a scalar.")
 
-        if not scalar > 0.0:
-            raise ValueError("'scalar' must be positive.")
-
         self._kernel = kernel
         self._scalar = utils.as_numpy_scalar(scalar)
 

--- a/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
+++ b/tests/test_randprocs/test_kernels/test_arithmetic_fallbacks.py
@@ -21,14 +21,6 @@ def test_scaled_kernel_evaluation(
     np.testing.assert_allclose(k_scaled.matrix(x0), scalar * kernel.matrix(x0))
 
 
-def test_non_positive_scalar_raises_error():
-    with pytest.raises(ValueError):
-        ScaledKernel(kernel=kernels.WhiteNoise(input_shape=()), scalar=0.0)
-
-    with pytest.raises(ValueError):
-        ScaledKernel(kernel=kernels.WhiteNoise(input_shape=()), scalar=-1.0)
-
-
 def test_non_scalar_raises_error():
     with pytest.raises(TypeError):
         ScaledKernel(kernel=kernels.WhiteNoise(input_shape=()), scalar=np.array([0, 1]))


### PR DESCRIPTION
# In a Nutshell
Enables scaling a kernel with a negative value.

# Detailed Description
#654 introduced the possibility to multiply `Kernel`s scalar and the multiplication throws an exception in case this scalar is negative or 0. The latter is desirable in the context of covariance functions, since it ensures positive-semidefiniteness. However, `Kernel` is our interface for covariance functions as well as cross-covariance functions and in the case of cross-covariance functions, scaling with a negative value makes sense. For example, this happens if we want to compute the cross-covariance between a GP and its negative.

# Related Issues
None
