### PR TITLE
Split `Kernel.input_shape` into `Kernel.input_shape_{0,1}`

### DIFF
--- a/src/probnum/randprocs/kernels/_kernel.py
+++ b/src/probnum/randprocs/kernels/_kernel.py
@@ -138,7 +138,7 @@ class Kernel(abc.ABC):
         assert (
             input_shape_0 is not None and input_shape_1 is not None
         ) or input_shape is not None, (
-            "Either `input_shape_0` and `input_shape_1` or `input_shape` must be given"
+            "Either `input_shape_0` and `input_shape_1` or `input_shape` must be given."
         )
 
         if input_shape is not None:


### PR DESCRIPTION
# In a Nutshell
This PR splits the `input_shape` of a `Kernel` into separate input shapes for the two arguments. With this change, we can model cross-covariance functions of random processes with different domains.

# Detailed Description
- split `Kernel.input_shape` into `Kernel.input_shape_{0,1}`
- retain `Kernel.input_shape` as a convenience argument if `input_shape_0 == input_shape_1`
- the same is done for `input_{ndim_size}`

# Related Issues
None
