### PR TITLE
Fix matmul implementation of Zero linop

### DIFF
--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -326,8 +326,6 @@ class Scaling(_linear_operator.LambdaLinearOperator):
 
 class Zero(_linear_operator.LambdaLinearOperator):
     def __init__(self, shape, dtype=np.float64):
-
-        matmul = lambda x: np.zeros(x.shape, np.result_type(x, self.dtype))
         apply = lambda x, axis: np.zeros(x.shape, np.result_type(x, self.dtype))
         todense = lambda: np.zeros(shape=shape, dtype=dtype)
         rank = lambda: np.intp(0)
@@ -335,6 +333,11 @@ class Zero(_linear_operator.LambdaLinearOperator):
         det = lambda: np.zeros(shape=(), dtype=dtype)
 
         trace = lambda: np.zeros(shape=(), dtype=dtype)
+
+        def matmul(x: np.ndarray) -> np.ndarray:
+            target_shape = list(x.shape)
+            target_shape[-2] = self.shape[0]
+            return np.zeros(target_shape, np.result_type(x, self.dtype))
 
         super().__init__(
             shape,

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -326,7 +326,6 @@ class Scaling(_linear_operator.LambdaLinearOperator):
 
 class Zero(_linear_operator.LambdaLinearOperator):
     def __init__(self, shape, dtype=np.float64):
-        apply = lambda x, axis: np.zeros(x.shape, np.result_type(x, self.dtype))
         todense = lambda: np.zeros(shape=shape, dtype=dtype)
         rank = lambda: np.intp(0)
         eigvals = lambda: np.zeros(shape=(shape[0],), dtype=dtype)
@@ -343,9 +342,8 @@ class Zero(_linear_operator.LambdaLinearOperator):
             shape,
             dtype=dtype,
             matmul=matmul,
-            apply=apply,
             todense=todense,
-            transpose=lambda: self,
+            transpose=lambda: Zero(self.shape[::-1], self.dtype),
             rank=rank,
             eigvals=eigvals,
             det=det,

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -69,7 +69,6 @@ def case_identity(n: int) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     return pn.linops.Identity(shape=n), np.eye(n)
 
 
-@pytest_cases.case(tags=("symmetric"))
 @pytest.mark.parametrize("shape", [(3, 3), (3, 4), (6, 5)])
 def case_zero(shape: tuple) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     return pn.linops.Zero(shape=shape), np.zeros(shape)

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -69,6 +69,12 @@ def case_identity(n: int) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     return pn.linops.Identity(shape=n), np.eye(n)
 
 
+@pytest_cases.case(tags=("symmetric"))
+@pytest.mark.parametrize("shape", [(3, 3), (3, 4), (6, 5)])
+def case_zero(shape: tuple) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    return pn.linops.Zero(shape=shape), np.zeros(shape)
+
+
 @pytest.mark.parametrize("rng", [np.random.default_rng(42)])
 def case_sparse_matrix(
     rng: np.random.Generator,


### PR DESCRIPTION
# In a Nutshell
matmul result now has the correct shape

# Detailed Description
The Zero linear operator had a bug where in the matmul implementation, it simply returned a zero vector of the same shape of the input. But this does not always match the shape we expect from the matmul output.

# Related Issues
Closes #761 
