### PR TITLE
Pin versions of doc dependencies

### DIFF
--- a/docs/notebook-requirements.txt
+++ b/docs/notebook-requirements.txt
@@ -3,6 +3,7 @@ jupyter
 
 # Notebook conversion
 nbsphinx>=0.8.6,<0.8.7
+Jinja2<3.1
 
 # Dependencies
 matplotlib

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -1,14 +1,13 @@
 # Sphinx builds the documentation
-sphinx>=3.0,<4.4.1
+sphinx>=3.0,<4.5
 
 # Sphinx dependencies
 Pygments>=2.6.1
 
 # Sphinx extensions
-pydata-sphinx-theme>=0.6.0
+pydata-sphinx-theme>=0.6.0,<0.8.1
 sphinx-automodapi
 sphinx-gallery
-sphinxcontrib-bibtex
 
 # Markdown conversion
 myst-parser<0.17.0


### PR DESCRIPTION
# In a Nutshell
Unpinned versions of the `pydata-sphinx-theme` and the dependency `Jinja` of `nbsphinx` caused the doc build to fail. This PR pins the appropriate versions and thus fixes the doc build.