### PR TITLE
Make `quad` integration measures stateless 

### DIFF
--- a/src/probnum/quad/_utils.py
+++ b/src/probnum/quad/_utils.py
@@ -53,12 +53,11 @@ def as_domain(
     """
     if input_dim is not None and input_dim < 1:
         raise ValueError(
-            f"If given, input dimension must be positive. Current value "
-            f"is ({input_dim})."
+            f"Input dimension must be positive. Current value is ({input_dim})."
         )
 
     if len(domain) != 2:
-        raise ValueError(f"domain must be of length 2 ({len(domain)}).")
+        raise ValueError(f"'domain' must be of length 2 ({len(domain)}).")
 
     # Domain limits must have equal dimensions
     if np.size(domain[0]) != np.size(domain[1]):
@@ -85,8 +84,8 @@ def as_domain(
         # Size of domain and input dimension do not match
         if input_dim != domain_dim:
             raise ValueError(
-                "If domain limits are not scalars, their lengths "
-                "must match the input dimension."
+                f"If domain limits are not scalars, their lengths "
+                f"must match the input dimension ({input_dim})."
             )
         domain_a = domain[0]
         domain_b = domain[1]

--- a/src/probnum/quad/integration_measures/_integration_measure.py
+++ b/src/probnum/quad/integration_measures/_integration_measure.py
@@ -54,7 +54,7 @@ class IntegrationMeasure(abc.ABC):
     def sample(
         self,
         n_sample: IntLike,
-        rng: Optional[np.random.Generator] = np.random.default_rng(),
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Sample ``n_sample`` points from the integration measure.
 
@@ -63,7 +63,7 @@ class IntegrationMeasure(abc.ABC):
         n_sample
             Number of points to be sampled
         rng
-            Random number generator. Optional. Default is `np.random.default_rng()`.
+            A Random number generator.
 
         Returns
         -------

--- a/src/probnum/quad/integration_measures/_lebesgue_measure.py
+++ b/src/probnum/quad/integration_measures/_lebesgue_measure.py
@@ -65,7 +65,7 @@ class LebesgueMeasure(IntegrationMeasure):
     def sample(
         self,
         n_sample: IntLike,
-        rng: Optional[np.random.Generator] = np.random.default_rng(),
+        rng: np.random.Generator,
     ) -> np.ndarray:
         return self.random_variable.rvs(
             size=(n_sample, self.input_dim), random_state=rng

--- a/tests/test_quad/test_bq_utils.py
+++ b/tests/test_quad/test_bq_utils.py
@@ -10,6 +10,7 @@ from probnum.quad._utils import as_domain
 @pytest.mark.parametrize(
     "dom, in_dim",
     [
+        ((0, 1), 0),  # zero dimension
         ((0, 1), -2),  # negative dimension
         ((np.zeros(2), np.ones(2)), 3),  # length of bounds does not match dimension
         ((np.zeros(2), np.ones(3)), None),  # lower and upper bounds not equal lengths

--- a/tests/test_quad/test_bq_utils.py
+++ b/tests/test_quad/test_bq_utils.py
@@ -17,6 +17,8 @@ from probnum.quad._utils import as_domain
         ((np.array([0, 0]), np.array([1, 0])), None),  # integration domain is empty
         ((np.zeros([2, 1]), np.ones([2, 1])), None),  # bounds have too many dimensions
         ((np.zeros([2, 1]), np.ones([2, 1])), 2),  # bounds have too many dimensions
+        ((0, 1, 2), 2),  # domain has too many elements
+        ((-np.ones(2), np.zeros(2), np.ones(2)), 2),  # domain has too many elements
     ]
 )
 def test_as_domain_wrong_input(dom, in_dim):


### PR DESCRIPTION
# In a Nutshell
This PR removes the default rng from the `quad` integration measures. Further, some long overdue shape tests for the sample method of the measures are added.

# Detailed Description
na

# Related Issues
Closes #...
