### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # RTD configuration file version
 version: 2
 
+# Pin the build environment
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html


### PR DESCRIPTION
# In a Nutshell
RTD builds have been broken for the past couple of days. This is because urllib3 was released which is not compatible with the docker image we're using for the build. See https://github.com/readthedocs/readthedocs.org/issues/10290

With this PR, RTD should use a more recent docker image which hopefully fixes the problem.
