### PR TITLE
Fix bug in `asrandvar` introduced by breaking changes in ScIPy 1.10

### DIFF
--- a/src/probnum/randvars/_scipy_stats.py
+++ b/src/probnum/randvars/_scipy_stats.py
@@ -155,9 +155,10 @@ def wrap_scipy_rv(
             # Multivariate normal distribution
             try:
                 cov_explicit = scipy_rv.cov
-            except AttributeError as e:
+            except AttributeError:
                 # As of SciPy 1.10.0 multivariate normal rvs have a Covariance object
-                # See https://scipy.github.io/devdocs/release.1.10.0.html#scipy-stats-improvements
+                # See https://scipy.github.io/devdocs/release.1.10.0.html\
+                # scipy-stats-improvements
                 cov_explicit = scipy_rv.cov_object.covariance
             return _normal.Normal(
                 mean=scipy_rv.mean,

--- a/src/probnum/randvars/_scipy_stats.py
+++ b/src/probnum/randvars/_scipy_stats.py
@@ -153,9 +153,15 @@ def wrap_scipy_rv(
         # Multivariate distributions
         if scipy_rv.__class__.__name__ == "multivariate_normal_frozen":
             # Multivariate normal distribution
+            try:
+                cov_explicit = scipy_rv.cov
+            except AttributeError as e:
+                # As of SciPy 1.10.0 multivariate normal rvs have a Covariance object
+                # See https://scipy.github.io/devdocs/release.1.10.0.html#scipy-stats-improvements
+                cov_explicit = scipy_rv.cov_object.covariance
             return _normal.Normal(
                 mean=scipy_rv.mean,
-                cov=scipy_rv.cov,
+                cov=cov_explicit,
             )
 
     # Generic random variables


### PR DESCRIPTION
# In a Nutshell
SciPy 1.10 introduced a `Covariance` object (see https://scipy.github.io/devdocs/release.1.10.0.html#scipy-stats-improvements), which is being used for `multivariate_normal` random variables. This caused a bug in the `asrandvar` function which is handled in this PR.
