### PR TITLE
Add `BlockDiagonalMatrix`

### DIFF
--- a/src/probnum/linops/__init__.py
+++ b/src/probnum/linops/__init__.py
@@ -12,6 +12,7 @@ Several algorithms in the :mod:`probnum.linalg` subpackage are able to operate o
 :class:`~probnum.linops.LinearOperator` instances.
 """
 
+from ._block import BlockDiagonalMatrix
 from ._kronecker import IdentityKronecker, Kronecker, SymmetricKronecker, Symmetrize
 from ._linear_operator import (
     Embedding,
@@ -38,6 +39,7 @@ __all__ = [
     "Selection",
     "SymmetricKronecker",
     "Symmetrize",
+    "BlockDiagonalMatrix",
     "Zero",
 ]
 
@@ -53,6 +55,7 @@ Kronecker.__module__ = "probnum.linops"
 Selection.__module__ = "probnum.linops"
 SymmetricKronecker.__module__ = "probnum.linops"
 Symmetrize.__module__ = "probnum.linops"
+BlockDiagonalMatrix.__module__ = "probnum.linops"
 Zero.__module__ = "probnum.linops"
 
 aslinop.__module__ = "probnum.linops"

--- a/src/probnum/linops/_block.py
+++ b/src/probnum/linops/_block.py
@@ -1,0 +1,133 @@
+"""Operators that utilize block structure."""
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+from scipy.linalg import block_diag
+
+from probnum.typing import DTypeLike, LinearOperatorLike
+
+from . import _linear_operator, _utils
+
+
+class BlockDiagonalMatrix(_linear_operator.LinearOperator):
+    r"""Forms a block diagonal matrix from the input linear operators.
+
+    Given linear operators A, B, ..., Z, this represents the block linear
+    operator
+    .. math::
+    \\begin{bmatrix}
+    A & & & & \\\\
+    & B & & & \\\\
+    & & \\ddots & & \\\\
+    & & & \\ddots & \\\\
+    & & & & Z
+    \\end{bmatrix}
+
+    Parameters
+    ----------
+    *blocks :
+        The (ordered!) input linear operators.
+    """
+
+    def __init__(self, *blocks: LinearOperatorLike):
+        blocks = tuple(_utils.aslinop(block) for block in blocks)
+        assert len(blocks) > 0
+
+        dtype = functools.reduce(np.promote_types, (block.dtype for block in blocks))
+        shape_0 = sum(block.shape[0] for block in blocks)
+        shape_1 = sum(block.shape[1] for block in blocks)
+        self.split_indices = np.array(
+            tuple(block.shape[1] for block in blocks)
+        ).cumsum()[:-1]
+
+        super().__init__((shape_0, shape_1), dtype)
+
+        self.is_symmetric = all(block.is_symmetric for block in blocks)
+        self.is_positive_definite = all(block.is_positive_definite for block in blocks)
+        self.is_upper_triangular = all(block.is_upper_triangular for block in blocks)
+        self.is_lower_triangular = all(block.is_lower_triangular for block in blocks)
+
+        self._blocks = blocks
+
+    @property
+    def blocks(self) -> tuple[_linear_operator.LinearOperator]:
+        """The linear operators that make up the diagonal (in order)."""
+        return self._blocks
+
+    def _split_input(self, x: np.ndarray) -> np.ndarray:
+        return np.split(x, self.split_indices, axis=-2)
+
+    def _matmul(self, x: np.ndarray) -> np.ndarray:
+        return np.concatenate(
+            tuple(
+                cur_block @ cur_x
+                for cur_block, cur_x in zip(self.blocks, self._split_input(x))
+            ),
+            axis=-2,
+        )
+
+    def _transpose(self) -> BlockDiagonalMatrix:
+        return BlockDiagonalMatrix(*[block.T for block in self.blocks])
+
+    def _solve(self, B: np.ndarray) -> np.ndarray:
+        if all(block.is_square for block in self.blocks):
+            return np.concatenate(
+                tuple(
+                    cur_block.inv() @ cur_x
+                    for cur_block, cur_x in zip(self.blocks, self._split_input(B))
+                ),
+                axis=-2,
+            )
+        return super()._solve(B)
+
+    def _inverse(self) -> BlockDiagonalMatrix:
+        if all(block.is_square for block in self.blocks):
+            return BlockDiagonalMatrix(*[block.inv() for block in self.blocks])
+        return super()._inverse()
+
+    def _todense(self) -> np.ndarray:
+        return block_diag(*[block.todense() for block in self.blocks])
+
+    def _det(self) -> np.inexact:
+        if all(block.is_square for block in self.blocks):
+            return np.prod([block.det() for block in self.blocks])
+        return super()._det()
+
+    def _logabsdet(self) -> np.floating:
+        if all(block.is_square for block in self.blocks):
+            return np.sum([block.logabsdet() for block in self.blocks])
+        return super()._logabsdet()
+
+    def _trace(self) -> np.number:
+        if all(block.is_square for block in self.blocks):
+            return np.sum([block.trace() for block in self.blocks])
+        return super()._trace()
+
+    def _eigvals(self) -> np.ndarray:
+        if all(block.is_square for block in self.blocks):
+            return np.concatenate([block.eigvals() for block in self.blocks])
+        return super()._eigvals()
+
+    def _rank(self) -> np.intp:
+        if all(block.is_square for block in self.blocks):
+            return np.sum([block.rank() for block in self.blocks])
+        return super()._rank()
+
+    def _cholesky(self, lower: bool) -> BlockDiagonalMatrix:
+        if all(block.is_square for block in self.blocks):
+            return BlockDiagonalMatrix(
+                *[block.cholesky(lower) for block in self.blocks]
+            )
+        return super()._cholesky(lower)
+
+    def _astype(
+        self, dtype: DTypeLike, order: str, casting: str, copy: bool
+    ) -> BlockDiagonalMatrix:
+        return BlockDiagonalMatrix(
+            *[
+                block.astype(dtype, order=order, casting=casting, copy=copy)
+                for block in self.blocks
+            ]
+        )

--- a/src/probnum/linops/_block.py
+++ b/src/probnum/linops/_block.py
@@ -1,4 +1,4 @@
-"""Operators that utilize block structure."""
+"""Operators with block structure."""
 from __future__ import annotations
 
 import functools
@@ -34,7 +34,8 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
 
     def __init__(self, *blocks: LinearOperatorLike):
         blocks = tuple(_utils.aslinop(block) for block in blocks)
-        assert len(blocks) > 0
+        if len(blocks) < 1:
+            raise ValueError("At least one block must be given.")
 
         dtype = functools.reduce(np.promote_types, (block.dtype for block in blocks))
         shape_0 = sum(block.shape[0] for block in blocks)
@@ -76,7 +77,7 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
         if all(block.is_square for block in self.blocks):
             return np.concatenate(
                 tuple(
-                    cur_block.inv() @ cur_x
+                    cur_block.solve(cur_x)
                     for cur_block, cur_x in zip(self.blocks, self._split_input(B))
                 ),
                 axis=-2,

--- a/src/probnum/linops/_block.py
+++ b/src/probnum/linops/_block.py
@@ -12,19 +12,19 @@ from . import _linear_operator, _utils
 
 
 class BlockDiagonalMatrix(_linear_operator.LinearOperator):
-    r"""Forms a block diagonal matrix from the input linear operators.
+    """Forms a block diagonal matrix from the input linear operators.
 
     Given linear operators A, B, ..., Z, this represents the block linear
     operator
 
     .. math::
-    \\begin{bmatrix}
-    A & & & & \\\\
-    & B & & & \\\\
-    & & \\ddots & & \\\\
-    & & & \\ddots & \\\\
-    & & & & Z
-    \\end{bmatrix}
+        \\begin{bmatrix}
+        A & & & & \\\\
+        & B & & & \\\\
+        & & \\ddots & & \\\\
+        & & & \\ddots & \\\\
+        & & & & Z
+        \\end{bmatrix}
 
     Parameters
     ----------

--- a/src/probnum/linops/_block.py
+++ b/src/probnum/linops/_block.py
@@ -72,7 +72,7 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
     ) -> Optional[bool]:
         if all(property_fn(block) for block in self.blocks):
             return True
-        elif any(property_fn(block) is False for block in self.blocks):
+        if any(property_fn(block) is False for block in self.blocks):
             return False
         return None
 

--- a/src/probnum/linops/_block.py
+++ b/src/probnum/linops/_block.py
@@ -16,6 +16,7 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
 
     Given linear operators A, B, ..., Z, this represents the block linear
     operator
+
     .. math::
     \\begin{bmatrix}
     A & & & & \\\\
@@ -27,7 +28,7 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
 
     Parameters
     ----------
-    *blocks :
+    blocks :
         The (ordered!) input linear operators.
     """
 

--- a/src/probnum/linops/_block.py
+++ b/src/probnum/linops/_block.py
@@ -15,8 +15,8 @@ from . import _linear_operator, _utils
 class BlockDiagonalMatrix(_linear_operator.LinearOperator):
     """Forms a block diagonal matrix from the input linear operators.
 
-    Given square linear operators A, B, ..., Z, this represents the block
-    linear operator
+    Given linear operators A, B, ..., Z, this represents the block linear
+    operator
 
     .. math::
         \\begin{bmatrix}
@@ -30,15 +30,14 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
     Parameters
     ----------
     blocks :
-        The (ordered!) input linear operators. Must all be square.
+        The (ordered!) input linear operators.
     """
 
     def __init__(self, *blocks: LinearOperatorLike):
         blocks = tuple(_utils.aslinop(block) for block in blocks)
         if len(blocks) < 1:
             raise ValueError("At least one block must be given.")
-        if not all(block.is_square for block in blocks):
-            raise ValueError("All blocks must be square.")
+        self._all_blocks_square = all(block.is_square for block in blocks)
 
         dtype = functools.reduce(np.promote_types, (block.dtype for block in blocks))
         shape_0 = sum(block.shape[0] for block in blocks)
@@ -101,28 +100,44 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
         )
 
     def _inverse(self) -> BlockDiagonalMatrix:
-        return BlockDiagonalMatrix(*[block.inv() for block in self.blocks])
+        if self._all_blocks_square:
+            return BlockDiagonalMatrix(*[block.inv() for block in self.blocks])
+        return super()._inverse()
 
     def _todense(self) -> np.ndarray:
         return block_diag(*[block.todense() for block in self.blocks])
 
     def _det(self) -> np.inexact:
-        return np.prod([block.det() for block in self.blocks])
+        if self._all_blocks_square:
+            return np.prod([block.det() for block in self.blocks])
+        return super()._det()
 
     def _logabsdet(self) -> np.floating:
-        return np.sum([block.logabsdet() for block in self.blocks])
+        if self._all_blocks_square:
+            return np.sum([block.logabsdet() for block in self.blocks])
+        return super()._logabsdet()
 
     def _trace(self) -> np.number:
-        return np.sum([block.trace() for block in self.blocks])
+        if self._all_blocks_square:
+            return np.sum([block.trace() for block in self.blocks])
+        return super()._trace()
 
     def _eigvals(self) -> np.ndarray:
-        return np.concatenate([block.eigvals() for block in self.blocks])
+        if self._all_blocks_square:
+            return np.concatenate([block.eigvals() for block in self.blocks])
+        return super()._eigvals()
 
     def _rank(self) -> np.intp:
-        return np.sum([block.rank() for block in self.blocks])
+        if self._all_blocks_square:
+            return np.sum([block.rank() for block in self.blocks])
+        return super()._rank()
 
     def _cholesky(self, lower: bool) -> BlockDiagonalMatrix:
-        return BlockDiagonalMatrix(*[block.cholesky(lower) for block in self.blocks])
+        if self._all_blocks_square:
+            return BlockDiagonalMatrix(
+                *[block.cholesky(lower) for block in self.blocks]
+            )
+        return super()._cholesky(lower)
 
     def _astype(
         self, dtype: DTypeLike, order: str, casting: str, copy: bool

--- a/tests/test_linops/test_block.py
+++ b/tests/test_linops/test_block.py
@@ -1,0 +1,31 @@
+"""Tests for block structure linear operators."""
+
+import numpy as np
+import pytest
+
+import probnum as pn
+
+
+def test_no_block():
+    with pytest.raises(ValueError):
+        bdm = pn.linops.BlockDiagonalMatrix()
+
+
+def test_not_all_square():
+    with pytest.raises(ValueError):
+        M = pn.linops.Matrix(np.array([[1, 2]]))
+        M.is_symmetric = False
+        bdm = pn.linops.BlockDiagonalMatrix(pn.linops.Identity((2, 2)), M)
+
+
+def test_property_inference():
+    M = pn.linops.Matrix(np.array([[1.0, -2.0], [-2.0, 5.0]]))
+    M.is_symmetric = True
+    M.is_positive_definite = True
+    M.is_lower_triangular = False
+    M.is_upper_triangular = False
+    bdm = pn.linops.BlockDiagonalMatrix(pn.linops.Identity((2, 2)), M)
+    assert bdm.is_symmetric
+    assert bdm.is_positive_definite
+    assert bdm.is_lower_triangular is False
+    assert bdm.is_upper_triangular is False

--- a/tests/test_linops/test_block.py
+++ b/tests/test_linops/test_block.py
@@ -11,13 +11,6 @@ def test_no_block():
         bdm = pn.linops.BlockDiagonalMatrix()
 
 
-def test_not_all_square():
-    with pytest.raises(ValueError):
-        M = pn.linops.Matrix(np.array([[1, 2]]))
-        M.is_symmetric = False
-        bdm = pn.linops.BlockDiagonalMatrix(pn.linops.Identity((2, 2)), M)
-
-
 def test_property_inference():
     M = pn.linops.Matrix(np.array([[1.0, -2.0], [-2.0, 5.0]]))
     M.is_symmetric = True

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -304,7 +304,7 @@ def test_eigvals(linop: pn.linops.LinearOperator, matrix: np.ndarray):
         assert linop_eigvals.shape == matrix_eigvals.shape
         assert linop_eigvals.dtype == matrix_eigvals.dtype
 
-        np.testing.assert_allclose(linop_eigvals, matrix_eigvals)
+        np.testing.assert_allclose(np.sort(linop_eigvals), np.sort(matrix_eigvals))
     else:
         with pytest.raises(np.linalg.LinAlgError):
             linop.eigvals()

--- a/tests/test_linops/test_linops_cases/block_cases.py
+++ b/tests/test_linops/test_linops_cases/block_cases.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import pytest
@@ -38,7 +38,7 @@ spd_matrices = (
     ],
 )
 def case_block_diagonal(
-    blocks: list[np.ndarray],
+    blocks: List[np.ndarray],
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
     linop = pn.linops.BlockDiagonalMatrix(*blocks)
     matrix = block_diag(*blocks)

--- a/tests/test_linops/test_linops_cases/block_cases.py
+++ b/tests/test_linops/test_linops_cases/block_cases.py
@@ -34,9 +34,9 @@ spd_matrices = (
             ]
         ),
         ([np.array([[4, 3], [2, 1]]), 5 * np.eye(4), np.array([[2]])]),
+        ([np.array([[8, 9]]), np.array([[3], [5]])]),
     ],
 )
-@pytest_cases.case(tags=["square"])
 def case_block_diagonal(
     blocks: List[np.ndarray],
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:

--- a/tests/test_linops/test_linops_cases/block_cases.py
+++ b/tests/test_linops/test_linops_cases/block_cases.py
@@ -34,9 +34,9 @@ spd_matrices = (
             ]
         ),
         ([np.array([[4, 3], [2, 1]]), 5 * np.eye(4), np.array([[2]])]),
-        ([np.array([[8, 9]]), np.array([[3], [5]])]),
     ],
 )
+@pytest_cases.case(tags=["square"])
 def case_block_diagonal(
     blocks: List[np.ndarray],
 ) -> Tuple[pn.linops.LinearOperator, np.ndarray]:

--- a/tests/test_linops/test_linops_cases/block_cases.py
+++ b/tests/test_linops/test_linops_cases/block_cases.py
@@ -1,0 +1,68 @@
+from typing import Tuple, Union
+
+import numpy as np
+import pytest
+import pytest_cases
+from scipy.linalg import block_diag
+
+import probnum as pn
+from probnum.problems.zoo.linalg import random_spd_matrix
+
+spd_matrices = (
+    pn.linops.Identity(shape=(1, 1)),
+    np.array([[1.0, -2.0], [-2.0, 5.0]]),
+    random_spd_matrix(np.random.default_rng(892), dim=9),
+)
+
+
+@pytest.mark.parametrize(
+    "blocks",
+    [
+        ([np.array([[3, 7], [1, 5]])]),
+        (
+            [
+                np.array([[1, 2], [3, 4]]),
+                np.array(
+                    [
+                        [
+                            5,
+                            6,
+                        ],
+                        [0, 8],
+                    ]
+                ),
+            ]
+        ),
+        ([np.array([[4, 3], [2, 1]]), 5 * np.eye(4), np.array([[2]])]),
+        ([np.array([[8, 9]]), np.array([[3], [5]])]),
+    ],
+)
+def case_block_diagonal(
+    blocks: list[np.ndarray],
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    linop = pn.linops.BlockDiagonalMatrix(*blocks)
+    matrix = block_diag(*blocks)
+
+    return linop, matrix
+
+
+@pytest_cases.case(tags=["square", "symmetric", "positive-definite"])
+@pytest_cases.parametrize("A", spd_matrices)
+@pytest_cases.parametrize("B", spd_matrices)
+@pytest_cases.parametrize("C", spd_matrices)
+def case_block_diagonal_positive_definite(
+    A: Union[np.ndarray, pn.linops.LinearOperator],
+    B: Union[np.ndarray, pn.linops.LinearOperator],
+    C: Union[np.ndarray, pn.linops.LinearOperator],
+) -> Tuple[pn.linops.LinearOperator, np.ndarray]:
+    blocks = []
+    for block in [A, B, C]:
+        block = pn.linops.aslinop(block)
+        block.is_symmetric = True
+        block.is_positive_definite = True
+        blocks.append(block)
+
+    linop = pn.linops.BlockDiagonalMatrix(*blocks)
+    matrix = block_diag(blocks[0].todense(), blocks[1].todense(), blocks[2].todense())
+
+    return linop, matrix


### PR DESCRIPTION
# In a Nutshell
Add a custom linear operator `BlockDiagonalMatrix` for block diagonal structures.

# Detailed Description
- Add `BlockDiagonalMatrix` along with custom implementations of `det`, `trace`, `eigvals`, etc...
- Add two test cases for it
- Fix bug in eigvals test. Previously this checked the arrays returned by `linop` and `matrix` for equality. But the eigenvalues may have a different order. For the comparison to be valid, we need to sort the arrays before comparing them.