### PR TITLE
Make scalar * Zero = Zero

### DIFF
--- a/src/probnum/linops/_arithmetic.py
+++ b/src/probnum/linops/_arithmetic.py
@@ -374,10 +374,12 @@ def _sub_anylinop_zero(op: LinearOperator, z: Zero) -> Zero:
 
 
 def _mul_scalar_zero(scalar: ScalarLike, z: Zero) -> Zero:
+    # pylint: disable=unused-argument
     return z
 
 
 def _mul_zero_scalar(z: Zero, scalar: ScalarLike) -> Zero:
+    # pylint: disable=unused-argument
     return z
 
 

--- a/src/probnum/linops/_arithmetic.py
+++ b/src/probnum/linops/_arithmetic.py
@@ -373,6 +373,18 @@ def _sub_anylinop_zero(op: LinearOperator, z: Zero) -> Zero:
     return op
 
 
+def _mul_scalar_zero(scalar: ScalarLike, z: Zero) -> Zero:
+    return z
+
+
+def _mul_zero_scalar(z: Zero, scalar: ScalarLike) -> Zero:
+    return z
+
+
+_mul_fns[(Zero, np.number)] = _mul_zero_scalar
+_mul_fns[(np.number, Zero)] = _mul_scalar_zero
+
+
 for op_type in _AnyLinOp:
     _matmul_fns[(Zero, op_type)] = _matmul_zero_anylinop
     _matmul_fns[(op_type, Zero)] = _matmul_anylinop_zero


### PR DESCRIPTION
# In a Nutshell
Previously, multiplying the Zero linear operator by a scalar would return a ScaledLinearOperator. But we can just directly return the original Zero linear operator. 

# Why?
This simplifies composed linear operators a little bit, particularly because the Zero linear operator can now be absorbed further, e.g. in a sum. Consider the following snippet:
```python
>>> from probnum.linops import Zero, Identity
>>> i = Identity((20, 20))
>>> z = Zero((20, 20))
>>> i + 3 * z
SumLinearOperator [
	<Identity with shape=(20, 20) and dtype=float64>,
	3.0 * <Zero with shape=(20, 20) and dtype=float64>
]
```
With this change, the result is
```python
>>> i + 3 * z
<Identity with shape=(20, 20) and dtype=float64>
```