### PR TITLE
`LinearOperator.solve` method

### DIFF
--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -224,7 +224,7 @@ class ProductLinearOperator(LambdaLinearOperator):
         return res + "]"
 
     def _solve(self, B: np.ndarray) -> np.ndarray:
-        return functools.reduce(lambda vec, op: op @ vec, self._factors, B)
+        return functools.reduce(lambda b, op: op.solve(b), self._factors, B)
 
 
 def _matmul_fallback(

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -152,6 +152,12 @@ class Kronecker(_linear_operator.LambdaLinearOperator):
         if self.A.is_symmetric and self.B.is_symmetric:
             self.is_symmetric = True
 
+    def _solve(self, B: np.ndarray) -> np.ndarray:
+        if self.A.is_square and self.B.is_square:
+            return self.inv() @ B
+
+        return super()._solve(B)
+
     def _astype(
         self, dtype: DTypeLike, order: str, casting: str, copy: bool
     ) -> "Kronecker":
@@ -415,6 +421,12 @@ class SymmetricKronecker(_linear_operator.LambdaLinearOperator):
 
         return y
 
+    def _solve(self, B: np.ndarray) -> np.ndarray:
+        if self.identical_factors:
+            return self.inv() @ B
+
+        return super()._solve(B)
+
     def _todense_identical_factors(self) -> np.ndarray:
         """Dense representation of the symmetric Kronecker product."""
         # 1/2 (A (x) B + B (x) A)
@@ -504,6 +516,9 @@ class IdentityKronecker(_linear_operator.LambdaLinearOperator):
     @property
     def num_blocks(self):
         return self._num_blocks
+
+    def _solve(self, B: np.ndarray) -> np.ndarray:
+        return self.inv() @ B
 
     def _matmul_idkronecker(self, other: "IdentityKronecker") -> "IdentityKronecker":
         if self.shape[1] != other.shape[0]:

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -8,11 +8,13 @@ from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 import scipy.linalg
-import scipy.sparse.linalg
+import scipy.sparse
 
 from probnum import config
-from probnum.typing import DTypeLike, ScalarLike, ShapeLike
+from probnum.typing import ArrayLike, DTypeLike, ScalarLike, ShapeLike
 import probnum.utils
+
+from . import _vectorize
 
 BinaryOperandType = Union[
     "LinearOperator", ScalarLike, np.ndarray, scipy.sparse.spmatrix
@@ -178,6 +180,97 @@ class LinearOperator(abc.ABC):
             return self._apply(x, axis=axis)
 
         raise ValueError("The operand must be at least one dimensional.")
+
+    def solve(self, b: ArrayLike) -> np.ndarray:
+        """Solves linear systems :code:`A @ x = b`, where :code:`b` is either a vector
+        or a (stack of) matrices.
+
+        This method behaves exactly like :code:`A.inv() @ b`.
+
+        Parameters
+        ----------
+        b
+            The right-hand side(s) of the linear system(s). This can either be a vector
+            or a (stack of) matrices.
+
+        Returns
+        -------
+        x
+            The solution(s) of the linear system(s). Depending on the shape of
+            :code:`b`, :code:`x` is either a vector or a (stack of) matrices.
+
+        Raises
+        ------
+        numpy.linalg.LinAlgError
+            If the linear operator is non-square or not invertible.
+        ValueError
+            If the shape of :code:`b` does not meet the requirements outlined above.
+        """
+        if not self.is_square:
+            raise np.linalg.LinAlgError("Only square matrices can be inverted.")
+
+        b = np.asarray(b)
+
+        if b.ndim < 1:
+            raise ValueError("`b` must be a vector or a (stack of) matrices.")
+
+        if b.shape[max(b.ndim - 2, 0)] != self.__shape[0]:
+            raise ValueError(
+                f"Dimension mismatch. Expected array with {self.__shape[0]} "
+                f"entries along axis {max(b.ndim - 2, 1)}, but got array with shape "
+                f"{b.shape}."
+            )
+
+        if b.ndim == 1:
+            return self._solve(b[:, None])[:, 0]
+
+        return self._solve(b)
+
+    @_vectorize.vectorize_matmat(method=True)
+    def _solve(self, B: np.ndarray) -> np.ndarray:
+        """Implementation of the :meth:`solve` method called after input preprocessing.
+
+        This method will only be called if the linear operator is square.
+        The implementation must follow the rules of ``__matmul__`` broadcasting.
+
+        When implementing a custom :meth:`_inv` method, then :meth:`_solve` should also
+        be implemented for performance reasons.
+
+        Parameters
+        ----------
+        B
+            The right-hand sides of the linear systems. This is guaranteed to be a
+            (stack of) matrices with appropriate dimensions.
+
+        Returns
+        -------
+        X
+            The solutions of the linear system.
+
+        Raises
+        ------
+        numpy.linalg.LinAlgError
+            The method must throw this exception if the linear operator is not
+            invertible.
+        """
+        assert B.ndim == 2
+
+        if self.is_symmetric:
+            if self.is_positive_definite is not False:
+                try:
+                    return scipy.linalg.cho_solve(
+                        (self.cholesky(lower=False).todense(), False),
+                        B,
+                        overwrite_b=False,
+                    )
+                except np.linalg.LinAlgError:
+                    pass
+
+        return scipy.linalg.lu_solve(
+            self._lu_factor(),
+            B,
+            overwrite_b=False,
+        )
 
     def astype(
         self,
@@ -746,22 +839,23 @@ class LinearOperator(abc.ABC):
             Transpose of this linear operator, which is again
             a LinearOperator.
         """
-        raise NotImplementedError()
+        # This does not need caching, since the `TransposeLinearOperator`
+        # only accesses quantities (particularly `todense`), which are
+        # cached inside the original `LinearOperator`.
+        return TransposedLinearOperator(self)
 
     @property
     def T(self) -> "LinearOperator":
-        try:
-            transposed = self._transpose()
-        except NotImplementedError:
-            # This does not need caching, since the `TransposeLinearOperator`
-            # only accesses quantities (particularly `todense`), which are
-            # cached inside the origina`LinearOperator`.
-            transposed = TransposedLinearOperator(self)
+        if self.is_symmetric:
+            return self
+
+        transposed = self._transpose()
 
         transposed.is_upper_triangular = self.is_lower_triangular
         transposed.is_lower_triangular = self.is_upper_triangular
         transposed.is_symmetric = self.is_symmetric
         transposed.is_positive_definite = self.is_positive_definite
+
         return transposed
 
     def transpose(self, *axes: Union[int, Tuple[int]]) -> "LinearOperator":
@@ -807,6 +901,8 @@ class LinearOperator(abc.ABC):
     def _inverse(self) -> "LinearOperator":
         """Inverse of this linear operator.
 
+        The linear operator is guaranteed to be square.
+
         You may implement this method in a subclass.
 
         Returns
@@ -815,7 +911,10 @@ class LinearOperator(abc.ABC):
             Inverse of this linear operator, which is again
             a LinearOperator.
         """
-        raise NotImplementedError()
+        # This does not need caching, since the `_InverseLinearOperator` only accesses
+        # quantities (particularly matrix decompositions), which are cached inside the
+        # original `LinearOperator`.
+        return _InverseLinearOperator(self)
 
     def inv(self) -> "LinearOperator":
         """Inverse of the linear operator.
@@ -826,15 +925,12 @@ class LinearOperator(abc.ABC):
             Inverse of this linear operator, which is again
             a LinearOperator.
         """
-        try:
-            return self._inverse()
-        except NotImplementedError:
-            pass
+        if not self.is_square:
+            raise np.linalg.LinAlgError(
+                "Inverses are only defined on square linear operators."
+            )
 
-        # This does not need caching, since the `_InverseLinearOperator` only accesses
-        # quantities (particularly matrix decompositions), which are cached inside the
-        # original `LinearOperator`.
-        return _InverseLinearOperator(self)
+        return self._inverse()
 
     def symmetrize(self) -> LinearOperator:
         """Compute or approximate the closest symmetric :class:`LinearOperator` in the
@@ -1043,39 +1139,11 @@ class LinearOperator(abc.ABC):
             return matmul(other, self)
 
     ####################################################################################
-    # Automatic `mat{vec,mat}`` to `matmul` Broadcasting
+    # Automatic `mat{vec,mat}`` to `matmul` Vectorization
     ####################################################################################
 
-    @classmethod
-    def broadcast_matvec(
-        cls, matvec: Callable[[np.ndarray], np.ndarray]
-    ) -> Callable[[np.ndarray], np.ndarray]:
-        """Broadcasting for a (implicitly defined) matrix-vector product.
-
-        Convenience function / decorator to broadcast the definition of a matrix-vector
-        product. This can be used to easily construct a new linear operator only from a
-        matrix-vector product.
-        """
-
-        def _matmul(x: np.ndarray) -> np.ndarray:
-            if x.ndim == 2 and x.shape[1] == 1:
-                return matvec(x[:, 0])[:, np.newaxis]
-
-            return np.apply_along_axis(matvec, -2, x)
-
-        return _matmul
-
-    @classmethod
-    def broadcast_matmat(
-        cls, matmat: Callable[[np.ndarray], np.ndarray]
-    ) -> Callable[[np.ndarray], np.ndarray]:
-        """Broadcasting for a (implicitly defined) matrix-matrix product.
-
-        Convenience function / decorator to broadcast the definition of a matrix-matrix
-        product to stacks of matrices. This can be used to easily construct a new linear
-        operator only from a matrix-matrix product.
-        """
-        return np.vectorize(matmat, signature="(n,k)->(m,k)")
+    broadcast_matvec = staticmethod(_vectorize.vectorize_matvec)
+    broadcast_matmat = staticmethod(_vectorize.vectorize_matmat)
 
 
 class LambdaLinearOperator(LinearOperator):
@@ -1100,9 +1168,6 @@ class LambdaLinearOperator(LinearOperator):
         of :func:`np.matmul` must apply.
         Note that the argument to this callable is guaranteed to have at least two
         dimensions.
-    rmatmul
-        Callable which implements the matrix-matrix product, i.e. :math:`A @ V`, where
-        :math:`A` is the linear operator and :math:`V` is a matrix of shape `(N, K)`.
     apply
         Callable which implements the application of the linear operator to an input
         array along a specified axis.
@@ -1156,8 +1221,8 @@ class LambdaLinearOperator(LinearOperator):
         dtype: DTypeLike,
         *,
         matmul: Callable[[np.ndarray], np.ndarray],
-        rmatmul: Optional[Callable[[np.ndarray], np.ndarray]] = None,
         apply: Callable[[np.ndarray, int], np.ndarray] = None,
+        solve: Callable[[np.ndarray], np.ndarray] = None,
         todense: Optional[Callable[[], np.ndarray]] = None,
         transpose: Optional[Callable[[np.ndarray], "LinearOperator"]] = None,
         inverse: Optional[Callable[[], "LinearOperator"]] = None,
@@ -1173,8 +1238,9 @@ class LambdaLinearOperator(LinearOperator):
         super().__init__(shape, dtype)
 
         self._matmul_fn = matmul  # (self @ x)
-        self._rmatmul_fn = rmatmul  # (x @ self)
         self._apply_fn = apply  # __call__
+
+        self._solve_fn = solve
 
         self._todense_fn = todense
 
@@ -1198,29 +1264,27 @@ class LambdaLinearOperator(LinearOperator):
 
         return self._apply_fn(x, axis)
 
+    def _solve(self, B: np.ndarray) -> np.ndarray:
+        if self._solve_fn is None:
+            return super()._solve(B)
+
+        return self._solve_fn(B)
+
     def _todense(self) -> np.ndarray:
         if self._todense_fn is None:
             return super()._todense()
 
         return self._todense_fn()
 
-    def _transpose(self) -> "LinearOperator":
-        if self._transpose_fn is not None:
-            return self._transpose_fn()
+    def _transpose(self) -> LinearOperator:
+        if self._transpose_fn is None:
+            return super()._transpose()
 
-        if self._rmatmul_fn is not None:
-            return TransposedLinearOperator(
-                self,
-                matmul=lambda x: np.moveaxis(
-                    self._rmatmul_fn(np.moveaxis(x, -2, -1)), -1, -2
-                ),
-            )
+        return self._transpose_fn()
 
-        raise NotImplementedError()
-
-    def _inverse(self) -> "LinearOperator":
+    def _inverse(self) -> LinearOperator:
         if self._inverse_fn is None:
-            super()._inverse()
+            return super()._inverse()
 
         return self._inverse_fn()
 
@@ -1283,10 +1347,9 @@ class TransposedLinearOperator(LambdaLinearOperator):
             shape=(self._linop.shape[1], self._linop.shape[0]),
             dtype=self._linop.dtype,
             matmul=matmul,
-            rmatmul=lambda x: self._linop(x, axis=-1),
             todense=lambda: self._linop.todense(cache=True).T,
             transpose=lambda: self._linop,
-            inverse=None,  # lambda: self._linop.inv().T,
+            inverse=lambda: self._linop.inv().T,
             rank=self._linop.rank,
             det=self._linop.det,
             logabsdet=self._linop.logabsdet,
@@ -1312,19 +1375,13 @@ class _InverseLinearOperator(LambdaLinearOperator):
 
         self._linop = linop
 
-        solve = np.vectorize(
-            self._solve,
-            excluded=("trans",),
-            signature="(n, k)->(n, k)",
-        )
-
         super().__init__(
             shape=self._linop.shape,
             dtype=self._linop._inexact_dtype,
-            matmul=solve,
+            matmul=self._linop.solve,
             transpose=lambda: TransposedLinearOperator(
                 self,
-                matmul=lambda x: solve(x, trans=True),
+                matmul=self._tmatmul,
             ),
             inverse=lambda: self._linop,
             det=lambda: 1 / self._linop.det(),
@@ -1338,34 +1395,16 @@ class _InverseLinearOperator(LambdaLinearOperator):
     def __repr__(self) -> str:
         return f"Inverse of {self._linop}"
 
-    def _solve(self, x: np.ndarray, trans: bool = False) -> np.ndarray:
-        """Solve :math:`A Y = X` for Y, where either :code:`A = self._linop` or
-        :code:`A = self._linop.T`, depending on the value of :code:`trans`.
+    @LinearOperator.broadcast_matmat(method=True)
+    def _tmatmul(self, B: ArrayLike) -> np.ndarray:
+        assert B.ndim == 2
 
-        Parameters
-        ----------
-        x
-            :code:`shape=(N,K)` --
-            The right-hand sides :math:`X` of the linear systems, where
-            :code:`A.shape == (N, N)`.
-        trans
-            If :code:`False`, then :code:`A = self._linop`.
-            Otherwise :code:`A = self._linop.T`.
-
-        Returns
-        -------
-        sol
-            The solutions :math:`A^{-1} X` of the linear systems.
-        """
-        assert x.ndim == 2
-
-        if self._linop.is_symmetric:
-            if self._linop.is_positive_definite is not False:
+        if self.is_symmetric:
+            if self.is_positive_definite is not False:
                 try:
-                    # A @ x = A^T @ x, since A is symmetric
                     return scipy.linalg.cho_solve(
                         (self._linop.cholesky(lower=False).todense(), False),
-                        x,
+                        B,
                         overwrite_b=False,
                     )
                 except np.linalg.LinAlgError:
@@ -1373,8 +1412,8 @@ class _InverseLinearOperator(LambdaLinearOperator):
 
         return scipy.linalg.lu_solve(
             self._linop._lu_factor(),
-            x,
-            trans=1 if trans else 0,
+            B,
+            trans=1,
             overwrite_b=False,
         )
 
@@ -1404,12 +1443,10 @@ class _TypeCastLinearOperator(LambdaLinearOperator):
             matmul=lambda x: (self._linop @ x).astype(
                 np.result_type(self.dtype, x.dtype), copy=False
             ),
-            rmatmul=lambda x: (x @ self._linop).astype(
-                np.result_type(x.dtype, self.dtype), copy=False
-            ),
             apply=lambda x, axis: self._linop(x, axis=axis).astype(
                 np.result_type(self.dtype, x.dtype), copy=False
             ),
+            solve=lambda b: self.inv() @ b,
             todense=lambda: self._linop.todense(cache=False).astype(
                 dtype, order=order, copy=copy
             ),
@@ -1439,50 +1476,42 @@ class Matrix(LambdaLinearOperator):
 
     Parameters
     ----------
-    A : array-like or scipy.sparse.spmatrix
+    A :
         The explicit matrix.
     """
 
-    def __init__(
-        self,
-        A: Union[np.ndarray, scipy.sparse.spmatrix],
-    ):
+    def __init__(self, A: Union[ArrayLike, scipy.sparse.spmatrix]):
         if isinstance(A, scipy.sparse.spmatrix):
             self.A = A
 
-            shape = self.A.shape
-            dtype = self.A.dtype
-
             matmul = LinearOperator.broadcast_matmat(lambda x: self.A @ x)
             todense = self.A.toarray
-            inverse = self._sparse_inv
             trace = lambda: self.A.diagonal().sum()
         else:
             self.A = np.asarray(A)
-
-            shape = self.A.shape
-            dtype = self.A.dtype
+            self.A.setflags(write=False)
 
             matmul = lambda x: self.A @ x
             todense = lambda: self.A
-            inverse = None
             trace = lambda: np.trace(self.A)
 
-        transpose = lambda: Matrix(self.A.T)
-
         super().__init__(
-            shape,
-            dtype,
+            self.A.shape,
+            self.A.dtype,
             matmul=matmul,
             todense=todense,
-            transpose=transpose,
-            inverse=inverse,
             trace=trace,
         )
+
+    def _transpose(self) -> "Matrix":
+        return Matrix(self.A.T)
 
     def _astype(
         self, dtype: np.dtype, order: str, casting: str, copy: bool
     ) -> "LinearOperator":
+        if self.dtype == dtype and not copy:
+            return self
+
         if isinstance(self.A, np.ndarray):
             A_astype = self.A.astype(dtype, order=order, casting=casting, copy=copy)
         else:
@@ -1490,16 +1519,7 @@ class Matrix(LambdaLinearOperator):
 
             A_astype = self.A.astype(dtype, casting=casting, copy=copy)
 
-        if A_astype is self.A:
-            return self
-
         return Matrix(A_astype)
-
-    def _sparse_inv(self) -> "Matrix":
-        try:
-            return Matrix(scipy.sparse.linalg.inv(self.A.tocsc()))
-        except RuntimeError as err:
-            raise np.linalg.LinAlgError(str(err)) from err
 
     def _matmul_matrix(self, other: "Matrix") -> "Matrix":
         if not config.lazy_matrix_matrix_matmul:
@@ -1551,7 +1571,6 @@ class Identity(LambdaLinearOperator):
             shape,
             dtype,
             matmul=lambda x: x.astype(np.result_type(self.dtype, x.dtype), copy=False),
-            rmatmul=lambda x: x.astype(np.result_type(self.dtype, x.dtype), copy=False),
             apply=lambda x, axis: x.astype(
                 np.result_type(self.dtype, x.dtype), copy=False
             ),
@@ -1576,6 +1595,9 @@ class Identity(LambdaLinearOperator):
         self.is_upper_triangular = True
 
         self.is_positive_definite = True
+
+    def _solve(self, B: np.ndarray) -> np.ndarray:
+        return B
 
     def _cond(
         self, p: Optional[Union[None, int, str, np.floating]] = None

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -185,7 +185,8 @@ class LinearOperator(abc.ABC):
         """Solves linear systems :code:`A @ x = b`, where :code:`b` is either a vector
         or a (stack of) matrices.
 
-        This method behaves exactly like :code:`A.inv() @ b`.
+        This method broadcasts like :code:`A.inv() @ b`, but it might not produce the
+        exact same result.
 
         Parameters
         ----------

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -150,6 +150,7 @@ class Scaling(_linear_operator.LambdaLinearOperator):
             dtype,
             matmul=matmul,
             apply=apply,
+            solve=lambda B: self.inv() @ B,
             todense=todense,
             transpose=lambda: self,
             inverse=inverse,

--- a/src/probnum/linops/_vectorize.py
+++ b/src/probnum/linops/_vectorize.py
@@ -1,0 +1,71 @@
+"""Vectorization utilities for matrix-{vector, matrix} products."""
+
+import functools
+from typing import Callable, Optional
+
+import numpy as np
+
+
+def vectorize_matmat(
+    matmat: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+    method: bool = False,
+):
+    """Broadcasting for a (implicitly defined) matrix-matrix product.
+
+    Convenience function / decorator to broadcast the definition of a matrix-matrix
+    product to stacks of matrices. This can be used to easily construct a new linear
+    operator only from a matrix-matrix product.
+    """
+
+    def _vectorize_matmat(
+        matmat: Callable[[np.ndarray], np.ndarray]
+    ) -> Callable[[np.ndarray], np.ndarray]:
+        np_vectorize_obj = np.vectorize(
+            matmat,
+            excluded={0} if method else None,
+            signature="(n,k)->(m,k)",
+        )
+
+        # The additional wrapper function is needed when using this as a method
+        # decorator, since the class np.vectorize is not implemented as a descriptor
+        @functools.wraps(matmat)
+        def vectorized_matmat(*args) -> np.ndarray:
+            return np_vectorize_obj(*args)
+
+        return vectorized_matmat
+
+    if matmat is None:
+        return _vectorize_matmat
+
+    return _vectorize_matmat(matmat)
+
+
+def vectorize_matvec(
+    matvec: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+    method: bool = False,
+):
+    """Broadcasting for a (implicitly defined) matrix-vector product.
+
+    Convenience function / decorator to broadcast the definition of a matrix-vector
+    product. This can be used to easily construct a new linear operator only from a
+    matrix-vector product.
+    """
+
+    def _vectorize_matvec(
+        matvec: Callable[[np.ndarray], np.ndarray]
+    ) -> Callable[[np.ndarray], np.ndarray]:
+        @functools.wraps(matvec)
+        def vectorized_matvec(*args) -> np.ndarray:
+            x = args[1 if method else 0]
+
+            if x.ndim == 2 and x.shape[1] == 1:
+                return matvec(x[:, 0])[:, np.newaxis]
+
+            return np.apply_along_axis(matvec, -2, x)
+
+        return vectorized_matvec
+
+    if matvec is None:
+        return _vectorize_matvec
+
+    return _vectorize_matvec(matvec)

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -248,6 +248,30 @@ def test_solve(
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_solve_shape_mismatch(
+    linop: pn.linops.LinearOperator,
+    matrix: np.ndarray,
+):
+    # Solve with scalar right-hand side
+    b = 42.0
+
+    with pytest.raises(Exception) as excinfo:
+        np.linalg.solve(matrix, b)
+
+    with pytest.raises(excinfo.type):
+        linop.solve(b)
+
+    # Solve with dimension mismatch
+    b = np.ones((2, matrix.shape[1] + 1, 2))
+
+    with pytest.raises(Exception) as excinfo:
+        np.linalg.solve(matrix, b)
+
+    with pytest.raises(excinfo.type):
+        linop.solve(b)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
 def test_todense(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     linop_dense = linop.todense()
 

--- a/tests/test_linops/test_linops_cases/arithmetic_cases.py
+++ b/tests/test_linops/test_linops_cases/arithmetic_cases.py
@@ -6,6 +6,7 @@ import pytest_cases
 import probnum as pn
 from probnum.linops._arithmetic_fallbacks import (
     NegatedLinearOperator,
+    ProductLinearOperator,
     ScaledLinearOperator,
     SumLinearOperator,
 )
@@ -80,3 +81,20 @@ def case_sum_linop_positive_definite(
     B.is_symmetric = True
 
     return SumLinearOperator(A, B), matrix
+
+
+@pytest_cases.case(tags=("square"))
+@pytest_cases.parametrize("A,B", spd_matrix_pairs)
+def case_product_linop_square(
+    A: np.ndarray, B: np.ndarray
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    matrix = A @ B
+
+    A = pn.linops.aslinop(A)
+    B = pn.linops.aslinop(B)
+
+    linop = A @ B
+
+    assert isinstance(linop, ProductLinearOperator)
+
+    return linop, matrix

--- a/tests/test_linops/test_linops_cases/linear_operator_cases.py
+++ b/tests/test_linops/test_linops_cases/linear_operator_cases.py
@@ -63,6 +63,16 @@ def case_matrix_spd(matrix: np.ndarray) -> Tuple[pn.linops.LinearOperator, np.nd
     return linop, matrix
 
 
+@pytest_cases.case(tags=("square", "symmetric"))
+def case_matrix_symmetric_indefinite() -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    matrix = np.diag((2.1, 1.3, -0.5))
+
+    linop = pn.linops.aslinop(matrix)
+    linop.is_symmetric = True
+
+    return linop, matrix
+
+
 @pytest_cases.case(tags=("square", "symmetric", "positive-definite"))
 @pytest.mark.parametrize("n", [3, 4, 8, 12, 15])
 def case_identity(n: int) -> Tuple[pn.linops.LinearOperator, np.ndarray]:

--- a/tests/test_linops/test_matrix.py
+++ b/tests/test_linops/test_matrix.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 
 import probnum as pn
 
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass:PendingDeprecationWarning")
 def test_matrix_linop_converts_numpy_matrix():
     matrix = np.asmatrix(np.eye(10))
     linop = pn.linops.Matrix(matrix)


### PR DESCRIPTION
# In a Nutshell
This PR adds the method `solve` to the `LinearOperator` interface.

# Detailed Description
- `LinearOperator.solve`
- `_InverseLinearOperator` uses `LinearOperator.solve` as `_matmul`
- remove redundant `rmatmul` argument in `LambdaLinearOperator`

# Related Issues
None
