### PR TITLE
Add KeOps support to CovarianceFunction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ extras_require["pls_calib"] = [
     # This is and should not be a ProbNum dependency.
     "matplotlib",
 ]
+extras_require["keops"] = ["pykeops>=2.1.1<3.0"]
 extras_require["full"] = (
-    extras_require["jax"] + extras_require["zoo"] + extras_require["pls_calib"]
+    extras_require["jax"]
+    + extras_require["zoo"]
+    + extras_require["pls_calib"]
+    + extras_require["keops"]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require["pls_calib"] = [
     # This is and should not be a ProbNum dependency.
     "matplotlib",
 ]
-extras_require["keops"] = ["pykeops>=2.1.1<3.0"]
+extras_require["keops"] = ["pykeops>=2.1.1,<3.0"]
 extras_require["full"] = (
     extras_require["jax"]
     + extras_require["zoo"]

--- a/src/probnum/randprocs/covfuncs/__init__.py
+++ b/src/probnum/randprocs/covfuncs/__init__.py
@@ -9,6 +9,7 @@ and multiplication.
 """
 
 from ._covariance_function import CovarianceFunction, IsotropicMixin
+from ._covariance_linear_operator import CovarianceLinearOperator
 from ._exponentiated_quadratic import ExpQuad
 from ._linear import Linear
 from ._matern import Matern

--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -11,7 +11,7 @@ import numpy as np
 
 try:
     from pykeops.numpy import LazyTensor
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 from probnum import linops, utils as _pn_utils

--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -526,7 +526,7 @@ class CovarianceFunction(abc.ABC):
         self,
         x0: np.ndarray,
         x1: Optional[np.ndarray],
-    ):
+    ) -> "pykeops.numpy.LazyTensor":
         """:class:`~pykeops.numpy.LazyTensor` representing the lazy computation of the
         pairwise covariances of evaluations of :math:`f_0` and :math:`f_1` at the given
         input points.
@@ -813,7 +813,7 @@ class IsotropicMixin(abc.ABC):  # pylint: disable=too-few-public-methods
         x1: Optional[np.ndarray],
         *,
         scale_factors: Optional[np.ndarray] = None,
-    ):
+    ) -> "pykeops.numpy.LazyTensor":
         """KeOps-based implementation of the squared (modified) Euclidean distance,
         which supports scalar inputs, an optional second argument, and separate scale
         factors for each input dimension."""
@@ -839,7 +839,7 @@ class IsotropicMixin(abc.ABC):  # pylint: disable=too-few-public-methods
         x1: Optional[np.ndarray],
         *,
         scale_factors: Optional[np.ndarray] = None,
-    ):
+    ) -> "pykeops.numpy.LazyTensor":
         """KeOps-based implementation of the (modified) Euclidean distance, which
         supports scalar inputs, an optional second argument, and separate scale factors
         for each input dimension."""

--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -9,8 +9,15 @@ from typing import Optional, Union
 
 import numpy as np
 
+try:
+    from pykeops.numpy import LazyTensor, Pm, Vi, Vj
+except ImportError:
+    pass
+
 from probnum import linops, utils as _pn_utils
 from probnum.typing import ArrayLike, ScalarLike, ShapeLike, ShapeType
+
+from ._covariance_linear_operator import CovarianceLinearOperator
 
 BinaryOperandType = Union["CovarianceFunction", ScalarLike]
 
@@ -409,6 +416,8 @@ class CovarianceFunction(abc.ABC):
         self,
         x0: ArrayLike,
         x1: Optional[ArrayLike] = None,
+        *,
+        use_keops=True,
     ) -> linops.LinearOperator:
         r""":class:`~probnum.linops.LinearOperator` representing the pairwise
         covariances of evaluations of :math:`f_0` and :math:`f_1` at the given input
@@ -427,6 +436,10 @@ class CovarianceFunction(abc.ABC):
         can be used to implement efficient matrix-vector products with covariance
         matrices without needing to construct the entire matrix in memory.
 
+        By default, a KeOps-based matrix-free implementation will be used if available.
+        If there is no KeOps-based implementation, the standard implementation will be
+        used as a fallback.
+
         Parameters
         ----------
         x0
@@ -438,6 +451,9 @@ class CovarianceFunction(abc.ABC):
             Can also be set to :data:`None`, in which case the function will behave as
             if ``x1 == x0`` (potentially using a more efficient implementation for this
             particular case).
+        use_keops
+            Optional keyword flag to choose whether to use a KeOps-based implementation
+            or the standard implementation.
 
         Returns
         -------
@@ -449,7 +465,7 @@ class CovarianceFunction(abc.ABC):
             corresponding to the given batches of input points.
             The order of the rows and columns of the covariance matrix corresponds to
             the order of entries obtained by flattening :class:`~numpy.ndarray`\ s with
-            shapes :attr:`output_shape_0` ``+ batch_shape_0`` and :attr:`output_shape_0`
+            shapes :attr:`output_shape_0` ``+ batch_shape_0`` and :attr:`output_shape_1`
             ``+ batch_shape_1`` in "C-order".
 
         Raises
@@ -466,7 +482,7 @@ class CovarianceFunction(abc.ABC):
         if x1 is not None:
             x1 = self._preprocess_linop_input(x1, argnum=1)
 
-        k_linop_x0_x1 = self._evaluate_linop(x0, x1)
+        k_linop_x0_x1 = self._evaluate_linop(x0, x1, use_keops)
 
         assert isinstance(k_linop_x0_x1, linops.LinearOperator)
         assert k_linop_x0_x1.shape == (
@@ -506,6 +522,39 @@ class CovarianceFunction(abc.ABC):
             See "Returns" section in the docstring of :meth:`__call__`.
         """
 
+    def _keops_lazy_tensor(
+        self,
+        x0: np.ndarray,
+        x1: Optional[np.ndarray],
+    ):
+        """:class:`~pykeops.numpy.LazyTensor` representing the lazy computation of the
+        pairwise covariances of evaluations of :math:`f_0` and :math:`f_1` at the given
+        input points.
+
+        If a subclass implements this method, it will be used by default for the
+        :class:`~probnum.linops.LinearOperator` returned by the :meth:`linop` method.
+
+        Parameters
+        ----------
+        x0
+            *shape=* ``(prod(batch_shape_0),) +`` :attr:`input_shape_0` -- (Batch of)
+            input(s) for the first argument of the :class:`CovarianceFunction`.
+        x1
+            *shape=* ``(prod(batch_shape_1),) +`` :attr:`input_shape_1` -- (Batch of)
+            input(s) for the second argument of the :class:`CovarianceFunction`.
+            Can also be set to :data:`None`, in which case the function will behave as
+            if ``x1 == x0`` (potentially using a more efficient implementation for this
+            particular case).
+
+        Returns
+        -------
+        k_x0_x1
+            :class:`~pykeops.numpy.LazyTensor` representing the covariance matrix
+            corresponding to the given batches of input points.
+            See :meth:`linop` for the shape and row/column order.
+        """
+        raise NotImplementedError()
+
     def _evaluate_matrix(
         self,
         x0: np.ndarray,
@@ -541,8 +590,24 @@ class CovarianceFunction(abc.ABC):
         self,
         x0: np.ndarray,
         x1: Optional[np.ndarray],
+        use_keops=True,
     ) -> linops.LinearOperator:
-        return linops.Matrix(self._evaluate_matrix(x0, x1))
+        try:
+            keops_lazy_tensor = self._keops_lazy_tensor(x0, x1) if use_keops else None
+        except (NotImplementedError, ModuleNotFoundError):
+            keops_lazy_tensor = None
+
+        shape = (
+            self.output_size_0 * x0.shape[0],
+            self.output_size_1 * (x1.shape[0] if x1 is not None else x0.shape[0]),
+        )
+        return CovarianceLinearOperator(
+            x0,
+            x1,
+            shape,
+            self._evaluate_matrix,
+            keops_lazy_tensor,
+        )
 
     def _check_shapes(
         self,
@@ -741,3 +806,43 @@ class IsotropicMixin(abc.ABC):  # pylint: disable=too-few-public-methods
         return np.sqrt(
             self._squared_euclidean_distances(x0, x1, scale_factors=scale_factors)
         )
+
+    def _squared_euclidean_distances_keops(
+        self,
+        x0: np.ndarray,
+        x1: Optional[np.ndarray],
+        *,
+        scale_factors: Optional[np.ndarray] = None,
+    ):
+        """KeOps-based implementation of the squared (modified) Euclidean distance,
+        which supports scalar inputs, an optional second argument, and separate scale
+        factors for each input dimension."""
+        if x1 is None:
+            x1 = x0
+        if len(x0.shape) < 2:
+            x0 = x0.reshape(-1, 1)
+        if len(x1.shape) < 2:
+            x1 = x1.reshape(-1, 1)
+
+        sqdiffs = Vi(x0) - Vj(x1)
+
+        if scale_factors is not None:
+            sqdiffs *= Pm(scale_factors)
+
+        sqdiffs *= sqdiffs
+
+        return sqdiffs.sum()
+
+    def _euclidean_distances_keops(
+        self,
+        x0: np.ndarray,
+        x1: Optional[np.ndarray],
+        *,
+        scale_factors: Optional[np.ndarray] = None,
+    ):
+        """KeOps-based implementation of the (modified) Euclidean distance, which
+        supports scalar inputs, an optional second argument, and separate scale factors
+        for each input dimension."""
+        return self._squared_euclidean_distances_keops(
+            x0, x1, scale_factors=scale_factors
+        ).sqrt()

--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -801,6 +801,7 @@ class IsotropicMixin(abc.ABC):  # pylint: disable=too-few-public-methods
             self._squared_euclidean_distances(x0, x1, scale_factors=scale_factors)
         )
 
+    # pylint: disable=no-self-use
     def _squared_euclidean_distances_keops(
         self,
         x0: np.ndarray,

--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -811,6 +811,7 @@ class IsotropicMixin(abc.ABC):  # pylint: disable=too-few-public-methods
         """KeOps-based implementation of the squared (modified) Euclidean distance,
         which supports scalar inputs, an optional second argument, and separate scale
         factors for each input dimension."""
+        # pylint: disable=import-outside-toplevel
         from pykeops.numpy import Pm, Vi, Vj
 
         if x1 is None:

--- a/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
@@ -1,0 +1,85 @@
+"""LinearOperator that represents pairwise covariances of evaluations."""
+
+from typing import Optional
+import warnings
+
+import numpy as np
+
+from probnum import linops
+
+_USE_KEOPS = True
+try:
+    from pykeops.numpy import LazyTensor
+except ImportError:
+    _USE_KEOPS = False
+    warnings.warn(
+        "KeOps is not installed and currently unavailable for Windows."
+        "This may prevent scaling to large datasets."
+    )
+
+
+class CovarianceLinearOperator(linops.LinearOperator):
+    """:class:`~probnum.linops.LinearOperator` representing the pairwise
+    covariances of evaluations of :math:`f_0` and :math:`f_1` at the given input
+    points.
+
+    Supports both KeOps-based and standard implementations, but will prefer KeOps-based
+    implementations by default.
+
+    Parameters
+        ----------
+        x0
+            *shape=* ``(prod(batch_shape_0),) +`` :attr:`input_shape_0` -- (Batch of)
+            input(s) for the first argument of the :class:`CovarianceFunction`.
+        x1
+            *shape=* ``(prod(batch_shape_1),) +`` :attr:`input_shape_1` -- (Batch of)
+            input(s) for the second argument of the :class:`CovarianceFunction`.
+            Can also be set to :data:`None`, in which case the function will behave as
+            if ``x1 == x0`` (potentially using a more efficient implementation for this
+            particular case).
+        shape
+            Shape of the linear operator.
+        evaluate_dense_matrix
+            Callable for the standard implementation that evaluates k(x0, x1) densely.
+        keops_lazy_tensor
+            :class:`~pykeops.numpy.LazyTensor` representing the covariance matrix
+            corresponding to the given batches of input points.
+    """
+
+    def __init__(
+        self,
+        x0: np.ndarray,
+        x1: Optional[np.ndarray],
+        shape,
+        evaluate_dense_matrix: callable,
+        keops_lazy_tensor=None,
+    ):
+        self._x0 = x0
+        self._x1 = x1
+
+        self._evaluate_dense_matrix = evaluate_dense_matrix
+        self._keops_lazy_tensor = keops_lazy_tensor
+        self._use_keops = _USE_KEOPS and keops_lazy_tensor is not None
+        dtype = np.promote_types(x0.dtype, x1.dtype) if x1 is not None else x0.dtype
+        super().__init__(shape, dtype)
+
+    @property
+    def keops_lazy_tensor(self):
+        """:class:`~pykeops.numpy.LazyTensor` representing the covariance matrix
+        corresponding to the given batches of input points.
+        When not using KeOps, this is set to :data:`None`.
+        """
+        return self._keops_lazy_tensor
+
+    def _todense(self) -> np.ndarray:
+        return self._evaluate_dense_matrix(self._x0, self._x1)
+
+    def _matmul(self, x: np.ndarray) -> np.ndarray:
+        if self._use_keops:
+            return self.keops_lazy_tensor @ x
+        return self.todense() @ x
+
+    def _transpose(self) -> linops.LinearOperator:
+        return CovarianceLinearOperator(
+            self._x0, self._x1, self._evaluate_dense_matrix, self.keops_lazy_tensor
+        )

--- a/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
@@ -52,7 +52,7 @@ class CovarianceLinearOperator(linops.LinearOperator):
         x1: Optional[np.ndarray],
         shape,
         evaluate_dense_matrix: callable,
-        keops_lazy_tensor: Optional["pykeops.numpy.LazyTensor"] = None,
+        keops_lazy_tensor: Optional["LazyTensor"] = None,
     ):
         self._x0 = x0
         self._x1 = x1
@@ -64,7 +64,7 @@ class CovarianceLinearOperator(linops.LinearOperator):
         super().__init__(shape, dtype)
 
     @property
-    def keops_lazy_tensor(self) -> "pykeops.numpy.LazyTensor":
+    def keops_lazy_tensor(self) -> "LazyTensor":
         """:class:`~pykeops.numpy.LazyTensor` representing the covariance matrix
         corresponding to the given batches of input points.
         When not using KeOps, this is set to :data:`None`.

--- a/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
@@ -10,7 +10,7 @@ from probnum import linops
 _USE_KEOPS = True
 try:
     from pykeops.numpy import LazyTensor
-except ImportError:
+except ImportError:  # pragma: no cover
     _USE_KEOPS = False
     warnings.warn(
         "KeOps is not installed and currently unavailable for Windows."

--- a/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
@@ -52,7 +52,7 @@ class CovarianceLinearOperator(linops.LinearOperator):
         x1: Optional[np.ndarray],
         shape,
         evaluate_dense_matrix: callable,
-        keops_lazy_tensor=None,
+        keops_lazy_tensor: Optional["pykeops.numpy.LazyTensor"] = None,
     ):
         self._x0 = x0
         self._x1 = x1
@@ -64,7 +64,7 @@ class CovarianceLinearOperator(linops.LinearOperator):
         super().__init__(shape, dtype)
 
     @property
-    def keops_lazy_tensor(self):
+    def keops_lazy_tensor(self) -> "pykeops.numpy.LazyTensor":
         """:class:`~pykeops.numpy.LazyTensor` representing the covariance matrix
         corresponding to the given batches of input points.
         When not using KeOps, this is set to :data:`None`.

--- a/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
+++ b/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
@@ -101,9 +101,9 @@ class ExpQuad(CovarianceFunction, IsotropicMixin):
 
     def _keops_lazy_tensor(
         self, x0: np.ndarray, x1: Optional[np.ndarray]
-    ) -> "pykeops.numpy.LazyTensor":
+    ) -> "LazyTensor":
         if not _USE_KEOPS:
-            raise ModuleNotFoundError()
+            raise ImportError()
         return (
             -self._squared_euclidean_distances_keops(
                 x0, x1, scale_factors=self._scale_factors

--- a/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
+++ b/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
@@ -12,7 +12,7 @@ from ._covariance_function import CovarianceFunction, IsotropicMixin
 _USE_KEOPS = True
 try:
     from pykeops.numpy import LazyTensor
-except ImportError:
+except ImportError:  # pragma: no cover
     _USE_KEOPS = False
 
 
@@ -102,7 +102,7 @@ class ExpQuad(CovarianceFunction, IsotropicMixin):
     def _keops_lazy_tensor(
         self, x0: np.ndarray, x1: Optional[np.ndarray]
     ) -> "LazyTensor":
-        if not _USE_KEOPS:
+        if not _USE_KEOPS:  # pragma: no cover
             raise ImportError()
         return (
             -self._squared_euclidean_distances_keops(

--- a/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
+++ b/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
@@ -99,7 +99,9 @@ class ExpQuad(CovarianceFunction, IsotropicMixin):
             )
         )
 
-    def _keops_lazy_tensor(self, x0: np.ndarray, x1: Optional[np.ndarray]):
+    def _keops_lazy_tensor(
+        self, x0: np.ndarray, x1: Optional[np.ndarray]
+    ) -> "pykeops.numpy.LazyTensor":
         if not _USE_KEOPS:
             raise ModuleNotFoundError()
         return (

--- a/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
+++ b/src/probnum/randprocs/covfuncs/_exponentiated_quadratic.py
@@ -9,6 +9,12 @@ from probnum.typing import ArrayLike, ShapeLike
 
 from ._covariance_function import CovarianceFunction, IsotropicMixin
 
+_USE_KEOPS = True
+try:
+    from pykeops.numpy import LazyTensor
+except ImportError:
+    _USE_KEOPS = False
+
 
 class ExpQuad(CovarianceFunction, IsotropicMixin):
     r"""Exponentiated quadratic covariance function.
@@ -92,3 +98,12 @@ class ExpQuad(CovarianceFunction, IsotropicMixin):
                 x0, x1, scale_factors=self._scale_factors
             )
         )
+
+    def _keops_lazy_tensor(self, x0: np.ndarray, x1: Optional[np.ndarray]):
+        if not _USE_KEOPS:
+            raise ModuleNotFoundError()
+        return (
+            -self._squared_euclidean_distances_keops(
+                x0, x1, scale_factors=self._scale_factors
+            )
+        ).exp()

--- a/src/probnum/randprocs/covfuncs/_matern.py
+++ b/src/probnum/randprocs/covfuncs/_matern.py
@@ -15,7 +15,7 @@ from ._covariance_function import CovarianceFunction, IsotropicMixin
 _USE_KEOPS = True
 try:
     from pykeops.numpy import LazyTensor
-except ImportError:
+except ImportError:  # pragma: no cover
     _USE_KEOPS = False
 
 
@@ -197,7 +197,7 @@ class Matern(CovarianceFunction, IsotropicMixin):
     def _keops_lazy_tensor(
         self, x0: np.ndarray, x1: Optional[np.ndarray]
     ) -> "LazyTensor":
-        if not _USE_KEOPS:
+        if not _USE_KEOPS:  # pragma: no cover
             raise ImportError()
 
         scaled_dists = self._euclidean_distances_keops(

--- a/src/probnum/randprocs/covfuncs/_matern.py
+++ b/src/probnum/randprocs/covfuncs/_matern.py
@@ -14,7 +14,7 @@ from ._covariance_function import CovarianceFunction, IsotropicMixin
 
 _USE_KEOPS = True
 try:
-    from pykeops.numpy import LazyTensor, Vi, Vj
+    from pykeops.numpy import LazyTensor
 except ImportError:
     _USE_KEOPS = False
 
@@ -196,9 +196,9 @@ class Matern(CovarianceFunction, IsotropicMixin):
 
     def _keops_lazy_tensor(
         self, x0: np.ndarray, x1: Optional[np.ndarray]
-    ) -> "pykeops.numpy.LazyTensor":
+    ) -> "LazyTensor":
         if not _USE_KEOPS:
-            raise ModuleNotFoundError()
+            raise ImportError()
 
         scaled_dists = self._euclidean_distances_keops(
             x0, x1, scale_factors=self._scale_factors
@@ -219,7 +219,8 @@ class Matern(CovarianceFunction, IsotropicMixin):
 
             return res
 
-        return super()._keops_lazy_tensor(x0, x1)
+        # TODO: Add KeOps implementation for non-half-integer case
+        raise NotImplementedError()
 
     @staticmethod
     @functools.lru_cache(maxsize=None)

--- a/src/probnum/randprocs/covfuncs/_matern.py
+++ b/src/probnum/randprocs/covfuncs/_matern.py
@@ -194,7 +194,9 @@ class Matern(CovarianceFunction, IsotropicMixin):
 
         return _matern_bessel(scaled_dists, nu=self._nu)
 
-    def _keops_lazy_tensor(self, x0: np.ndarray, x1: Optional[np.ndarray]):
+    def _keops_lazy_tensor(
+        self, x0: np.ndarray, x1: Optional[np.ndarray]
+    ) -> "pykeops.numpy.LazyTensor":
         if not _USE_KEOPS:
             raise ModuleNotFoundError()
 

--- a/tests/test_randprocs/test_covfuncs/test_linop_matrix.py
+++ b/tests/test_randprocs/test_covfuncs/test_linop_matrix.py
@@ -1,6 +1,5 @@
 """Test cases for ``CovarianceFunction.matrix`` and ``CovarianceFunction.linop``"""
 
-import builtins
 from typing import Callable, Optional
 
 import numpy as np

--- a/tests/test_randprocs/test_covfuncs/test_linop_matrix.py
+++ b/tests/test_randprocs/test_covfuncs/test_linop_matrix.py
@@ -24,6 +24,21 @@ def linop(
 
 
 @pytest.fixture
+def no_keops_linop(
+    k: pn.randprocs.covfuncs.CovarianceFunction,
+    x0: np.ndarray,
+    x1: Optional[np.ndarray],
+) -> pn.linops.LinearOperator:
+    """`LinearOperator` representation of the covariance matrix that does not use
+    KeOps."""
+
+    if x1 is None and np.prod(x0.shape[:-1]) >= 100:
+        pytest.skip("Runs too long")
+
+    return k.linop(x0, x1, use_keops=False)
+
+
+@pytest.fixture
 def matrix(
     k: pn.randprocs.covfuncs.CovarianceFunction,
     x0: np.ndarray,
@@ -43,7 +58,7 @@ def matrix_naive(
     x0: np.ndarray,
     x1: Optional[np.ndarray],
 ) -> np.ndarray:
-    """Reference covariance matrix"""
+    """Reference covariance matrix."""
     if x1 is None:
         if np.prod(x0.shape[:-1]) >= 100:
             pytest.skip("Runs too long")
@@ -113,6 +128,22 @@ def test_matrix_equals_matrix_naive(
     np.testing.assert_allclose(
         matrix,
         matrix_naive,
+        rtol=10**-12,
+        atol=10**-12,
+    )
+
+
+def test_keops_equals_no_keops(
+    linop: pn.linops.LinearOperator,
+    no_keops_linop: pn.linops.LinearOperator,
+):
+    """Test whether the KeOps-based linop implementation matches the non-KeOps based
+    implementation."""
+    I = np.eye(linop.shape[1])
+
+    np.testing.assert_allclose(
+        linop @ I,
+        no_keops_linop @ I,
         rtol=10**-12,
         atol=10**-12,
     )

--- a/tests/test_randprocs/test_covfuncs/test_linop_matrix.py
+++ b/tests/test_randprocs/test_covfuncs/test_linop_matrix.py
@@ -1,5 +1,6 @@
 """Test cases for ``CovarianceFunction.matrix`` and ``CovarianceFunction.linop``"""
 
+import builtins
 from typing import Callable, Optional
 
 import numpy as np
@@ -35,7 +36,12 @@ def no_keops_linop(
     if x1 is None and np.prod(x0.shape[:-1]) >= 100:
         pytest.skip("Runs too long")
 
-    return k.linop(x0, x1, use_keops=False)
+    linop = k.linop(x0, x1)
+    if isinstance(linop, pn.randprocs.covfuncs.CovarianceLinearOperator):
+        # TODO: Find a more elegant way to make the linop believe that KeOps
+        # is not installed
+        linop._use_keops = False
+    return linop
 
 
 @pytest.fixture


### PR DESCRIPTION
# In a Nutshell
Enable efficient matrix-free implementations of covariance linear operators via KeOps

# Detailed Description
The overall idea is inspired by @JonathanWenger's KeOps integration in IterGP.
- Add new method _keops_lazy_tensor that can be implemented in a subclass to return the LazyTensor equivalent of _evaluate_matrix
- Add new class CovarianceLinearOperator that represents the pairwise covariances and uses KeOps by default (if possible)
- Add KeOps implementations for Matern and ExpQuad

One problem I came across is that by making KeOps optional (implemented via import guards), we cannot use KeOps typing in function signatures because otherwise everything breaks for users who do not have KeOps installed. Any ideas on this?

EDIT: And I guess the CI tests are also problematic because they don't have KeOps installed (?), so the KeOps implementations will not be tested.