### PR TITLE
Bugfix in `CovarianceLinearOperator` transpose

### DIFF
--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -586,7 +586,9 @@ class CovarianceFunction(abc.ABC):
         x0: np.ndarray,
         x1: Optional[np.ndarray],
     ) -> linops.LinearOperator:
-        def keops_lazy_tensor(x0, x1):
+        def keops_lazy_tensor(
+            x0: np.ndarray, x1: Optional[np.ndarray]
+        ) -> Optional["LazyTensor"]:
             try:
                 return self._keops_lazy_tensor(x0, x1)
             except (NotImplementedError, ImportError):

--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -586,13 +586,10 @@ class CovarianceFunction(abc.ABC):
         x0: np.ndarray,
         x1: Optional[np.ndarray],
     ) -> linops.LinearOperator:
-        def keops_lazy_tensor(
-            x0: np.ndarray, x1: Optional[np.ndarray]
-        ) -> Optional["LazyTensor"]:
-            try:
-                return self._keops_lazy_tensor(x0, x1)
-            except (NotImplementedError, ImportError):
-                return None
+        try:
+            keops_lazy_tensor = self._keops_lazy_tensor(x0, x1)
+        except (NotImplementedError, ImportError):
+            keops_lazy_tensor = None
 
         shape = (
             self.output_size_0 * x0.shape[0],

--- a/src/probnum/randprocs/covfuncs/_covariance_function.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_function.py
@@ -586,10 +586,11 @@ class CovarianceFunction(abc.ABC):
         x0: np.ndarray,
         x1: Optional[np.ndarray],
     ) -> linops.LinearOperator:
-        try:
-            keops_lazy_tensor = self._keops_lazy_tensor(x0, x1)
-        except (NotImplementedError, ImportError):
-            keops_lazy_tensor = None
+        def keops_lazy_tensor(x0, x1):
+            try:
+                return self._keops_lazy_tensor(x0, x1)
+            except (NotImplementedError, ImportError):
+                return None
 
         shape = (
             self.output_size_0 * x0.shape[0],

--- a/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
@@ -1,6 +1,6 @@
 """LinearOperator that represents pairwise covariances of evaluations."""
 
-from typing import Optional
+from typing import Callable, Optional
 import warnings
 
 import numpy as np
@@ -50,21 +50,24 @@ class CovarianceLinearOperator(linops.LinearOperator):
         self,
         x0: np.ndarray,
         x1: Optional[np.ndarray],
-        shape,
-        evaluate_dense_matrix: callable,
-        keops_lazy_tensor: Optional["LazyTensor"] = None,
+        shape: tuple[int],
+        evaluate_dense_matrix: Callable[[np.ndarray, Optional[np.ndarray]], np.ndarray],
+        keops_lazy_tensor_fn: Callable[
+            [np.ndarray, Optional[np.ndarray]], Optional["LazyTensor"]
+        ],
     ):
         self._x0 = x0
         self._x1 = x1
 
         self._evaluate_dense_matrix = evaluate_dense_matrix
-        self._keops_lazy_tensor = keops_lazy_tensor
-        self._use_keops = _USE_KEOPS and keops_lazy_tensor is not None
+        self._keops_lazy_tensor = keops_lazy_tensor_fn(x0, x1)
+        self._keops_lazy_tensor_fn = keops_lazy_tensor_fn
+        self._use_keops = _USE_KEOPS and self._keops_lazy_tensor is not None
         dtype = np.promote_types(x0.dtype, x1.dtype) if x1 is not None else x0.dtype
         super().__init__(shape, dtype)
 
     @property
-    def keops_lazy_tensor(self) -> "LazyTensor":
+    def keops_lazy_tensor(self) -> Optional["LazyTensor"]:
         """:class:`~pykeops.numpy.LazyTensor` representing the covariance matrix
         corresponding to the given batches of input points.
         When not using KeOps, this is set to :data:`None`.
@@ -81,5 +84,9 @@ class CovarianceLinearOperator(linops.LinearOperator):
 
     def _transpose(self) -> linops.LinearOperator:
         return CovarianceLinearOperator(
-            self._x0, self._x1, self._evaluate_dense_matrix, self.keops_lazy_tensor
+            self._x1,
+            self._x0,
+            (self.shape[1], self.shape[0]),
+            self._evaluate_dense_matrix,
+            self._keops_lazy_tensor_fn,
         )

--- a/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
+++ b/src/probnum/randprocs/covfuncs/_covariance_linear_operator.py
@@ -1,6 +1,6 @@
 """LinearOperator that represents pairwise covariances of evaluations."""
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 import warnings
 
 import numpy as np
@@ -50,7 +50,7 @@ class CovarianceLinearOperator(linops.LinearOperator):
         self,
         x0: np.ndarray,
         x1: Optional[np.ndarray],
-        shape: tuple[int],
+        shape: Tuple[int],
         evaluate_dense_matrix: Callable[[np.ndarray, Optional[np.ndarray]], np.ndarray],
         keops_lazy_tensor_fn: Callable[
             [np.ndarray, Optional[np.ndarray]], Optional["LazyTensor"]


### PR DESCRIPTION
# In a Nutshell
Bugfix in transpose of `CovarianceLinearOperator`

# Detailed Description
The previous `_transpose` implementation only worked for the case that both inputs are equal. The new implementation works for the general case where x0 and x1 may not be equal.

The new implementation now requires passing a callback `keops_lazy_tensor_fn` (as opposed to directly passing a `LazyTensor`) which the `CovarianceLinearOperator` can then pass on in `_transpose`.
