### PR TITLE
Reduce frequency of dependabot updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
# In a Nutshell
Previously dependabot checked dependencies weekly. We depend on libraries that frequently change their version (e.g. JAX), but we don't need to upgrade the dependencies as frequently.

