### PR TITLE
resolve pylint in benchmark for line-too-long

### DIFF
--- a/benchmarks/linearsolvers.py
+++ b/benchmarks/linearsolvers.py
@@ -24,7 +24,8 @@ def get_linear_system(name: str, dim: int):
     elif name == "linop":
         if dim > 100:
             raise NotImplementedError()
-            # TODO: Larger benchmarks currently fail. Remove once PLS refactor (https://github.com/probabilistic-numerics/probnum/issues/51) is resolved
+            # TODO: Larger benchmarks currently fail. Remove once PLS refactor
+            # (https://github.com/probabilistic-numerics/probnum/issues/51) is resolved
         A = linops.Scaling(factors=rng.normal(size=(dim,)))
     else:
         raise NotImplementedError()
@@ -90,7 +91,7 @@ class PosteriorBelief:
     def setup(self, linsys, dim, qoi):
 
         if dim > 1000:
-            # Operations on the posterior for large matrices can be very memory intensive.
+            # Operations on posterior for large matrices can be very memory-intensive
             raise NotImplementedError()
 
         self.linsys = get_linear_system(name=linsys, dim=dim)

--- a/benchmarks/randprocs.py
+++ b/benchmarks/randprocs.py
@@ -41,9 +41,8 @@ class MarkovProcessSampling:
 
     def time_sample(self, matrix_free, len_trajectory, num_derivatives, dimension):
         with config(matrix_free=matrix_free):
-            self.markov_process \
-                .transition \
-                .jointly_transform_base_measure_realization_list_forward(
+            process = self.markov_process
+            process.transition.jointly_transform_base_measure_realization_list_forward(
                 base_measure_realizations=self.base_measure_realization,
                 t=self.time_grid,
                 initrv=self.markov_process.initrv,

--- a/benchmarks/randprocs.py
+++ b/benchmarks/randprocs.py
@@ -41,7 +41,9 @@ class MarkovProcessSampling:
 
     def time_sample(self, matrix_free, len_trajectory, num_derivatives, dimension):
         with config(matrix_free=matrix_free):
-            self.markov_process.transition.jointly_transform_base_measure_realization_list_forward(
+            self.markov_process \
+                .transition \
+                .jointly_transform_base_measure_realization_list_forward(
                 base_measure_realizations=self.base_measure_realization,
                 t=self.time_grid,
                 initrv=self.markov_process.initrv,

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,6 @@ commands =
     pylint src/probnum/utils --disable="no-else-return,else-if-used,line-too-long,missing-raises-doc,missing-return-type-doc" --jobs=0
     # Benchmark and Test Code Linting Pass
     # pylint benchmarks --disable="unused-argument,attribute-defined-outside-init,missing-function-docstring" --jobs=0 # not a work in progress, but final
-    pylint benchmarks --disable="unused-argument,attribute-defined-outside-init,no-else-return,no-self-use,consider-using-from-import,line-too-long,missing-module-docstring,missing-class-docstring,missing-function-docstring" --jobs=0
+    pylint benchmarks --disable="unused-argument,attribute-defined-outside-init,no-else-return,no-self-use,consider-using-from-import,missing-module-docstring,missing-class-docstring,missing-function-docstring" --jobs=0
     # pylint tests --disable="missing-function-docstring" --jobs=0 # not a work in progress, but final
     pylint tests --disable="arguments-differ,redefined-outer-name,too-many-instance-attributes,too-many-arguments,too-many-locals,too-few-public-methods,protected-access,unnecessary-pass,unused-variable,unused-argument,unused-private-member,attribute-defined-outside-init,no-else-return,no-self-use,consider-using-from-import,duplicate-code,line-too-long,missing-module-docstring,missing-class-docstring,missing-function-docstring,missing-param-doc,missing-type-doc,missing-raises-doc,missing-return-type-doc,redundant-returns-doc" --jobs=0


### PR DESCRIPTION
# In a Nutshell
This PR resolves pylint-ignore `line-too-long` message in `benchmark`. 

# Detailed Description
Removed the explicit pylint-ignore on the bottom of the tox.ini file for `benchmark`.

# Related Issues
Closes #674
