### PR TITLE
Scaling parameter for kernels

### DIFF
--- a/src/probnum/quad/kernel_embeddings/_expquad_gauss.py
+++ b/src/probnum/quad/kernel_embeddings/_expquad_gauss.py
@@ -20,7 +20,7 @@ def _kernel_mean_expquad_gauss(
         \begin{equation}
             k_P(x)
             =
-            \det( I + \Sigma / l^2)^{-1/2}
+            \sigma^2 \det( I + \Sigma / l^2)^{-1/2}
             \exp\bigg(-\frac{1}{2}(x-\mu)^\maths{T} (l^2 I + \Sigma)^{-1}
                         (x-\mu) \bigg),
         \end{equation}
@@ -61,7 +61,7 @@ def _kernel_mean_expquad_gauss(
         exp_factor = np.exp(-0.5 * ((x - measure.mean) * chol_inv_x.T).sum(axis=1))
         det_factor = kernel.lengthscale**input_dim / np.diag(chol[0]).prod()
 
-    return det_factor * exp_factor
+    return kernel.sigma_sq * det_factor * exp_factor
 
 
 def _kernel_variance_expquad_gauss(kernel: ExpQuad, measure: GaussianMeasure) -> float:
@@ -74,7 +74,7 @@ def _kernel_variance_expquad_gauss(kernel: ExpQuad, measure: GaussianMeasure) ->
         \begin{equation}
             k_{PP}
             =
-            l^D \sqrt{\frac{1}{\det(l^2 I + 2\b{\Sigma})}}
+            \sigma^2 l^D \sqrt{\frac{1}{\det(l^2 I + 2\b{\Sigma})}}
         \end{equation}
 
     where :math:`I` is the identity matrix.
@@ -101,4 +101,4 @@ def _kernel_variance_expquad_gauss(kernel: ExpQuad, measure: GaussianMeasure) ->
             kernel.lengthscale**2 * np.eye(input_dim) + 2.0 * measure.cov
         )
 
-    return kernel.lengthscale**input_dim / np.sqrt(denom)
+    return kernel.sigma_sq * kernel.lengthscale**input_dim / np.sqrt(denom)

--- a/src/probnum/quad/kernel_embeddings/_expquad_lebesgue.py
+++ b/src/probnum/quad/kernel_embeddings/_expquad_lebesgue.py
@@ -23,7 +23,7 @@ def _kernel_mean_expquad_lebesgue(
         \begin{equation}
             k_P(x)
             =
-            \bigg( \frac{\pi}{2} \bigg)^{D/2} l^D \prod_{i=1}^D
+            \sigma^2 \bigg( \frac{\pi}{2} \bigg)^{D/2} l^D \prod_{i=1}^D
             \Bigg[ \mathrm{erf}\bigg( \frac{b_i-x_i}{l \sqrt{2}}\bigg)
             - \erf\bigg(\frac{a_i-x_i}{l\sqrt{2}}\bigg) \Bigg]
         \end{equation}
@@ -50,7 +50,7 @@ def _kernel_mean_expquad_lebesgue(
     (input_dim,) = kernel.input_shape
 
     ell = kernel.lengthscale
-    return (
+    return kernel.sigma_sq * (
         measure.normalization_constant
         * (np.pi * ell**2 / 2) ** (input_dim / 2)
         * (
@@ -73,7 +73,7 @@ def _kernel_variance_expquad_lebesgue(
         \begin{equation}
             k_{PP}
             =
-            ( 2 \pi )^{D/2} l^D \prod_{i=1}^D
+            \sigma^2 ( 2 \pi )^{D/2} l^D \prod_{i=1}^D
             \Bigg[ \frac{l\sqrt{2} }{\sqrt{\pi}}\bigg(
                 \exp\bigg(-\frac{(b_i - a_i)^2}{2l^2} \bigg) - 1 \bigg) + (b_i - a_i)
                 \mathrm{erf}\bigg( \frac{b_i - a_i}{l\sqrt{2}} \bigg) \Bigg]
@@ -98,7 +98,7 @@ def _kernel_variance_expquad_lebesgue(
 
     r = measure.domain[1] - measure.domain[0]
     ell = kernel.lengthscale
-    return (
+    return kernel.sigma_sq * (
         measure.normalization_constant**2
         * (2 * np.pi * ell**2) ** (input_dim / 2)
         * (

--- a/src/probnum/randprocs/kernels/_exponentiated_quadratic.py
+++ b/src/probnum/randprocs/kernels/_exponentiated_quadratic.py
@@ -16,7 +16,8 @@ class ExpQuad(Kernel, IsotropicMixin):
     Covariance function defined by
 
     .. math ::
-        k(x_0, x_1) = \exp \left( -\frac{\lVert x_0 - x_1 \rVert_2^2}{2 l^2} \right).
+        k(x_0, x_1) = \sigma^2 \exp \left( -\frac{\lVert x_0 - x_1 \rVert_2^2}{2 l^2}
+        \right).
 
     This kernel is also known as the squared
     exponential or radial basis function kernel.
@@ -25,6 +26,8 @@ class ExpQuad(Kernel, IsotropicMixin):
     ----------
     input_shape
         Shape of the kernel's input.
+    sigma_sq
+        Positive kernel output scaling parameter :math:`\sigma^2 > 0`.
     lengthscale
         Lengthscale :math:`l` of the kernel. Describes the input scale on which the
         process varies.
@@ -46,17 +49,23 @@ class ExpQuad(Kernel, IsotropicMixin):
            [1.92874985e-22, 3.72665317e-06, 1.00000000e+00]])
     """
 
-    def __init__(self, input_shape: ShapeLike, lengthscale: ScalarLike = 1.0):
+    def __init__(
+        self,
+        input_shape: ShapeLike,
+        sigma_sq: ScalarLike = 1.0,
+        lengthscale: ScalarLike = 1.0,
+    ):
         self.lengthscale = _utils.as_numpy_scalar(lengthscale)
-        super().__init__(input_shape=input_shape)
+        super().__init__(input_shape=input_shape, sigma_sq=sigma_sq)
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
         if x1 is None:
-            return np.ones_like(  # pylint: disable=unexpected-keyword-arg
+            return self.sigma_sq * np.ones_like(
+                # pylint: disable=unexpected-keyword-arg
                 x0,
                 shape=x0.shape[: x0.ndim - self.input_ndim],
             )
 
-        return np.exp(
+        return self.sigma_sq * np.exp(
             -self._squared_euclidean_distances(x0, x1) / (2.0 * self.lengthscale**2)
         )

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -62,6 +62,10 @@ class Kernel(abc.ABC):
         Shape of the :class:`Kernel`'s input.
     output_shape
         Shape of the :class:`Kernel`'s output.
+    sigma_sq
+        A scalar scaling parameter that determines the output scaling of the kernel.
+        Every evaluation of the kernel is multiplied by ``sigma_sq``.
+        Must be positive. Defaults to one.
 
         If ``output_shape`` is set to ``()``, the :class:`Kernel` instance represents a
         single (cross-)covariance function. Otherwise, i.e. if ``output_shape`` is a
@@ -137,6 +141,7 @@ class Kernel(abc.ABC):
         self,
         input_shape: ShapeLike,
         output_shape: ShapeLike = (),
+        sigma_sq: ScalarLike = 1.0,
     ):
         self._input_shape = _pn_utils.as_shape(input_shape)
         self._input_ndim = len(self._input_shape)
@@ -148,6 +153,14 @@ class Kernel(abc.ABC):
 
         self._output_shape = _pn_utils.as_shape(output_shape)
         self._output_ndim = len(self._output_shape)
+
+        if sigma_sq <= 0:
+            raise ValueError(
+                f"The kernel scale parameter sigma_sq={sigma_sq} 'scale' must be "
+                f"positive."
+            )
+
+        self.sigma_sq = _pn_utils.as_numpy_scalar(sigma_sq)
 
     @property
     def input_shape(self) -> ShapeType:

--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -153,14 +153,7 @@ class Kernel(abc.ABC):
 
         self._output_shape = _pn_utils.as_shape(output_shape)
         self._output_ndim = len(self._output_shape)
-
-        if sigma_sq <= 0:
-            raise ValueError(
-                f"The kernel scale parameter sigma_sq={sigma_sq} 'scale' must be "
-                f"positive."
-            )
-
-        self.sigma_sq = _pn_utils.as_numpy_scalar(sigma_sq)
+        self.sigma_sq = sigma_sq
 
     @property
     def input_shape(self) -> ShapeType:
@@ -187,6 +180,21 @@ class Kernel(abc.ABC):
     def output_ndim(self) -> int:
         """Syntactic sugar for ``len(output_shape)``."""
         return self._output_ndim
+
+    @property
+    def sigma_sq(self) -> ScalarLike:
+        """Squared scaling parameter of the kernel."""
+        return self._sigma_sq
+
+    @sigma_sq.setter
+    def sigma_sq(self, sigma_sq):
+        """Setter for the squared scaling parameter of the kernel. Makes sure that the
+        parameter is positive."""
+        if sigma_sq <= 0:
+            raise ValueError(
+                f"The kernel scale parameter sigma_sq = {sigma_sq} must be positive."
+            )
+        self._sigma_sq = _pn_utils.as_numpy_scalar(sigma_sq)
 
     def __repr__(self) -> str:
         return (

--- a/src/probnum/randprocs/kernels/_linear.py
+++ b/src/probnum/randprocs/kernels/_linear.py
@@ -18,12 +18,14 @@ class Linear(Kernel):
     Linear covariance function defined by
 
     .. math ::
-        k(x_0, x_1) = x_0^\top x_1 + c.
+        k(x_0, x_1) = \sigma^2 ( x_0^\top x_1 + c ) .
 
     Parameters
     ----------
     input_shape
         Shape of the kernel's input.
+    sigma_sq
+        Positive kernel output scaling parameter :math:`\sigma^2 \geq 0`.
     constant
         Constant offset :math:`c`.
 
@@ -42,9 +44,14 @@ class Linear(Kernel):
            [ 8., 13.]])
     """
 
-    def __init__(self, input_shape: ShapeLike, constant: ScalarLike = 0.0):
+    def __init__(
+        self,
+        input_shape: ShapeLike,
+        sigma_sq: ScalarLike = 1.0,
+        constant: ScalarLike = 0.0,
+    ):
         self.constant = _utils.as_numpy_scalar(constant)
-        super().__init__(input_shape=input_shape)
+        super().__init__(input_shape=input_shape, sigma_sq=sigma_sq)
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray]) -> np.ndarray:
-        return self._euclidean_inner_products(x0, x1) + self.constant
+        return self.sigma_sq * (self._euclidean_inner_products(x0, x1) + self.constant)

--- a/src/probnum/randprocs/kernels/_polynomial.py
+++ b/src/probnum/randprocs/kernels/_polynomial.py
@@ -16,12 +16,14 @@ class Polynomial(Kernel):
     Covariance function defined by
 
     .. math ::
-        k(x_0, x_1) = (x_0^\top x_1 + c)^q.
+        k(x_0, x_1) = \sigma^2 (x_0^\top x_1 + c)^q.
 
     Parameters
     ----------
     input_shape
         Shape of the kernel's input.
+    sigma_sq
+        Positive kernel output scaling parameter :math:`\sigma^2 \geq 0`.
     constant
         Constant offset :math:`c`.
     exponent
@@ -45,12 +47,16 @@ class Polynomial(Kernel):
     def __init__(
         self,
         input_shape: ShapeLike,
+        sigma_sq: ScalarLike = 1.0,
         constant: ScalarLike = 0.0,
         exponent: IntLike = 1.0,
     ):
         self.constant = _utils.as_numpy_scalar(constant)
         self.exponent = _utils.as_numpy_scalar(exponent)
-        super().__init__(input_shape=input_shape)
+        super().__init__(input_shape=input_shape, sigma_sq=sigma_sq)
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray] = None) -> np.ndarray:
-        return (self._euclidean_inner_products(x0, x1) + self.constant) ** self.exponent
+        return (
+            self.sigma_sq
+            * (self._euclidean_inner_products(x0, x1) + self.constant) ** self.exponent
+        )

--- a/src/probnum/randprocs/kernels/_product_matern.py
+++ b/src/probnum/randprocs/kernels/_product_matern.py
@@ -113,6 +113,7 @@ class ProductMatern(Kernel):
 
         # scalar case is same as a scalar Matern
         if self.input_shape == ():
+            # pylint: disable=protected-access
             if x1 is None:
                 return self.sigma_sq * self.univariate_materns[0]._evaluate(x0, None)
             return self.sigma_sq * self.univariate_materns[0]._evaluate(x0, x1)
@@ -123,11 +124,13 @@ class ProductMatern(Kernel):
         kernel_eval = 1.0
         if x1 is None:
             for dim in range(input_dim):
+                # pylint: disable=protected-access
                 kernel_eval *= self.univariate_materns[dim]._evaluate(
                     x0[..., dim], None
                 )
         else:
             for dim in range(input_dim):
+                # pylint: disable=protected-access
                 kernel_eval *= self.univariate_materns[dim]._evaluate(
                     x0[..., dim], x1[..., dim]
                 )

--- a/src/probnum/randprocs/kernels/_white_noise.py
+++ b/src/probnum/randprocs/kernels/_white_noise.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import numpy as np
 
-from probnum import utils as _utils
 from probnum.typing import ScalarLike, ShapeLike
 
 from ._kernel import Kernel
@@ -23,17 +22,12 @@ class WhiteNoise(Kernel):
     input_shape
         Shape of the kernel's input.
     sigma_sq
-        Noise level :math:`\sigma^2 \geq 0`.
+        Positive noise level :math:`\sigma^2 > 0`.
     """
 
     def __init__(self, input_shape: ShapeLike, sigma_sq: ScalarLike = 1.0):
 
-        if sigma_sq < 0:
-            raise ValueError(f"Noise level sigma_sq={sigma_sq} must be non-negative.")
-
-        self.sigma_sq = _utils.as_numpy_scalar(sigma_sq)
-
-        super().__init__(input_shape=input_shape)
+        super().__init__(input_shape=input_shape, sigma_sq=sigma_sq)
 
     def _evaluate(self, x0: np.ndarray, x1: Optional[np.ndarray]) -> np.ndarray:
         if x1 is None:

--- a/tests/test_quad/conftest.py
+++ b/tests/test_quad/conftest.py
@@ -123,7 +123,9 @@ def fixture_measure(measure_params) -> measures.IntegrationMeasure:
     params=[
         pytest.param(kerndef, id=kerndef[0].__name__)
         for kerndef in [
-            (kernels.ExpQuad, {"lengthscale": 1.25}),
+            (kernels.ExpQuad, {"lengthscale": 1.25, "sigma_sq": 0.2}),
+            (kernels.ExpQuad, {"lengthscale": 1.25, "sigma_sq": 1.0}),
+            (kernels.ExpQuad, {"lengthscale": 1.25, "sigma_sq": 1.8}),
         ]
     ],
     name="kernel",
@@ -162,13 +164,23 @@ def fixture_f1d(request):
 # Matern kernels
 @pytest.fixture(
     params=[
+        pytest.param(matern_sigma_sq, id=f"sigma_sq={matern_sigma_sq}")
+        for matern_sigma_sq in [0.2, 1.0, 1.8]
+    ],
+    name="matern_sigma_sq",
+)
+def fixture_matern_sigma_sq(request) -> int:
+    return request.param
+
+
+@pytest.fixture(
+    params=[
         pytest.param(matern_nu, id=f"nu={matern_nu}")
         for matern_nu in [0.5, 1.5, 2.5, 3.5]
     ],
     name="matern_nu",
 )
 def fixture_matern_nu(request) -> int:
-    """Input dimension of the covariance function."""
     return request.param
 
 
@@ -186,9 +198,16 @@ def fixture_matern_lengthscale(request) -> int:
 
 @pytest.fixture(name="matern_kernel")
 def fixture_matern_kernel(
-    request, input_dim: int, matern_nu: float, matern_lengthscale: float
+    request,
+    input_dim: int,
+    matern_sigma_sq: float,
+    matern_nu: float,
+    matern_lengthscale: float,
 ) -> kernels.Kernel:
     """Set up Matern kernel."""
     return kernels.ProductMatern(
-        input_shape=(input_dim,), nus=matern_nu, lengthscales=matern_lengthscale
+        input_shape=(input_dim,),
+        sigma_sq=matern_sigma_sq,
+        nus=matern_nu,
+        lengthscales=matern_lengthscale,
     )

--- a/tests/test_quad/test_kernel_embeddings.py
+++ b/tests/test_quad/test_kernel_embeddings.py
@@ -130,6 +130,7 @@ def test_kernel_mean_matern_lebesgue_measure(matern_kernel, measure, num_data, r
         num_kernel_means[indx] = (
             integral_current_dim * kernel_embedding.measure.normalization_constant
         )
+    num_kernel_means *= matern_kernel.sigma_sq
     # True kernel means
     true_kernel_means = kernel_embedding.kernel_mean(points)
     # Compare

--- a/tests/test_randprocs/test_kernels/test_kernel.py
+++ b/tests/test_randprocs/test_kernels/test_kernel.py
@@ -1,0 +1,29 @@
+"""Generic tests for kernels."""
+
+import copy
+import numpy as np
+import pytest
+
+from probnum.randprocs import kernels
+
+
+@pytest.mark.parametrize("sigma_sq", [-2.0, -0.5, 0.0])
+def test_nonpositive_sigma_sq_raises_value_error(sigma_sq, kernel: kernels.Kernel):
+    with pytest.raises(ValueError):
+        kernel.sigma_sq = sigma_sq
+
+
+@pytest.mark.parametrize("sigma_sq", [0.4, 1.0, 2.1])
+def test_scaling(
+    sigma_sq,
+    kernel: kernels.Kernel,
+    x0: np.ndarray,
+):
+    """Check multiplication by the squared scaling parameter is equivalent to
+    evaluating the scaled kernel."""
+    kernel_unscaled = copy.copy(kernel)
+    kernel_unscaled.sigma_sq = 1.0
+    kernel.sigma_sq = sigma_sq
+    assert np.allclose(
+        kernel(x0, x0), sigma_sq * kernel_unscaled(x0, x0), rtol=1e-16, atol=1e-16
+    )


### PR DESCRIPTION
The PR implements a scaling parameter `sigma_sq` for all covariance kernels. Currently this parameter is only implemented for the white noise kernel. The parameter scales all kernel evaluations as `sigma_sq * unscaled_kernel(x0, x1)`. 

A future PR will implement maximum likelihood estimation of the scaling parameter in `quad`.