### PR TITLE
Make Matrix transpose keep some properties

### DIFF
--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -1487,6 +1487,16 @@ class Matrix(LambdaLinearOperator):
             trace=trace,
         )
 
+    def _transpose(self) -> "Matrix":
+        M = Matrix(self.A.T)
+        if self.is_lower_triangular:
+            M.is_upper_triangular = True
+        elif self.is_upper_triangular:
+            M.is_lower_triangular = True
+        M.is_symmetric = self.is_symmetric
+        M.is_positive_definite = self.is_positive_definite
+        return M
+
     def _astype(
         self, dtype: np.dtype, order: str, casting: str, copy: bool
     ) -> "LinearOperator":

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -768,9 +768,9 @@ class LinearOperator(abc.ABC):
         try:
             transposed = self._transpose()
         except NotImplementedError:
-            # This does not need caching, since the `TransposeLinearOperator` only accesses
-            # quantities (particularly `todense`), which are cached inside the original
-            # `LinearOperator`.
+            # This does not need caching, since the `TransposeLinearOperator`
+            # only accesses quantities (particularly `todense`), which are
+            # cached inside the origina`LinearOperator`.
             transposed = TransposedLinearOperator(self)
 
         transposed.is_upper_triangular = self.is_lower_triangular


### PR DESCRIPTION
# In a Nutshell
Transposing a Matrix now maintains symmetry and positive definiteness - if the original Matrix had them. It also flips triangular properties.

# Detailed Description
- Extend previous implementation of _transpose for Matrix
- If original Matrix is lower/upper triangular, transposed Matrix is upper/lower triangular
- If original Matrix is symmetric/positive definite, transposed Matrix is symmetric/positive definite

I am not sure if this is the right way to do it. I know that _TransposedLinearOperator already keeps these properties, but this only comes into play when the user doesn't provide a custom _transpose implementation. I think it might make sense to - more generally - transfer these properties in LinearOperator's transpose before returning the transposed linop object. But I was a bit hesitant to do that since it might interfere with this rule that you're not allowed to set LinearOperator properties that already have a value.