### PR TITLE
Fix to benchmark runner by adding custom build command

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -24,6 +24,7 @@
     "install_command": ["python -mpip install --force-reinstall {wheel_file}"],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
     "build_command": [
+        "python -m pip install build",
         "PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -23,10 +23,7 @@
     //
     "install_command": ["python -mpip install --force-reinstall {wheel_file}"],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    // "build_command": [
-    //     "python setup.py build",
-    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
-    // ],
+    "build_command": ["PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"],
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -24,7 +24,6 @@
     "install_command": ["python -mpip install --force-reinstall {wheel_file}"],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
     "build_command": [
-        "python -m pip install build",
         "PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -23,7 +23,9 @@
     //
     "install_command": ["python -mpip install --force-reinstall {wheel_file}"],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    "build_command": ["PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"],
+    "build_command": [
+        "PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,3 +1,3 @@
 # Dependencies needed to run the benchmarks
-
+virtualenv
 asv>=0.5.1,<0.6

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,3 +1,3 @@
 # Dependencies needed to run the benchmarks
 
-asv>=0.5,<0.6
+asv>=0.5.1,<0.6

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,6 @@ basepython = python3
 deps = -r{toxinidir}/benchmarks/requirements.txt
 changedir = benchmarks
 commands =
-    asv check -v
     asv machine --yes
     asv run -e --quick --dry-run --strict --show-stderr --python=same
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ basepython = python3
 deps = -r{toxinidir}/benchmarks/requirements.txt
 changedir = benchmarks
 commands =
+    asv check -v
     asv machine --yes
     asv run -e --quick --dry-run --strict --show-stderr --python=same
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ basepython = python3
 deps = -r{toxinidir}/benchmarks/requirements.txt
 changedir = benchmarks
 commands =
+    asv check --environment existing
     asv machine --yes
     asv run -e --quick --dry-run --strict --show-stderr --python=same
 


### PR DESCRIPTION
# In a Nutshell
Adds a custom build command for the benchmarks and a `asv check` to the github action.

# Detailed Description
Tries to address the issues raised in #787. The problem was presumably that probnum was not properly installed into the virtualenv that was used for benchmarking.

# Related Issues
Closes #787 
