### PR TITLE
Specify matplotlib version for notebooks

### DIFF
--- a/docs/notebook-requirements.txt
+++ b/docs/notebook-requirements.txt
@@ -11,5 +11,5 @@ nbsphinx>=0.8.6,<0.8.7
 Jinja2<3.1
 
 # Dependencies
-matplotlib
+matplotlib<3.7
 pytest


### PR DESCRIPTION
# In a Nutshell
Fix the matplotlib version used to generate plots in the tutorials and documentation.

# Detailed Description
The tutorial notebooks started failing after #780 was merged with the following error:

```sh
[NbConvertApp] Converting notebook ./docs/source/tutorials/linalg/linear_solvers_quickstart.ipynb to notebook
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.16/x64/bin/jupyter-nbconvert", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/jupyter_core/application.py", line 277, in launch_instance
    return super().launch_instance(argv=argv, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/traitlets/config/application.py", line 1043, in launch_instance
    app.start()
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 418, in start
    self.convert_notebooks()
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 592, in convert_notebooks
    self.convert_single_notebook(notebook_filename)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 555, in convert_single_notebook
    output, resources = self.export_single_notebook(
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 483, in export_single_notebook
    output, resources = self.exporter.from_filename(
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 198, in from_filename
    return self.from_file(f, resources=resources, **kw)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 217, in from_file
    return self.from_notebook_node(
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/exporters/notebook.py", line 36, in from_notebook_node
    nb_copy, resources = super().from_notebook_node(nb, resources, **kw)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 153, in from_notebook_node
    nb_copy, resources = self._preprocess(nb_copy, resources)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 349, in _preprocess
    nbc, resc = preprocessor(nbc, resc)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/preprocessors/base.py", line 48, in __call__
    return self.preprocess(nb, resources)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/preprocessors/execute.py", line 100, in preprocess
    self.preprocess_cell(cell, resources, index)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbconvert/preprocessors/execute.py", line 121, in preprocess_cell
    cell = self.execute_cell(cell, index, store_history=True)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/jupyter_core/utils/__init__.py", line 166, in wrapped
    return loop.run_until_complete(inner)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbclient/client.py", line 1021, in async_execute_cell
    await self._check_raise_for_error(cell, cell_index, exec_reply)
  File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/nbclient/client.py", line 915, in _check_raise_for_error
    raise CellExecutionError.from_cell_and_msg(cell, exec_reply_content)
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
------------------
import warnings
warnings.filterwarnings('ignore')

# Make inline plots vector graphics instead of raster graphics
%matplotlib inline
from IPython.display import set_matplotlib_formats

set_matplotlib_formats("pdf", "svg")

# Plotting
import matplotlib.pyplot as plt
from matplotlib.colors import TwoSlopeNorm 

plt.style.use("../../probnum.mplstyle")
------------------

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 14
     11 import matplotlib.pyplot as plt
     12 from matplotlib.colors import TwoSlopeNorm 
---> 14 plt.style.use("../../probnum.mplstyle")

File /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/matplotlib/style/core.py:153, in use(style)
    151 pkg, _, name = style.rpartition(".")
    152 try:
--> 153     path = (importlib_resources.files(pkg)
    154             / f"{name}.{STYLE_EXTENSION}")
    155     style = _rc_params_in_file(path)
    156 except (ModuleNotFoundError, IOError) as exc:
    157     # There is an ambiguity whether a dotted name refers to a
    158     # package.style_name or to a dotted file path.  Currently,
   (...)
    161     # either use Path objects or be prepended with "./" and use
    162     # the slash as marker for file paths.

File /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/importlib_resources/_common.py:46, in package_to_anchor.<locals>.wrapper(anchor, package)
     44 elif anchor is undefined:
     45     return func()
---> 46 return func(anchor)

File /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/importlib_resources/_common.py:56, in files(anchor)
     51 @package_to_anchor
     52 def files(anchor: Optional[Anchor] = None) -> Traversable:
     53     """
     54     Get a Traversable resource for an anchor.
     55     """
---> 56     return from_package(resolve(anchor))

File /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/functools.py:888, in singledispatch.<locals>.wrapper(*args, **kw)
    884 if not args:
    885     raise TypeError(f'{funcname} requires at least '
    886                     '1 positional argument')
--> 888 return dispatch(args[0].__class__)(*args, **kw)

File /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/importlib_resources/_common.py:82, in _(cand)
     80 @resolve.register
     81 def _(cand: str) -> types.ModuleType:
---> 82     return importlib.import_module(cand)

File /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/importlib/__init__.py:122, in import_module(name, package)
    119 if not package:
    120     msg = ("the 'package' argument is required to perform a relative "
    121            "import for {!r}")
--> 122     raise TypeError(msg.format(name))
    123 for character in name:
    124     if character != '.':

TypeError: the 'package' argument is required to perform a relative import for '../../probnum'
TypeError: the 'package' argument is required to perform a relative import for '../../probnum'
```


This could possibly have to do with a release of a new [matplotlib version v3.7](https://github.com/matplotlib/matplotlib/releases/tag/v3.7.0) at the same time. Before this PR the matplotlib version used for the tutorials was not fixed.
