### PR TITLE
Fixing parameters expansion in `ProductMatern`

### DIFF
--- a/src/probnum/randprocs/kernels/_product_matern.py
+++ b/src/probnum/randprocs/kernels/_product_matern.py
@@ -71,10 +71,21 @@ class ProductMatern(Kernel):
         input_dim = 1 if input_shape == () else input_shape[0]
 
         # If only single scalar lengthcsale or nu is given, use this in every dimension
+        def expand_array(x, ndim):
+            return np.full((ndim,), _utils.as_numpy_scalar(x))
+
+        if isinstance(lengthscales, np.ndarray):
+            if lengthscales.shape == ():
+                lengthscales = expand_array(lengthscales, input_dim)
+        if isinstance(nus, np.ndarray):
+            if nus.shape == ():
+                nus = expand_array(nus, input_dim)
+
+        # also expand if scalars are given
         if np.isscalar(lengthscales):
-            lengthscales = np.full((input_dim,), _utils.as_numpy_scalar(lengthscales))
+            lengthscales = expand_array(lengthscales, input_dim)
         if np.isscalar(nus):
-            nus = np.full((input_dim,), _utils.as_numpy_scalar(nus))
+            nus = expand_array(nus, input_dim)
 
         univariate_materns = []
         for dim in range(input_dim):

--- a/tests/test_quad/test_kernel_conversion.py
+++ b/tests/test_quad/test_kernel_conversion.py
@@ -1,0 +1,24 @@
+"""Test cases for converting kernels to product kernels in quad."""
+
+import pytest
+
+from probnum.quad.kernel_embeddings._matern_lebesgue import _convert_to_product_matern
+from probnum.randprocs.kernels import Matern
+
+
+def test_product_kernel_conversion_matern():
+    kernel = Matern(input_shape=(1,))
+    product_kernel = _convert_to_product_matern(kernel)
+
+    # shapes
+    assert product_kernel.lengthscales.shape == (1,)
+    assert product_kernel.nus.shape == (1,)
+    assert product_kernel.input_shape == (1,)
+
+    # values
+    assert product_kernel.lengthscales[0] == kernel.lengthscale
+    assert product_kernel.nus[0] == kernel.nu
+
+    # raises
+    with pytest.raises(NotImplementedError):
+        _convert_to_product_matern(Matern(input_shape=(2,)))


### PR DESCRIPTION
# In a Nutshell
The parameter expansion of `ProductMatern` now catches cases where `lengthscales` and `nus` are given by `numpy.ndarray`s of shape `()`. This was actually a bug since it broke some kernel conversion in `quad`. I added a test to catch the latter.

# Detailed Description
Bug in `quad` was introduced in #583 .

# Related Issues
Closes #...
