### PR TITLE
`MaxAcquisitionPolicy` for `quad`

### DIFF
--- a/src/probnum/quad/_bayesquad.py
+++ b/src/probnum/quad/_bayesquad.py
@@ -75,6 +75,7 @@ def bayesquad(
          Bayesian Monte Carlo [2]_                    ``bmc``
          Van Der Corput points                        ``vdc``
          Uncertainty Sampling with random candidates  ``us_rand``
+         Uncertainty Sampling with optimizer          ``us``
         ============================================  ===========
 
     initial_design

--- a/src/probnum/quad/_bayesquad.py
+++ b/src/probnum/quad/_bayesquad.py
@@ -112,12 +112,16 @@ def bayesquad(
                 inversion. Defaults to 1e-8.
             batch_size : Optional[IntLike]
                 Number of new observations at each update. Defaults to 1.
-            num_initial_design_nodes : Optional[IntLike]
+            n_initial_design_nodes : Optional[IntLike]
                 The number of nodes created by the initial design. Defaults to
                 ``input_dim * 5`` if an initial design is given.
-            us_rand_num_candidates : Optional[IntLike]
+            us_rand_n_candidates : Optional[IntLike]
                 The number of candidate nodes used by the policy 'us_rand'. Defaults
                 to 1e2.
+            us_n_restarts : Optional[IntLike]
+                The number of restarts that the acquisition optimizer performs in
+                order to find the maximizer when policy 'us' is used. Defaults
+                to 10.
 
     Returns
     -------

--- a/src/probnum/quad/solvers/_bayesian_quadrature.py
+++ b/src/probnum/quad/solvers/_bayesian_quadrature.py
@@ -144,13 +144,13 @@ class BayesianQuadrature:
                     inversion. Defaults to 1e-8.
                 batch_size : Optional[IntLike]
                     Batch size used in node acquisition. Defaults to 1.
-                num_initial_design_nodes : Optional[IntLike]
+                n_initial_design_nodes : Optional[IntLike]
                     The number of nodes created by the initial design. Defaults to
                     ``input_dim * 5`` if an initial design is given.
-                us_rand_num_candidates : Optional[IntLike]
+                us_rand_n_candidates : Optional[IntLike]
                     The number of candidate nodes used by the policy 'us_rand'. Defaults
                     to 1e2.
-                us_num_restarts : Optional[IntLike]
+                us_n_restarts : Optional[IntLike]
                     The number of restarts that the acquisition optimizer performs in
                     order to find the maximizer when policy 'us' is used. Defaults
                     to 10.
@@ -187,11 +187,11 @@ class BayesianQuadrature:
         scale_estimation = options.get("scale_estimation", "mle")
         jitter = options.get("jitter", 1.0e-8)
         batch_size = options.get("batch_size", int(1))
-        num_initial_design_nodes = options.get(
-            "num_initial_design_nodes", int(5 * input_dim)
+        n_initial_design_nodes = options.get(
+            "n_initial_design_nodes", int(5 * input_dim)
         )
-        us_rand_num_candidates = options.get("us_rand_num_candidates", int(1e2))
-        us_num_restarts = options.get("us_num_restarts", int(10))
+        us_rand_n_candidates = options.get("us_rand_n_candidates", int(1e2))
+        us_n_restarts = options.get("us_n_restarts", int(10))
 
         # Set up integration measure
         if domain is None and measure is None:
@@ -219,13 +219,13 @@ class BayesianQuadrature:
             policy = RandomMaxAcquisitionPolicy(
                 batch_size=1,
                 acquisition_func=WeightedPredictiveVariance(),
-                n_candidates=us_rand_num_candidates,
+                n_candidates=us_rand_n_candidates,
             )
         elif policy == "us":
             policy = MaxAcquisitionPolicy(
                 batch_size=1,
                 acquisition_func=WeightedPredictiveVariance(),
-                n_restarts=us_num_restarts,
+                n_restarts=us_n_restarts,
             )
         else:
             raise NotImplementedError(f"The given policy ({policy}) is unknown.")
@@ -271,9 +271,9 @@ class BayesianQuadrature:
         if initial_design is None:
             pass  # not to raise the exception
         elif initial_design == "mc":
-            initial_design = MCDesign(num_initial_design_nodes, measure)
+            initial_design = MCDesign(n_initial_design_nodes, measure)
         elif initial_design == "latin":
-            initial_design = LatinDesign(num_initial_design_nodes, measure)
+            initial_design = LatinDesign(n_initial_design_nodes, measure)
         else:
             raise NotImplementedError(
                 f"The given initial design ({initial_design}) is unknown."

--- a/src/probnum/quad/solvers/_bayesian_quadrature.py
+++ b/src/probnum/quad/solvers/_bayesian_quadrature.py
@@ -96,6 +96,7 @@ class BayesianQuadrature:
         self.stopping_criterion = stopping_criterion
         self.initial_design = initial_design
 
+    # pylint: disable=too-many-statements
     @classmethod
     def from_problem(
         cls,

--- a/src/probnum/quad/solvers/_bayesian_quadrature.py
+++ b/src/probnum/quad/solvers/_bayesian_quadrature.py
@@ -14,6 +14,7 @@ from probnum.quad.solvers.acquisition_functions import WeightedPredictiveVarianc
 from probnum.quad.solvers.belief_updates import BQBeliefUpdate, BQStandardBeliefUpdate
 from probnum.quad.solvers.initial_designs import InitialDesign, LatinDesign, MCDesign
 from probnum.quad.solvers.policies import (
+    MaxAcquisitionPolicy,
     Policy,
     RandomMaxAcquisitionPolicy,
     RandomPolicy,
@@ -148,6 +149,10 @@ class BayesianQuadrature:
                 us_rand_num_candidates : Optional[IntLike]
                     The number of candidate nodes used by the policy 'us_rand'. Defaults
                     to 1e2.
+                us_num_restarts : Optional[IntLike]
+                    The number of restarts that the acquisition optimizer performs in
+                    order to find the maximizer when policy 'us' is used. Defaults
+                    to 10.
 
         Returns
         -------
@@ -185,6 +190,7 @@ class BayesianQuadrature:
             "num_initial_design_nodes", int(5 * input_dim)
         )
         us_rand_num_candidates = options.get("us_rand_num_candidates", int(1e2))
+        us_num_restarts = options.get("us_num_restarts", int(10))
 
         # Set up integration measure
         if domain is None and measure is None:
@@ -213,6 +219,12 @@ class BayesianQuadrature:
                 batch_size=1,
                 acquisition_func=WeightedPredictiveVariance(),
                 n_candidates=us_rand_num_candidates,
+            )
+        elif policy == "us":
+            policy = MaxAcquisitionPolicy(
+                batch_size=1,
+                acquisition_func=WeightedPredictiveVariance(),
+                n_restarts=us_num_restarts,
             )
         else:
             raise NotImplementedError(f"The given policy ({policy}) is unknown.")

--- a/src/probnum/quad/solvers/initial_designs/_initial_design.py
+++ b/src/probnum/quad/solvers/initial_designs/_initial_design.py
@@ -17,15 +17,15 @@ class InitialDesign(abc.ABC):
 
     Parameters
     ----------
-    num_nodes
+    n_nodes
         The number of nodes to be designed.
     measure
         The integration measure.
 
     """
 
-    def __init__(self, num_nodes: IntLike, measure: IntegrationMeasure) -> None:
-        self.num_nodes = int(num_nodes)
+    def __init__(self, n_nodes: IntLike, measure: IntegrationMeasure) -> None:
+        self.n_nodes = int(n_nodes)
         self.measure = measure
 
     @property
@@ -46,6 +46,6 @@ class InitialDesign(abc.ABC):
         Returns
         -------
         nodes :
-            *shape=(num_nodes, input_dim)* -- Initial design nodes.
+            *shape=(n_nodes, input_dim)* -- Initial design nodes.
         """
         raise NotImplementedError

--- a/src/probnum/quad/solvers/initial_designs/_latin_design.py
+++ b/src/probnum/quad/solvers/initial_designs/_latin_design.py
@@ -19,7 +19,7 @@ class LatinDesign(InitialDesign):
 
     Parameters
     ----------
-    num_nodes
+    n_nodes
         The number of nodes to be designed.
     measure
         The integration measure.
@@ -31,14 +31,14 @@ class LatinDesign(InitialDesign):
 
     """
 
-    def __init__(self, num_nodes: IntLike, measure: IntegrationMeasure) -> None:
+    def __init__(self, n_nodes: IntLike, measure: IntegrationMeasure) -> None:
         if np.Inf in np.hstack([abs(measure.domain[0]), abs(measure.domain[1])]):
             raise ValueError(
                 "Latin hypercube samples require a finite domain. "
                 "At least one dimension seems to be unbounded."
             )
 
-        super().__init__(measure=measure, num_nodes=num_nodes)
+        super().__init__(measure=measure, n_nodes=n_nodes)
 
     @property
     def requires_rng(self) -> bool:
@@ -46,5 +46,5 @@ class LatinDesign(InitialDesign):
 
     def __call__(self, rng: Optional[np.random.Generator]) -> np.ndarray:
         sampler = qmc.LatinHypercube(d=self.measure.input_dim, seed=rng)
-        sample = sampler.random(n=self.num_nodes)
+        sample = sampler.random(n=self.n_nodes)
         return qmc.scale(sample, self.measure.domain[0], self.measure.domain[1])

--- a/src/probnum/quad/solvers/initial_designs/_mc_design.py
+++ b/src/probnum/quad/solvers/initial_designs/_mc_design.py
@@ -18,19 +18,19 @@ class MCDesign(InitialDesign):
 
     Parameters
     ----------
-    num_nodes
+    n_nodes
         The number of nodes to be designed.
     measure
         The integration measure.
 
     """
 
-    def __init__(self, num_nodes: IntLike, measure: IntegrationMeasure) -> None:
-        super().__init__(measure=measure, num_nodes=num_nodes)
+    def __init__(self, n_nodes: IntLike, measure: IntegrationMeasure) -> None:
+        super().__init__(measure=measure, n_nodes=n_nodes)
 
     @property
     def requires_rng(self) -> bool:
         return True
 
     def __call__(self, rng: Optional[np.random.Generator]) -> np.ndarray:
-        return self.measure.sample(self.num_nodes, rng=rng)
+        return self.measure.sample(self.n_nodes, rng=rng)

--- a/src/probnum/quad/solvers/policies/__init__.py
+++ b/src/probnum/quad/solvers/policies/__init__.py
@@ -1,6 +1,6 @@
 """Policies for Bayesian quadrature."""
 
-from ._max_aquisition_policy import RandomMaxAcquisitionPolicy
+from ._max_aquisition_policy import MaxAcquisitionPolicy, RandomMaxAcquisitionPolicy
 from ._policy import Policy
 from ._random_policy import RandomPolicy
 from ._van_der_corput_policy import VanDerCorputPolicy
@@ -10,6 +10,7 @@ __all__ = [
     "Policy",
     "RandomPolicy",
     "VanDerCorputPolicy",
+    "MaxAcquisitionPolicy",
     "RandomMaxAcquisitionPolicy",
 ]
 
@@ -18,3 +19,4 @@ Policy.__module__ = "probnum.quad.solvers.policies"
 RandomPolicy.__module__ = "probnum.quad.solvers.policies"
 VanDerCorputPolicy.__module__ = "probnum.quad.solvers.policies"
 RandomMaxAcquisitionPolicy.__module__ = "probnum.quad.solvers.policies"
+MaxAcquisitionPolicy.__module__ = "probnum.quad.solvers.policies"

--- a/src/probnum/quad/solvers/policies/_max_aquisition_policy.py
+++ b/src/probnum/quad/solvers/policies/_max_aquisition_policy.py
@@ -88,6 +88,13 @@ class MaxAcquisitionPolicy(Policy):
     ------
     ValueError
         If ``batch_size`` is not 1, or if ``n_restarts`` is too small.
+
+    Notes
+    -----
+    The policy uses SciPy's 'Nelder-Mead' optimizer when gradients are unavailable.
+    This is the current standard setting since ``probnum`` does not provide gradients
+    yet.
+
     """
 
     def __init__(
@@ -121,7 +128,7 @@ class MaxAcquisitionPolicy(Policy):
     ) -> np.ndarray:
 
         measure = bq_state.measure
-        domain = bq_state.measure.domain  # Todo: non-bounded?
+        domain = bq_state.measure.domain
         bounds = list(zip(domain[0], domain[1]))
 
         if self.acquisition_func.has_gradients:

--- a/src/probnum/quad/solvers/policies/_max_aquisition_policy.py
+++ b/src/probnum/quad/solvers/policies/_max_aquisition_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
+from scipy.optimize import minimize as scipy_minimize
 
 from probnum.quad.solvers._bq_state import BQState
 from probnum.quad.solvers.acquisition_functions import AcquisitionFunction
@@ -50,7 +51,7 @@ class RandomMaxAcquisitionPolicy(Policy):
             )
         if n_candidates < 1:
             raise ValueError(
-                f"The number of candidates ({n_candidates}) must be equal "
+                f"The number of candidates ({n_candidates}) must be equal to"
                 f"or larger than 1."
             )
 
@@ -69,3 +70,80 @@ class RandomMaxAcquisitionPolicy(Policy):
         values = self.acquisition_func(random_nodes, bq_state)[0]
         idx_max = int(np.argmax(values))
         return random_nodes[idx_max, :][None, :]
+
+
+class MaxAcquisitionPolicy(Policy):
+    """Policy that maximizes an acquisition function with an optimizer.
+
+    Parameters
+    ----------
+    batch_size
+        Size of batch of nodes when calling the policy once (must be equal to 1).
+    acquisition_func
+        The acquisition function.
+    n_restarts
+        The number of times the optimizer is being restarted.
+
+    Raises
+    ------
+    ValueError
+        If ``batch_size`` is not 1, or if ``n_restarts`` is too small.
+    """
+
+    def __init__(
+        self,
+        batch_size: IntLike,
+        acquisition_func: AcquisitionFunction,
+        n_restarts: IntLike,
+    ) -> None:
+
+        if batch_size != 1:
+            raise ValueError(
+                f"MaxAcquisitionPolicy can only be used with batch size 1 "
+                f"({batch_size})."
+            )
+        if n_restarts < 1:
+            raise ValueError(
+                f"The number of restarts ({n_restarts}) must be equal to"
+                f"or larger than 1."
+            )
+
+        super().__init__(batch_size=batch_size)
+        self.acquisition_func = acquisition_func
+        self.n_restarts = int(n_restarts)
+
+    @property
+    def requires_rng(self) -> bool:
+        return True
+
+    def __call__(
+        self, bq_state: BQState, rng: Optional[np.random.Generator]
+    ) -> np.ndarray:
+
+        measure = bq_state.measure
+        domain = bq_state.measure.domain  # Todo: non-bounded?
+        bounds = list(zip(domain[0], domain[1]))
+
+        if self.acquisition_func.has_gradients:
+            # Todo (#581): Gradients should not be available yet.
+            raise NotImplementedError
+
+        f = lambda x: -self.acquisition_func(x[None, :], bq_state)[0][0]
+        initial_points = measure.sample(n_sample=self.n_restarts, rng=rng)
+        x_min, f_min, success = None, np.inf, False
+        for x0 in initial_points:
+            scipy_result = scipy_minimize(
+                fun=f, jac=None, x0=x0, bounds=bounds, method="Nelder-Mead"
+            )
+            if scipy_result["success"] and scipy_result["fun"] < f_min:
+                f_min = scipy_result["fun"]
+                x_min = scipy_result["x"][None, :]
+                success = True
+
+        if not success:
+            raise RuntimeError(
+                f"Acquisition optimizer could not find a suitable maximizer with "
+                f"({self.n_restarts}) restarts."
+            )
+
+        return x_min

--- a/tests/test_quad/test_bayesian_quadrature.py
+++ b/tests/test_quad/test_bayesian_quadrature.py
@@ -9,6 +9,7 @@ from probnum.quad.solvers import BayesianQuadrature
 from probnum.quad.solvers.belief_updates import BQStandardBeliefUpdate
 from probnum.quad.solvers.initial_designs import LatinDesign, MCDesign
 from probnum.quad.solvers.policies import (
+    MaxAcquisitionPolicy,
     RandomMaxAcquisitionPolicy,
     RandomPolicy,
     VanDerCorputPolicy,
@@ -89,6 +90,7 @@ def test_bayesian_quadrature_wrong_input(input_dim):
         ("bmc", RandomPolicy),
         ("vdc", VanDerCorputPolicy),
         ("us_rand", RandomMaxAcquisitionPolicy),
+        ("us", MaxAcquisitionPolicy),
     ],
 )
 def test_bq_from_problem_policy_assignment(policy, policy_type):
@@ -165,6 +167,10 @@ def test_bq_from_problem_options_default_values():
     bq = BayesianQuadrature.from_problem(input_dim=2, domain=(0, 1), policy="us_rand")
     assert bq.policy.n_candidates == int(1e2)
 
+    # n_restarts for policy 'us'
+    bq = BayesianQuadrature.from_problem(input_dim=2, domain=(0, 1), policy="us")
+    assert bq.policy.n_restarts == int(10)
+
     # num_initial_design_nodes for initial design
     input_dim = 5
     bq = BayesianQuadrature.from_problem(
@@ -205,6 +211,16 @@ def test_bq_from_problem_options_custom_values(bq, bq_no_policy):
         options=dict(us_rand_num_candidates=us_rand_num_candidates),
     )
     assert bq.policy.n_candidates == us_rand_num_candidates
+
+    # n_restarts for policy 'us'
+    us_num_restarts = 5
+    bq = BayesianQuadrature.from_problem(
+        input_dim=2,
+        domain=(0, 1),
+        policy="us",
+        options=dict(us_num_restarts=us_num_restarts),
+    )
+    assert bq.policy.n_restarts == us_num_restarts
 
     # num_initial_design_nodes for initial design
     input_dim = 5

--- a/tests/test_quad/test_bayesian_quadrature.py
+++ b/tests/test_quad/test_bayesian_quadrature.py
@@ -73,7 +73,7 @@ def test_bayesian_quadrature_wrong_input(input_dim):
             policy=None,
             belief_update=BQStandardBeliefUpdate(jitter=1e-6, scale_estimation=None),
             stopping_criterion=MaxNevals(max_nevals=10),
-            initial_design=MCDesign(num_nodes=3, measure=measure),
+            initial_design=MCDesign(n_nodes=3, measure=measure),
         )
 
 
@@ -171,14 +171,14 @@ def test_bq_from_problem_options_default_values():
     bq = BayesianQuadrature.from_problem(input_dim=2, domain=(0, 1), policy="us")
     assert bq.policy.n_restarts == int(10)
 
-    # num_initial_design_nodes for initial design
+    # n_initial_design_nodes for initial design
     input_dim = 5
     bq = BayesianQuadrature.from_problem(
         input_dim=input_dim,
         domain=(0, 1),
         initial_design="mc",
     )
-    assert bq.initial_design.num_nodes == int(5 * input_dim)
+    assert bq.initial_design.n_nodes == int(5 * input_dim)
 
 
 def test_bq_from_problem_options_custom_values(bq, bq_no_policy):
@@ -203,36 +203,36 @@ def test_bq_from_problem_options_custom_values(bq, bq_no_policy):
     assert bq.belief_update.jitter == jitter
 
     # n_candidates for policy 'us_rand'
-    us_rand_num_candidates = 5
+    us_rand_n_candidates = 5
     bq = BayesianQuadrature.from_problem(
         input_dim=2,
         domain=(0, 1),
         policy="us_rand",
-        options=dict(us_rand_num_candidates=us_rand_num_candidates),
+        options=dict(us_rand_n_candidates=us_rand_n_candidates),
     )
-    assert bq.policy.n_candidates == us_rand_num_candidates
+    assert bq.policy.n_candidates == us_rand_n_candidates
 
     # n_restarts for policy 'us'
-    us_num_restarts = 5
+    us_n_restarts = 5
     bq = BayesianQuadrature.from_problem(
         input_dim=2,
         domain=(0, 1),
         policy="us",
-        options=dict(us_num_restarts=us_num_restarts),
+        options=dict(us_n_restarts=us_n_restarts),
     )
-    assert bq.policy.n_restarts == us_num_restarts
+    assert bq.policy.n_restarts == us_n_restarts
 
-    # num_initial_design_nodes for initial design
+    # n_initial_design_nodes for initial design
     input_dim = 5
-    num_initial_design_nodes = 3
-    assert int(input_dim * 5) != num_initial_design_nodes
+    n_initial_design_nodes = 3
+    assert int(input_dim * 5) != n_initial_design_nodes
     bq = BayesianQuadrature.from_problem(
         input_dim=input_dim,
         domain=(0, 1),
         initial_design="mc",
-        options=dict(num_initial_design_nodes=num_initial_design_nodes),
+        options=dict(n_initial_design_nodes=n_initial_design_nodes),
     )
-    assert bq.initial_design.num_nodes == num_initial_design_nodes
+    assert bq.initial_design.n_nodes == n_initial_design_nodes
 
 
 # Tests for input checks and exception raises start here.
@@ -272,28 +272,28 @@ def test_integrate_output_shapes(initial_design_provided, nodes_provided, data, 
     # consistently.
 
     max_evals = 15
-    num_design_nodes = 4
+    n_design_nodes = 4
 
     # get data
     nodes, fun_evals, fun = data
-    (num_nodes, input_dim) = nodes.shape
+    (n_nodes, input_dim) = nodes.shape
 
     params = dict(input_dim=input_dim, domain=(0, 1))
     options = dict(max_evals=max_evals)
-    num_updates = max_evals
+    n_updates = max_evals
 
     # get correct shapes and values
     if nodes_provided:
-        num_updates += -num_nodes + 1
+        n_updates += -n_nodes + 1
     else:
         nodes, fun_evals = None, None
 
     if initial_design_provided:
-        num_updates += -num_design_nodes + (1 - 1 * nodes_provided) * 1
+        n_updates += -n_design_nodes + (1 - 1 * nodes_provided) * 1
         params["initial_design"] = "mc"
-        options["num_initial_design_nodes"] = num_design_nodes
+        options["n_initial_design_nodes"] = n_design_nodes
 
-    assert num_updates > 1  # make sure that some nodes are collected
+    assert n_updates > 1  # make sure that some nodes are collected
 
     bq = BayesianQuadrature.from_problem(**params, options=options)
     res, bq_state, info = bq.integrate(
@@ -303,7 +303,7 @@ def test_integrate_output_shapes(initial_design_provided, nodes_provided, data, 
     assert isinstance(bq_state.integral_belief, Normal)
     assert isinstance(bq_state.scale_sq, float)
     assert len(bq_state.kernel_means) == max_evals
-    assert len(bq_state.previous_integral_beliefs) == num_updates
+    assert len(bq_state.previous_integral_beliefs) == n_updates
     assert bq_state.nodes.shape == (max_evals, input_dim)
     assert bq_state.fun_evals.shape == (max_evals,)
     assert bq_state.gram.shape == (max_evals, max_evals)

--- a/tests/test_quad/test_initial_designs.py
+++ b/tests/test_quad/test_initial_designs.py
@@ -18,7 +18,7 @@ def input_dim():
 
 
 @pytest.fixture
-def num_nodes():
+def n_nodes():
     return 5
 
 
@@ -42,31 +42,31 @@ def gaussian_measure(input_dim):
         ]
     ],
 )
-def design(request, num_nodes) -> Tuple[InitialDesign, dict]:
+def design(request, n_nodes) -> Tuple[InitialDesign, dict]:
     measure = request.getfixturevalue(request.param[1])
     values = request.param[2]
-    return request.param[0](**dict(measure=measure, num_nodes=num_nodes)), values
+    return request.param[0](**dict(measure=measure, n_nodes=n_nodes)), values
 
 
 # Tests shared by all designs start here.
 
 
-def test_initial_design_attribute_values(design, num_nodes):
+def test_initial_design_attribute_values(design, n_nodes):
     design, values = design
-    assert design.num_nodes == num_nodes
+    assert design.n_nodes == n_nodes
     assert design.requires_rng is values["requires_rng"]
 
 
-def test_initial_design_shapes(design, rng, input_dim, num_nodes):
+def test_initial_design_shapes(design, rng, input_dim, n_nodes):
     design, _ = design
     res = design(rng)  # get nodes
-    assert res.shape == (num_nodes, input_dim)
+    assert res.shape == (n_nodes, input_dim)
 
 
 # Tests specific to LatinDesign start here.
 
 
-def test_latin_design_wrong_domain(gaussian_measure, num_nodes):
+def test_latin_design_wrong_domain(gaussian_measure, n_nodes):
     # Latin design requires finite domain but Gaussian measure has infinite domain)
     with pytest.raises(ValueError):
-        LatinDesign(num_nodes, gaussian_measure)
+        LatinDesign(n_nodes, gaussian_measure)


### PR DESCRIPTION
# In a Nutshell
This PR introduces a policy (`MaxAcquisitionPolicy`) for the `quad` package which optimizes an acquisition function with an optimizer. 

# Detailed Description
- Scipy's 'Nelder-Mead'  is used for now as optimization method since gradients are not available. This can be swapped out once gradients become available.
- policy is added to the existing tests for policies. 
- unified the use of `n_` and `num_` to denote 'number of ...' in some places.

# Related Issues
Closes #...
