### PR TITLE
Refactor LinearOperator for method overriding

### DIFF
--- a/docs/source/tutorials/linops/linear_operators_quickstart.ipynb
+++ b/docs/source/tutorials/linops/linear_operators_quickstart.ipynb
@@ -249,7 +249,7 @@
     {
      "data": {
       "text/plain": [
-       "<SumLinearOperator with shape=(5, 5) and dtype=float64>"
+       "<Matrix with shape=(5, 5) and dtype=float64>"
       ]
      },
      "execution_count": 9,
@@ -269,7 +269,10 @@
     {
      "data": {
       "text/plain": [
-       "<ProductLinearOperator with shape=(5, 5) and dtype=float64>"
+       "ProductLinearOperator [\n",
+       "\t<Matrix with shape=(5, 5) and dtype=float64>, \n",
+       "\t<Matrix with shape=(5, 5) and dtype=float64>, \n",
+       "]"
       ]
      },
      "execution_count": 10,
@@ -311,10 +314,10 @@
     {
      "data": {
       "text/plain": [
-       "array([-1.39282086, -2.09807924, -1.01469708, -0.74204673, -3.26963901,\n",
-       "       -0.92439367, -0.65638407,  0.43823505,  0.66964627, -0.316306  ,\n",
-       "        5.7153326 ,  0.43495681,  0.46390134, -2.66045433,  0.62615866,\n",
-       "        0.00715237, -0.83637837, -0.95389845, -0.41350942, -1.23499484])"
+       "array([ 1.49421769, -1.35451937,  1.05551543, -0.41823967,  0.42934955,\n",
+       "       -0.82155968, -1.93141743, -4.31860989, -1.70475714,  4.36385187,\n",
+       "        2.36850628, -2.94034717,  0.39821307, -1.08656905,  0.36490375,\n",
+       "       -0.86441656, -0.44778464, -0.44155178,  0.55687361,  0.17178464])"
       ]
      },
      "execution_count": 11,
@@ -361,7 +364,7 @@
     {
      "data": {
       "text/plain": [
-       "<LinearOperator with shape=(5, 5) and dtype=float64>"
+       "<LambdaLinearOperator with shape=(5, 5) and dtype=float64>"
       ]
      },
      "execution_count": 12,
@@ -370,14 +373,14 @@
     }
    ],
    "source": [
-    "from probnum.linops import LinearOperator\n",
+    "from probnum.linops import LinearOperator, LambdaLinearOperator\n",
     "\n",
     "@LinearOperator.broadcast_matvec\n",
     "def mv(v):\n",
     "    return np.roll(v, 1)\n",
     "\n",
     "n = 5\n",
-    "P_op = LinearOperator(shape=(n, n), dtype=np.float_, matmul=mv)\n",
+    "P_op = LambdaLinearOperator(shape=(n, n), dtype=np.float_, matmul=mv)\n",
     "x = np.arange(0., n, 1)\n",
     "\n",
     "P_op"
@@ -509,7 +512,7 @@
     "def mv(v):\n",
     "    return v[:n-1]\n",
     "\n",
-    "Pr = LinearOperator(shape=(n-1, n), dtype=np.float_, matmul=mv)\n",
+    "Pr = LambdaLinearOperator(shape=(n-1, n), dtype=np.float_, matmul=mv)\n",
     "\n",
     "# Apply the operator to the 3D normal random variable\n",
     "rv_projected = Pr @ rv"
@@ -602,7 +605,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.6 (conda)",
    "language": "python",
    "name": "python3"
   },
@@ -616,7 +619,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0457b12441837086dec1b475e0008c28e5fc37f4ffe0e5ee9f2b481cc28bc3c9"
+   }
   }
  },
  "nbformat": 4,

--- a/src/probnum/linalg/solvers/matrixbased.py
+++ b/src/probnum/linalg/solvers/matrixbased.py
@@ -109,14 +109,14 @@ class MatrixBasedSolver(abc.ABC):
 
         Ainv0_mean = linops.Scaling(
             alpha, shape=(self.n, self.n)
-        ) + 2 / bx0 * linops.LinearOperator(
+        ) + 2 / bx0 * linops.LambdaLinearOperator(
             shape=(self.n, self.n),
             dtype=np.result_type(x0.dtype, alpha.dtype, b.dtype),
             matmul=_matmul,
         )
         A0_mean = linops.Scaling(1 / alpha, shape=(self.n, self.n)) - 1 / (
             alpha * np.squeeze((x0 - alpha * b).T @ x0)
-        ) * linops.LinearOperator(
+        ) * linops.LambdaLinearOperator(
             shape=(self.n, self.n),
             dtype=np.result_type(x0.dtype, alpha.dtype, b.dtype),
             matmul=_matmul,
@@ -632,7 +632,7 @@ class SymmetricMatrixBasedSolver(MatrixBasedSolver):
 
         # Compute calibration term in the A view as a linear operator with scaling from
         # degrees of freedom
-        calibration_term_A = linops.LinearOperator(
+        calibration_term_A = linops.LambdaLinearOperator(
             shape=(self.n, self.n),
             dtype=S.dtype,
             matmul=linops.LinearOperator.broadcast_matvec(
@@ -642,7 +642,7 @@ class SymmetricMatrixBasedSolver(MatrixBasedSolver):
 
         # Compute calibration term in the Ainv view as a linear operator with scaling
         # from degrees of freedom
-        calibration_term_Ainv = linops.LinearOperator(
+        calibration_term_Ainv = linops.LambdaLinearOperator(
             shape=(self.n, self.n),
             dtype=S.dtype,
             matmul=linops.LinearOperator.broadcast_matvec(
@@ -669,7 +669,7 @@ class SymmetricMatrixBasedSolver(MatrixBasedSolver):
                     # First term of calibration covariance class: AS(S'AS)^{-1}S'A
                     return (Y * sy**-1) @ (Y.T @ x.ravel())
 
-                _A_covfactor0 = linops.LinearOperator(
+                _A_covfactor0 = linops.LambdaLinearOperator(
                     shape=(self.n, self.n),
                     dtype=np.result_type(Y, sy),
                     matmul=_matmul,
@@ -686,7 +686,7 @@ class SymmetricMatrixBasedSolver(MatrixBasedSolver):
                     )
                     return self.Ainv_mean0 @ (Y @ YAinv0Y_inv_YAinv0x)
 
-                _Ainv_covfactor0 = linops.LinearOperator(
+                _Ainv_covfactor0 = linops.LambdaLinearOperator(
                     shape=(self.n, self.n),
                     dtype=np.result_type(Y, self.Ainv_mean0),
                     matmul=_matmul,
@@ -733,7 +733,7 @@ class SymmetricMatrixBasedSolver(MatrixBasedSolver):
         def _matmul(x):
             return 0.5 * (bWb * _Ainv_covfactor @ x + Wb @ (Wb.T @ x))
 
-        cov_op = linops.LinearOperator(
+        cov_op = linops.LambdaLinearOperator(
             shape=(self.n, self.n),
             dtype=np.result_type(Wb.dtype, bWb.dtype),
             matmul=_matmul,
@@ -755,7 +755,7 @@ class SymmetricMatrixBasedSolver(MatrixBasedSolver):
         def _matmul(x):
             return u @ (v.T @ x) + v @ (u.T @ x)
 
-        return linops.LinearOperator(
+        return linops.LambdaLinearOperator(
             shape=(self.n, self.n),
             dtype=np.result_type(u.dtype, v.dtype),
             matmul=_matmul,
@@ -768,7 +768,7 @@ class SymmetricMatrixBasedSolver(MatrixBasedSolver):
         def _matmul(x):
             return Ws @ (u.T @ x)
 
-        return linops.LinearOperator(
+        return linops.LambdaLinearOperator(
             shape=(self.n, self.n),
             dtype=np.result_type(u.dtype, Ws.dtype),
             matmul=_matmul,

--- a/src/probnum/linops/__init__.py
+++ b/src/probnum/linops/__init__.py
@@ -13,7 +13,14 @@ Several algorithms in the :mod:`probnum.linalg` subpackage are able to operate o
 """
 
 from ._kronecker import IdentityKronecker, Kronecker, SymmetricKronecker, Symmetrize
-from ._linear_operator import Embedding, Identity, LinearOperator, LambdaLinearOperator, Matrix, Selection
+from ._linear_operator import (
+    Embedding,
+    Identity,
+    LambdaLinearOperator,
+    LinearOperator,
+    Matrix,
+    Selection,
+)
 from ._scaling import Scaling, Zero
 from ._utils import LinearOperatorLike, aslinop
 

--- a/src/probnum/linops/__init__.py
+++ b/src/probnum/linops/__init__.py
@@ -13,7 +13,7 @@ Several algorithms in the :mod:`probnum.linalg` subpackage are able to operate o
 """
 
 from ._kronecker import IdentityKronecker, Kronecker, SymmetricKronecker, Symmetrize
-from ._linear_operator import Embedding, Identity, LinearOperator, Matrix, Selection
+from ._linear_operator import Embedding, Identity, LinearOperator, LambdaLinearOperator, Matrix, Selection
 from ._scaling import Scaling, Zero
 from ._utils import LinearOperatorLike, aslinop
 
@@ -22,6 +22,7 @@ __all__ = [
     "aslinop",
     "Embedding",
     "LinearOperator",
+    "LambdaLinearOperator",
     "Matrix",
     "Identity",
     "IdentityKronecker",
@@ -35,6 +36,7 @@ __all__ = [
 
 # Set correct module paths. Corrects links and module paths in documentation.
 LinearOperator.__module__ = "probnum.linops"
+LambdaLinearOperator.__module__ = "probnum.linops"
 Embedding.__module__ = "probnum.linops"
 Matrix.__module__ = "probnum.linops"
 Identity.__module__ = "probnum.linops"

--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -10,14 +10,14 @@ import numpy as np
 from probnum.typing import NotImplementedType, ScalarLike
 import probnum.utils
 
-from ._linear_operator import BinaryOperandType, LinearOperator
+from ._linear_operator import BinaryOperandType, LinearOperator, LambdaLinearOperator
 
 ########################################################################################
 # Generic Linear Operator Arithmetic (Fallbacks)
 ########################################################################################
 
 
-class ScaledLinearOperator(LinearOperator):
+class ScaledLinearOperator(LambdaLinearOperator):
     """Linear operator scaled with a scalar."""
 
     def __init__(self, linop: LinearOperator, scalar: ScalarLike):
@@ -81,7 +81,7 @@ class NegatedLinearOperator(ScaledLinearOperator):
         return f"-{self._linop}"
 
 
-class SumLinearOperator(LinearOperator):
+class SumLinearOperator(LambdaLinearOperator):
     """Sum of linear operators."""
 
     def __init__(self, *summands: LinearOperator):
@@ -166,7 +166,7 @@ def _mul_fallback(
     return res
 
 
-class ProductLinearOperator(LinearOperator):
+class ProductLinearOperator(LambdaLinearOperator):
     """(Operator) Product of linear operators."""
 
     def __init__(self, *factors: LinearOperator):

--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -10,7 +10,7 @@ import numpy as np
 from probnum.typing import NotImplementedType, ScalarLike
 import probnum.utils
 
-from ._linear_operator import BinaryOperandType, LinearOperator, LambdaLinearOperator
+from ._linear_operator import BinaryOperandType, LambdaLinearOperator, LinearOperator
 
 ########################################################################################
 # Generic Linear Operator Arithmetic (Fallbacks)

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -589,7 +589,9 @@ class IdentityKronecker(_linear_operator.LambdaLinearOperator):
 
         return NotImplemented
 
-    def _cond(self, p) -> np.inexact:
+    def _cond(
+        self, p: Optional[Union[None, int, str, np.floating]] = None
+    ) -> np.number:
         if p is None or p in (2, 1, np.inf, "fro", -2, -1, -np.inf):
             return self.A.cond(p=p) * self.B.cond(p=p)
 

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -10,7 +10,7 @@ from probnum.typing import DTypeLike, LinearOperatorLike, NotImplementedType
 from . import _linear_operator, _utils
 
 
-class Symmetrize(_linear_operator.LinearOperator):
+class Symmetrize(_linear_operator.LambdaLinearOperator):
     r"""Symmetrizes a vector in its matrix representation.
 
     Given a vector :math:`x=\operatorname{vec}(X)`
@@ -65,7 +65,7 @@ class Symmetrize(_linear_operator.LinearOperator):
         )
 
 
-class Kronecker(_linear_operator.LinearOperator):
+class Kronecker(_linear_operator.LambdaLinearOperator):
     """Kronecker product of two linear operators.
 
     The Kronecker product [1]_ :math:`A \\otimes B` of two linear operators :math:`A`
@@ -282,7 +282,7 @@ def _kronecker_rmatmul(
     return y
 
 
-class SymmetricKronecker(_linear_operator.LinearOperator):
+class SymmetricKronecker(_linear_operator.LambdaLinearOperator):
     """Symmetric Kronecker product of two linear operators.
 
     The symmetric Kronecker product [1]_ :math:`A \\otimes_{s} B` of two square linear
@@ -498,7 +498,7 @@ class SymmetricKronecker(_linear_operator.LinearOperator):
         return SymmetricKronecker(A=self.A.symmetrize(), B=self.B.symmetrize())
 
 
-class IdentityKronecker(_linear_operator.LinearOperator):
+class IdentityKronecker(_linear_operator.LambdaLinearOperator):
     """Block-diagonal linear operator.
 
     Parameters

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -358,7 +358,7 @@ class LinearOperator(abc.ABC):
 
         You may implement this method in a subclass.
         """
-        raise NotImplementedError("_rank is not implemented.")
+        raise NotImplementedError()
 
     def rank(self) -> np.intp:
         """Rank of the linear operator."""

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -1019,7 +1019,7 @@ class LinearOperator(abc.ABC):
             return matmul(other, self)
 
     ####################################################################################
-    # Automatic `(r)mat{vec,mat}`` to `(r)matmul` Broadcasting
+    # Automatic `mat{vec,mat}`` to `matmul` Broadcasting
     ####################################################################################
 
     @classmethod
@@ -1059,30 +1059,6 @@ class LinearOperator(abc.ABC):
             return _apply_to_matrix_stack(matmat, x)
 
         return _matmul
-
-    @classmethod
-    def broadcast_rmatvec(
-        cls, rmatvec: Callable[[np.ndarray], np.ndarray]
-    ) -> Callable[[np.ndarray], np.ndarray]:
-        def _rmatmul(x: np.ndarray) -> np.ndarray:
-            if x.ndim == 2 and x.shape[0] == 1:
-                return rmatvec(x[0, :])[np.newaxis, :]
-
-            return np.apply_along_axis(rmatvec, -1, x)
-
-        return _rmatmul
-
-    @classmethod
-    def broadcast_rmatmat(
-        cls, rmatmat: Callable[[np.ndarray], np.ndarray]
-    ) -> Callable[[np.ndarray], np.ndarray]:
-        def _rmatmul(x: np.ndarray) -> np.ndarray:
-            if x.ndim == 2:
-                return rmatmat(x)
-
-            return _apply_to_matrix_stack(rmatmat, x)
-
-        return _rmatmul
 
     @property
     def _inexact_dtype(self) -> np.dtype:
@@ -1495,7 +1471,6 @@ class Matrix(LambdaLinearOperator):
             dtype = self.A.dtype
 
             matmul = LinearOperator.broadcast_matmat(lambda x: self.A @ x)
-            rmatmul = LinearOperator.broadcast_rmatmat(lambda x: x @ self.A)
             todense = self.A.toarray
             inverse = self._sparse_inv
             trace = lambda: self.A.diagonal().sum()
@@ -1506,7 +1481,6 @@ class Matrix(LambdaLinearOperator):
             dtype = self.A.dtype
 
             matmul = lambda x: self.A @ x
-            rmatmul = lambda x: x @ self.A
             todense = lambda: self.A
             inverse = None
             trace = lambda: np.trace(self.A)
@@ -1517,7 +1491,6 @@ class Matrix(LambdaLinearOperator):
             shape,
             dtype,
             matmul=matmul,
-            rmatmul=rmatmul,
             todense=todense,
             transpose=transpose,
             inverse=inverse,

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -13,7 +13,7 @@ from . import _linear_operator
 # pylint: disable="too-many-statements"
 
 
-class Scaling(_linear_operator.LinearOperator):
+class Scaling(_linear_operator.LambdaLinearOperator):
     r"""Scaling linear operator.
 
     Creates a diagonal linear operator which (non-uniformly)
@@ -330,7 +330,7 @@ class Scaling(_linear_operator.LinearOperator):
         return Scaling(np.sqrt(self._factors))
 
 
-class Zero(_linear_operator.LinearOperator):
+class Zero(_linear_operator.LambdaLinearOperator):
     def __init__(self, shape, dtype=np.float64):
 
         matmul = lambda x: np.zeros(x.shape, np.result_type(x, self.dtype))

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -76,9 +76,6 @@ class Scaling(_linear_operator.LambdaLinearOperator):
                 matmul = lambda x: x.astype(
                     np.result_type(self.dtype, x.dtype), copy=False
                 )
-                rmatmul = lambda x: x.astype(
-                    np.result_type(self.dtype, x.dtype), copy=False
-                )
 
                 apply = lambda x, axis: x.astype(
                     np.result_type(self.dtype, x.dtype), copy=False
@@ -97,7 +94,6 @@ class Scaling(_linear_operator.LambdaLinearOperator):
                 )
             else:
                 matmul = lambda x: self._scalar * x
-                rmatmul = lambda x: self._scalar * x
 
                 apply = lambda x, axis: self._scalar * x
 
@@ -129,7 +125,6 @@ class Scaling(_linear_operator.LambdaLinearOperator):
             dtype = self._factors.dtype
 
             matmul = lambda x: self._factors[:, np.newaxis] * x
-            rmatmul = lambda x: self._factors * x
 
             apply = lambda x, axis: (
                 self._factors.reshape((-1,) + (x.ndim - (axis + 1)) * (1,)) * x
@@ -154,7 +149,6 @@ class Scaling(_linear_operator.LambdaLinearOperator):
             shape,
             dtype,
             matmul=matmul,
-            rmatmul=rmatmul,
             apply=apply,
             todense=todense,
             transpose=lambda: self,
@@ -334,7 +328,6 @@ class Zero(_linear_operator.LambdaLinearOperator):
     def __init__(self, shape, dtype=np.float64):
 
         matmul = lambda x: np.zeros(x.shape, np.result_type(x, self.dtype))
-        rmatmul = lambda x: np.zeros(x.shape, np.result_type(x, self.dtype))
         apply = lambda x, axis: np.zeros(x.shape, np.result_type(x, self.dtype))
         todense = lambda: np.zeros(shape=shape, dtype=dtype)
         rank = lambda: np.intp(0)
@@ -347,7 +340,6 @@ class Zero(_linear_operator.LambdaLinearOperator):
             shape,
             dtype=dtype,
             matmul=matmul,
-            rmatmul=rmatmul,
             apply=apply,
             todense=todense,
             transpose=lambda: self,

--- a/src/probnum/linops/_utils.py
+++ b/src/probnum/linops/_utils.py
@@ -41,7 +41,7 @@ def aslinop(A: LinearOperatorLike) -> _linear_operator.LinearOperator:
     elif isinstance(A, (np.ndarray, scipy.sparse.spmatrix)):
         return _linear_operator.Matrix(A=A)
     elif isinstance(A, scipy.sparse.linalg.LinearOperator):
-        return _linear_operator.LinearOperator(
+        return _linear_operator.LambdaLinearOperator(
             A.shape,
             A.dtype,
             matmul=_linear_operator.LinearOperator.broadcast_matmat(A.matmat),

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -26,7 +26,7 @@ def case_matvec(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.ndarra
     def _matmul(vec: np.ndarray):
         return matrix @ vec
 
-    linop = pn.linops.LinearOperator(
+    linop = pn.linops.LambdaLinearOperator(
         shape=matrix.shape, dtype=matrix.dtype, matmul=_matmul
     )
 
@@ -40,7 +40,7 @@ def case_matvec_spd(matrix: np.ndarray):
     def _matmul(vec: np.ndarray):
         return matrix @ vec
 
-    linop = pn.linops.LinearOperator(
+    linop = pn.linops.LambdaLinearOperator(
         shape=matrix.shape, dtype=matrix.dtype, matmul=_matmul
     )
 

--- a/tests/test_randvars/test_normal.py
+++ b/tests/test_randvars/test_normal.py
@@ -125,7 +125,7 @@ class NormalTestCase(unittest.TestCase, NumpyAssertions):
         def _matmul(v):
             return np.array([2 * v[0], 3 * v[1]])
 
-        A = linops.LinearOperator(shape=(2, 2), dtype=np.double, matmul=_matmul)
+        A = linops.LambdaLinearOperator(shape=(2, 2), dtype=np.double, matmul=_matmul)
         V = linops.Kronecker(A, A)
         randvars.Normal(mean=A, cov=V)
 


### PR DESCRIPTION
# In a Nutshell
_matmul, _apply, _transpose etc. can now be implemented by overriding the corresponding methods in a subclass instead of passing the implementations in the constructor. The previous approach is still possible via the new LambdaLinearOperator.

# Detailed Description
* Refactor LinearOperator such that method implementations are provided via subclass overrides
* Introduce LambdaLinearOperator subclass which provides support for the old approach of passing method implementations via the constructor
* Replace all previous uses of LinearOperator with LambdaLinearOperator to maintain compatibility
