### PR TITLE
Linop diagonal

### DIFF
--- a/src/probnum/linops/_arithmetic_fallbacks.py
+++ b/src/probnum/linops/_arithmetic_fallbacks.py
@@ -40,6 +40,7 @@ class ScaledLinearOperator(LambdaLinearOperator):
             transpose=lambda: self._scalar * self._linop.T,
             inverse=self._inv,
             trace=lambda: self._scalar * self._linop.trace(),
+            diagonal=lambda: self._scalar * self._linop.diagonal(),
         )
 
         # Matrix properties
@@ -89,7 +90,6 @@ class SumLinearOperator(LambdaLinearOperator):
     """Sum of linear operators."""
 
     def __init__(self, *summands: LinearOperator):
-
         if not all(summand.shape == summands[0].shape for summand in summands):
             raise ValueError("All summands must have the same shape.")
 
@@ -112,6 +112,9 @@ class SumLinearOperator(LambdaLinearOperator):
             ),
             trace=lambda: functools.reduce(
                 operator.add, (summand.trace() for summand in self._summands)
+            ),
+            diagonal=lambda: functools.reduce(
+                operator.add, (summand.diagonal() for summand in self._summands)
             ),
         )
 
@@ -176,7 +179,6 @@ class ProductLinearOperator(LambdaLinearOperator):
     """(Operator) Product of linear operators."""
 
     def __init__(self, *factors: LinearOperator):
-
         if not all(
             lfactor.shape[1] == rfactor.shape[0]
             for lfactor, rfactor in zip(factors[:-1], factors[1:])

--- a/src/probnum/linops/_block.py
+++ b/src/probnum/linops/_block.py
@@ -132,6 +132,11 @@ class BlockDiagonalMatrix(_linear_operator.LinearOperator):
             return np.sum([block.rank() for block in self.blocks])
         return super()._rank()
 
+    def _diagonal(self) -> np.ndarray:
+        if self._all_blocks_square:
+            return np.concatenate([block.diagonal() for block in self.blocks])
+        return super()._diagonal()
+
     def _cholesky(self, lower: bool) -> BlockDiagonalMatrix:
         if self._all_blocks_square:
             return BlockDiagonalMatrix(

--- a/src/probnum/linops/_kronecker.py
+++ b/src/probnum/linops/_kronecker.py
@@ -172,6 +172,11 @@ class Kronecker(_linear_operator.LinearOperator):
 
         return super()._trace()
 
+    def _diagonal(self) -> np.ndarray:
+        if self.B.is_square:
+            return np.kron(self.A.diagonal(), self.B.diagonal())
+        return super()._diagonal()
+
     def _astype(
         self, dtype: DTypeLike, order: str, casting: str, copy: bool
     ) -> "Kronecker":
@@ -200,7 +205,6 @@ class Kronecker(_linear_operator.LinearOperator):
     def _add_kronecker(
         self, other: "Kronecker"
     ) -> Union[NotImplementedType, "Kronecker"]:
-
         if self.A is other.A or self.A == other.A:
             return Kronecker(A=self.A, B=self.B + other.B)
 
@@ -212,7 +216,6 @@ class Kronecker(_linear_operator.LinearOperator):
     def _sub_kronecker(
         self, other: "Kronecker"
     ) -> Union[NotImplementedType, "Kronecker"]:
-
         if self.A is other.A or self.A == other.A:
             return Kronecker(A=self.A, B=self.B - other.B)
 
@@ -537,7 +540,6 @@ class IdentityKronecker(Kronecker):
     def _add_idkronecker(
         self, other: "IdentityKronecker"
     ) -> Union[NotImplementedType, "IdentityKronecker"]:
-
         if self.A.shape == other.A.shape:
             return IdentityKronecker(num_blocks=self._num_blocks, B=self.B + other.B)
 
@@ -546,7 +548,6 @@ class IdentityKronecker(Kronecker):
     def _sub_idkronecker(
         self, other: "IdentityKronecker"
     ) -> Union[NotImplementedType, "IdentityKronecker"]:
-
         if self.A.shape == other.A.shape:
             return IdentityKronecker(num_blocks=self._num_blocks, B=self.B - other.B)
 

--- a/src/probnum/linops/_linear_operator.py
+++ b/src/probnum/linops/_linear_operator.py
@@ -1615,7 +1615,7 @@ class Matrix(LambdaLinearOperator):
             matmul = LinearOperator.broadcast_matmat(lambda x: self.A @ x)
             todense = self.A.toarray
             trace = lambda: self.A.diagonal().sum()
-            diagonal = lambda: self.A.diagonal()
+            diagonal = self.A.diagonal
         else:
             self.A = np.asarray(A)
             self.A.setflags(write=False)

--- a/src/probnum/linops/_scaling.py
+++ b/src/probnum/linops/_scaling.py
@@ -312,6 +312,9 @@ class Scaling(_linear_operator.LambdaLinearOperator):
 
         return np.linalg.cond(self.todense(cache=False), p=p)
 
+    def _diagonal(self) -> np.ndarray:
+        return self.factors
+
     def _cholesky(self, lower: bool = True) -> Scaling:
         if self._scalar is not None:
             if self._scalar <= 0:
@@ -347,6 +350,7 @@ class Zero(_linear_operator.LambdaLinearOperator):
         det = lambda: np.zeros(shape=(), dtype=dtype)
 
         trace = lambda: np.zeros(shape=(), dtype=dtype)
+        diagonal = lambda: np.zeros(shape=(np.min(shape),), dtype=dtype)
 
         def matmul(x: np.ndarray) -> np.ndarray:
             target_shape = list(x.shape)
@@ -363,6 +367,7 @@ class Zero(_linear_operator.LambdaLinearOperator):
             eigvals=eigvals,
             det=det,
             trace=trace,
+            diagonal=diagonal,
         )
 
         # Matrix properties

--- a/tests/test_linops/test_linops.py
+++ b/tests/test_linops/test_linops.py
@@ -382,6 +382,18 @@ def test_trace(linop: pn.linops.LinearOperator, matrix: np.ndarray):
 
 
 @pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
+def test_diagonal(linop: pn.linops.LinearOperator, matrix: np.ndarray):
+    linop_diagonal = linop.diagonal()
+    matrix_diagonal = np.diagonal(matrix)
+
+    assert isinstance(linop_diagonal, np.ndarray)
+    assert linop_diagonal.shape == matrix_diagonal.shape
+    assert linop_diagonal.dtype == matrix_diagonal.dtype
+
+    np.testing.assert_allclose(linop_diagonal, matrix_diagonal)
+
+
+@pytest_cases.parametrize_with_cases("linop,matrix", cases=case_modules)
 def test_transpose(linop: pn.linops.LinearOperator, matrix: np.ndarray):
     matrix_transpose = matrix.transpose()
 


### PR DESCRIPTION
# In a Nutshell
Add `LinearOperator.diagonal()`.

# Detailed Description
... which computes the diagonal of the linear operator. Default implementation uses `np.diagonal`, and subclasses may use more efficient implementations, e.g. for Kronecker linear operators.

# "Future work"
- Figure out a good way to compute the diagonal of a kronecker product when the second factor is not square
- Implement diagonal of a covariance linear operator (shouldn't be too hard since it gets both inputs as arguments, but then you would possibly have to reshape and call the covariance function so that it only computes the diagonal)