### PR TITLE
Caching of the LU decomposition computed by `_InverseLinearOperator`

### DIFF
--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -1377,8 +1377,8 @@ class _InverseLinearOperator(LambdaLinearOperator):
         ----------
         x
             :code:`shape=(N,K)` --
-            The right-hand sides :math:`X` of the linear systems, where :attr:`shape`
-            :code:`=(N,N)`.
+            The right-hand sides :math:`X` of the linear systems, where
+            :code:`A.shape == (N, N)`.
         trans
             If :code:`False`, then :code:`A = self._linop`.
             Otherwise :code:`A = self._linop.T`.
@@ -1388,6 +1388,8 @@ class _InverseLinearOperator(LambdaLinearOperator):
         sol
             The solutions :math:`A^{-1} X` of the linear systems.
         """
+        assert x.ndim == 2
+
         if self._linop.is_symmetric:
             if self._linop.is_positive_definite is not False:
                 try:

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -80,6 +80,7 @@ class LinearOperator(abc.ABC):
         self._logabsdet_cache = None
         self._trace_cache = None
 
+        self._lu_cache = None
         self._cholesky_cache = None
 
         # Property inference
@@ -707,6 +708,37 @@ class LinearOperator(abc.ABC):
             )
         )
 
+    def _lu_factor(self):
+        """This is a modified version of the original implementation in SciPy:
+
+        https://github.com/scipy/scipy/blob/v1.7.1/scipy/linalg/decomp_lu.py#L15-L84
+        because the SciPy implementation does not raise an exception if the matrix is
+        singular.
+        """
+
+        if self._lu_cache is None:
+            from scipy.linalg.lapack import (  # pylint: disable=no-name-in-module,import-outside-toplevel
+                get_lapack_funcs,
+            )
+
+            a = np.asarray_chkfinite(self.todense())
+            (getrf,) = get_lapack_funcs(("getrf",), (a,))
+            lu, piv, info = getrf(a, overwrite_a=False)
+
+            if info < 0:
+                raise ValueError(
+                    f"illegal value in argument {-info} of internal getrf (lu_factor)"
+                )
+
+            if info > 0:
+                raise np.linalg.LinAlgError(
+                    f"Diagonal number {info} is exactly zero. Singular matrix."
+                )
+
+            self._lu_cache = lu, piv
+
+        return self._lu_cache
+
     ####################################################################################
     # Unary Arithmetic
     ####################################################################################
@@ -810,6 +842,9 @@ class LinearOperator(abc.ABC):
         except NotImplementedError:
             pass
 
+        # This does not need caching, since the `_InverseLinearOperator` only accesses
+        # quantities (particularly matrix decompositions), which are cached inside the
+        # original `LinearOperator`.
         return _InverseLinearOperator(self)
 
     def symmetrize(self) -> LinearOperator:
@@ -1312,17 +1347,16 @@ class _InverseLinearOperator(LambdaLinearOperator):
 
         self._linop = linop
 
-        self.__factorization = None
-        self._cho_solve = False
-
-        tmatmul = LinearOperator.broadcast_matmat(self._tmatmat)
-
         super().__init__(
             shape=self._linop.shape,
             dtype=self._linop._inexact_dtype,
-            matmul=LinearOperator.broadcast_matmat(self._matmat),
-            rmatmul=lambda x: tmatmul(x[..., np.newaxis])[..., 0],
-            transpose=lambda: TransposedLinearOperator(self, matmul=tmatmul),
+            matmul=LinearOperator.broadcast_matmat(self._solve),
+            transpose=lambda: TransposedLinearOperator(
+                self,
+                matmul=LinearOperator.broadcast_matmat(
+                    lambda x: self._solve(x, trans=True)
+                ),
+            ),
             inverse=lambda: self._linop,
             det=lambda: 1 / self._linop.det(),
             logabsdet=lambda: -self._linop.logabsdet(),
@@ -1335,65 +1369,43 @@ class _InverseLinearOperator(LambdaLinearOperator):
     def __repr__(self) -> str:
         return f"Inverse of {self._linop}"
 
-    @property
-    def factorization(self):
-        if self.__factorization is None:
-            try:
-                self.__factorization = (
-                    self._linop.cholesky(lower=True).T.todense(),
-                    False,
-                )
-                self._cho_solve = True
-            except np.linalg.LinAlgError:
-                self.__factorization = _InverseLinearOperator._lu_factor(
-                    self._linop.todense(cache=False)
-                )
+    def _solve(self, x: np.ndarray, trans: bool = False) -> np.ndarray:
+        """Solve :math:`A Y = X` for Y, where either :code:`A = self._linop` or
+        :code:`A = self._linop.T`, depending on the value of :code:`trans`.
 
-        return self.__factorization
+        Parameters
+        ----------
+        x
+            :code:`shape=(N,K)` --
+            The right-hand sides :math:`X` of the linear systems, where :attr:`shape`
+            :code:`=(N,N)`.
+        trans
+            If :code:`False`, then :code:`A = self._linop`.
+            Otherwise :code:`A = self._linop.T`.
 
-    def _matmat(self, x: np.ndarray) -> np.ndarray:
-        factorization = self.factorization  # Precompute, so that _cho_solve will be set
-
-        if self._cho_solve:
-            return scipy.linalg.cho_solve(factorization, x, overwrite_b=False)
-
-        return scipy.linalg.lu_solve(factorization, x, trans=0, overwrite_b=False)
-
-    def _tmatmat(self, x: np.ndarray) -> np.ndarray:
-        factorization = self.factorization  # Precompute, so that _cho_solve will be set
-
-        if self._cho_solve:
-            return scipy.linalg.cho_solve(factorization, x.T, overwrite_b=False)
-
-        return scipy.linalg.lu_solve(factorization, x, trans=1, overwrite_b=False)
-
-    @staticmethod
-    def _lu_factor(a):
-        """This is a modified version of the original implementation in SciPy:
-
-        https://github.com/scipy/scipy/blob/v1.7.1/scipy/linalg/decomp_lu.py#L15-L84
-        because for some reason, the SciPy implementation does not raise an exception
-        if the matrix is singular.
+        Returns
+        -------
+        sol
+            The solutions :math:`A^{-1} X` of the linear systems.
         """
-        from scipy.linalg.lapack import (  # pylint: disable=no-name-in-module,import-outside-toplevel
-            get_lapack_funcs,
+        if self._linop.is_symmetric:
+            if self._linop.is_positive_definite is not False:
+                try:
+                    # A @ x = A^T @ x, since A is symmetric
+                    return scipy.linalg.cho_solve(
+                        (self._linop.cholesky(lower=False).todense(), False),
+                        x,
+                        overwrite_b=False,
+                    )
+                except np.linalg.LinAlgError:
+                    pass
+
+        return scipy.linalg.lu_solve(
+            self._linop._lu_factor(),
+            x,
+            trans=1 if trans else 0,
+            overwrite_b=False,
         )
-
-        a = np.asarray_chkfinite(a)
-        (getrf,) = get_lapack_funcs(("getrf",), (a,))
-        lu, piv, info = getrf(a, overwrite_a=False)
-
-        if info < 0:
-            raise ValueError(
-                f"illegal value in argument {-info} of internal getrf (lu_factor)"
-            )
-
-        if info > 0:
-            raise np.linalg.LinAlgError(
-                f"Diagonal number {info} is exactly zero. Singular matrix."
-            )
-
-        return lu, piv
 
 
 class _TypeCastLinearOperator(LambdaLinearOperator):

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -97,7 +97,7 @@ def case_sparse_matrix_singular(
 def case_inverse(
     rng: np.random.Generator,
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
-    N = 100
+    N = 21
 
     v = rng.uniform(0.2, 0.5, N)
 
@@ -107,4 +107,4 @@ def case_inverse(
         matmul=lambda x: 2.0 * x + v[:, None] @ (v[None, :] @ x),
     )
 
-    return linop, linop.todense()
+    return linop.inv(), linop.inv().todense()

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -91,3 +91,20 @@ def case_sparse_matrix_singular(
     )
 
     return pn.linops.Matrix(matrix), matrix.toarray()
+
+
+@pytest.mark.parametrize("rng", [np.random.default_rng(422)])
+def case_inverse(
+    rng: np.random.Generator,
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    N = 100
+
+    v = rng.uniform(0.2, 0.5, N)
+
+    linop = pn.linops.LambdaLinearOperator(
+        shape=(N, N),
+        dtype=np.double,
+        matmul=lambda x: 2.0 * x + v[:, None] @ (v[None, :] @ x),
+    )
+
+    return linop, linop.todense()


### PR DESCRIPTION
# In a Nutshell
Currently, executing
```python
A = pn.linops.Matrix(...)
x1 = A.inv() @ b1
x2 = A.inv() @ b2
```
runs `scipy.linalg.lu_factor` on `A.dense` twice.
In principle, it would be possible to cache the return value of `A.inv()`, but that would introduce cyclic references,
which might cause memory overhead before being collected by the garbage collector.
An elegant solution is to cache all expensive quantities in the linear operator `A` itself, and then create "throwaway" objects like `_InverseLinearOperator` and `TransposeLinearOperator`, which are essentially views of `A`, accessing these quantities through the base linear operator.

# Detailed Description
- caching of LU decomposition in `LinearOperator`s
- bugfix in `_InverseLinearOperator.__rmatmul__`
- add test case for `_InverseLinearOperator`
- Replace custom implementation of `LinearOperator.broadcast_matmul` with `np.vectorize`-based implementation 

# Related Issues
None