### PR TITLE
Updated tox configuration with new keyword for externals

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies for a full ProbNum development environment
 -e .[full]
 
-tox>=3,<4
+tox>=3.18,<4
 
 -r benchmarks/requirements.txt
 -r docs/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@
 # and then run "tox" from this directory.
 
 [tox]
-minversion = 3.18
 envlist = py3, docs, benchmarks, black, isort, pylint
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
+minversion = 3.18
 envlist = py3, docs, benchmarks, black, isort, pylint
 
 [testenv]
@@ -19,7 +20,7 @@ basepython = python3
 passenv = HOME
 deps = -r{toxinidir}/docs/requirements.txt
 changedir = docs
-whitelist_externals = make
+allowlist_externals = make
 commands =
     make clean
     make html


### PR DESCRIPTION
# In a Nutshell
The documentation build is failing with the following output:

```bash
docs: failed with make is not allowed, use allowlist_externals to allow it
.pkg: _exit> python /opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta
  docs: FAIL code 1 (103.39 seconds)
  evaluation failed :( (103.66 seconds)
```

This seems to be caused by a change in the tox configuration for external tools like `make`.