### PR TITLE
Pinned IPython version to fix bug in documentation build

### DIFF
--- a/docs/notebook-requirements.txt
+++ b/docs/notebook-requirements.txt
@@ -1,5 +1,10 @@
 # Jupyter notebooks
+ipython<=8.6.0
+# ipython 8.7 introduced a bug regarding pygments lexer support
+# https://github.com/spatialaudio/nbsphinx/issues/24
+# https://github.com/ipython/ipython/issues/13845
 jupyter
+
 
 # Notebook conversion
 nbsphinx>=0.8.6,<0.8.7

--- a/docs/notebook-requirements.txt
+++ b/docs/notebook-requirements.txt
@@ -5,7 +5,6 @@ ipython<=8.6.0
 # https://github.com/ipython/ipython/issues/13845
 jupyter
 
-
 # Notebook conversion
 nbsphinx>=0.8.6,<0.8.7
 # Jinja2 version 3.1 introduced a bug in nbconvert, see https://github.com/jupyter/nbconvert/pull/1737


### PR DESCRIPTION
# In a Nutshell
Due to a bug introduced in IPython 8.7 (https://github.com/ipython/ipython/issues/13845) our doc build started failing on readthedocs with warnings like these:

```bash
/home/docs/checkouts/readthedocs.org/user_builds/probnum/checkouts/746/docs/source/tutorials/quickstart.ipynb:: WARNING: Pygments lexer name 'ipython3' is not known
```

This PR pins the version of IPython in the documentation requirements.